### PR TITLE
[CHORE] 쿠키에 카카오 리프레시 토큰 저장 로직 추가

### DIFF
--- a/src/main/java/umc/nook/users/controller/UserController.java
+++ b/src/main/java/umc/nook/users/controller/UserController.java
@@ -83,14 +83,24 @@ public class UserController {
             description = "인가 코드 발급 url : https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=f7b98086764f9e26027fabdd1812417f&redirect_uri=http://nook-server/oauth")
     public ApiResponse<UserDTO.LoginResponseDTO> kakaoLogin(@RequestParam("code") String code, HttpServletResponse response) {
         UserDTO.LoginResponseDTO responseDto = userService.kakaoLogin(code);
-        ResponseCookie refreshTokenCookie = ResponseCookie.from("refreshToken", responseDto.getToken().getRefreshToken())
+        ResponseCookie jwtRefreshTokenCookie = ResponseCookie.from("refreshToken", responseDto.getToken().getRefreshToken())
                 .httpOnly(true)
                 .secure(false)
                 .sameSite("Lax")
                 .path("/")
                 .maxAge(Duration.ofDays(14))
                 .build();
-        response.setHeader("Set-Cookie", refreshTokenCookie.toString());
+
+        ResponseCookie kakaoRefreshTokenCookie = ResponseCookie.from("kakaoRefreshToken", userService.viewKakaoRefreshTokenByUser(responseDto.getUserId()))
+                .httpOnly(true)
+                .secure(false)
+                .sameSite("Lax")
+                .path("/")
+                .maxAge(Duration.ofDays(60))
+                .build();
+
+        response.setHeader("Set-Cookie", jwtRefreshTokenCookie.toString());
+        response.addHeader("Set-Cookie", kakaoRefreshTokenCookie.toString());
 
         return ApiResponse.onSuccess(responseDto, SuccessCode.OK);
     }
@@ -102,7 +112,7 @@ public class UserController {
             HttpServletResponse response) {
         UserDTO.TokenResponseDto responseDto = userService.kakaoReissue(userDetails.getUser());
 
-        ResponseCookie refreshTokenCookie = ResponseCookie.from("refreshToken", responseDto.getRefreshToken())
+        ResponseCookie refreshTokenCookie = ResponseCookie.from("kakaoRefreshToken", responseDto.getRefreshToken())
                 .httpOnly(true)
                 .secure(false)
                 .sameSite("Lax")

--- a/src/main/java/umc/nook/users/repository/KakaoRefreshTokenRepository.java
+++ b/src/main/java/umc/nook/users/repository/KakaoRefreshTokenRepository.java
@@ -11,4 +11,6 @@ public interface KakaoRefreshTokenRepository extends JpaRepository<KakaoRefreshT
     Optional<KakaoRefreshToken> findByUserId(Long userId);
 
     void deleteByUserId(Long userId);
+
+    String findRefreshTokenByUserId(Long userId);
 }

--- a/src/main/java/umc/nook/users/service/UserService.java
+++ b/src/main/java/umc/nook/users/service/UserService.java
@@ -164,4 +164,9 @@ public class UserService {
         kakaoRefreshTokenRepository.deleteByUserId(user.getUserId());
     }
 
+    // 카카오 토큰 조회
+    @Transactional
+    public String viewKakaoRefreshTokenByUser(Long userId) {
+        return kakaoRefreshTokenRepository.findRefreshTokenByUserId(userId);
+    }
 }


### PR DESCRIPTION
## 📄 작업 내용 요약
<!-- 무엇을 작업했는지 간단하게 요약해주세요 -->
카카오 엑세스 토큰 재발급 로직 구현
- 예: 회원가입 API 구현
- 예: 예외 처리 공통화

---

## 📎 Issue 번호
<!-- 관련된 이슈가 있다면 닫히도록 연결해주세요 (ex: closed #1) -->

- closed #

---

## ✅ 작업 목록
<!-- 체크박스로 완료한 작업을 표시해주세요 -->

- [ ] 기능 구현
- [ ] 코드 리뷰 반영
- [ ] 테스트 코드 작성
- [ ] 문서 업데이트

---

## 📝 기타 참고사항
<!-- 리뷰어가 참고하면 좋을 추가 정보나 질문이 있다면 자유롭게 작성해주세요 -->