### PR TITLE
[FEAT] 회원탈퇴 기능 구현 및 주기적 삭제 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,9 @@ dependencies {
 
 	// WebClient
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+	// Spring Batch
+	implementation 'org.springframework.boot:spring-boot-starter-batch'
 }
 
 tasks.named('test') {

--- a/src/main/generated/umc/nook/users/domain/QUser.java
+++ b/src/main/generated/umc/nook/users/domain/QUser.java
@@ -27,6 +27,8 @@ public class QUser extends EntityPathBase<User> {
     //inherited
     public final DateTimePath<java.time.LocalDateTime> createdDate = _super.createdDate;
 
+    public final DateTimePath<java.time.LocalDateTime> deletedAt = createDateTime("deletedAt", java.time.LocalDateTime.class);
+
     public final StringPath email = createString("email");
 
     public final NumberPath<Integer> goal = createNumber("goal", Integer.class);
@@ -34,6 +36,8 @@ public class QUser extends EntityPathBase<User> {
     public final BooleanPath isKakao = createBoolean("isKakao");
 
     public final ListPath<umc.nook.readingrooms.domain.ReadingRoomUser, umc.nook.readingrooms.domain.QReadingRoomUser> joinedRooms = this.<umc.nook.readingrooms.domain.ReadingRoomUser, umc.nook.readingrooms.domain.QReadingRoomUser>createList("joinedRooms", umc.nook.readingrooms.domain.ReadingRoomUser.class, umc.nook.readingrooms.domain.QReadingRoomUser.class, PathInits.DIRECT2);
+
+    public final NumberPath<Long> kakaoUserId = createNumber("kakaoUserId", Long.class);
 
     //inherited
     public final DateTimePath<java.time.LocalDateTime> modifiedDate = _super.modifiedDate;

--- a/src/main/java/umc/nook/common/config/BatchJobConfig.java
+++ b/src/main/java/umc/nook/common/config/BatchJobConfig.java
@@ -1,0 +1,47 @@
+package umc.nook.common.config;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+import umc.nook.users.repository.UserRepository;
+
+import java.time.LocalDateTime;
+
+@Configuration
+@EnableBatchProcessing
+@RequiredArgsConstructor
+@Slf4j
+public class BatchJobConfig {
+
+    private final JobRepository jobRepository;
+    private final PlatformTransactionManager transactionManager;
+    private final UserRepository userRepository;
+
+    @Bean
+    public Job purgeDeletedUsersJob() {
+        return new JobBuilder("purgeDeletedUsersJob", jobRepository)
+                .start(purgeDeletedUsersStep())
+                .build();
+    }
+
+    @Bean
+    public Step purgeDeletedUsersStep() {
+        return new StepBuilder("purgeDeletedUsersStep", jobRepository)
+                .tasklet((contribution, chunkContext) -> {
+                    LocalDateTime threshold = LocalDateTime.now().minusDays(30);
+                    int deleted = userRepository.hardDeleteUsersOlderThan(threshold);
+                    log.info("[Batch] 탈퇴 후 30일 경과 사용자 삭제: " + deleted);
+                    return RepeatStatus.FINISHED;
+                }, transactionManager)
+                .build();
+    }
+}

--- a/src/main/java/umc/nook/common/response/ErrorCode.java
+++ b/src/main/java/umc/nook/common/response/ErrorCode.java
@@ -9,7 +9,6 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode implements BaseCode {
 
     // 사용자
-
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "ACCOUNT-001", "사용자를 찾을 수 없습니다."),
     DUPLICATE_NAME(HttpStatus.CONFLICT, "ACCOUNT-002", "중복된 닉네임입니다."),
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "ACCOUNT-003", "비밀번호가 유효하지 않습니다."),
@@ -19,6 +18,8 @@ public enum ErrorCode implements BaseCode {
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "ACCOUNT-007", "인증이 필요합니다."),
     EMAIL_DUPLICATE(HttpStatus.BAD_REQUEST,"ACCOUNT-008" ,"중복된 이메일입니다." ),
     PERMISSION_DENIED(HttpStatus.FORBIDDEN, "ACCOUNT-009", "권한이 없습니다."),
+
+    USER_INACTIVE(HttpStatus.FORBIDDEN,"ACCOUNT-010", "탈퇴한 사용자입니다."),
 
     // 서재 관련
     BOOK_NOT_FOUND(HttpStatus.NOT_FOUND,"BOOK-001" ,"존재하지 않는 책입니다." ),

--- a/src/main/java/umc/nook/users/controller/UserController.java
+++ b/src/main/java/umc/nook/users/controller/UserController.java
@@ -195,4 +195,13 @@ public class UserController {
         loungeService.modifyGoal(userDetails, goalRequestDTO);
         return ApiResponse.onSuccess(null, SuccessCode.OK);
     }
+
+
+    @DeleteMapping("/me")
+    @Operation(summary = "회원 탈퇴",
+            description = "로그인한 본인 계정을 탈퇴 처리합니다. 계정 정보는 30일 후에 자동 삭제됩니다.")
+    public ApiResponse<String> withdrawMe(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        String msg = userService.withdrawUser(userDetails.getUser());
+        return ApiResponse.onSuccess(msg,SuccessCode.OK);
+    }
 }

--- a/src/main/java/umc/nook/users/domain/User.java
+++ b/src/main/java/umc/nook/users/domain/User.java
@@ -8,6 +8,7 @@ import umc.nook.readingrooms.domain.ReadingRoomUser;
 import umc.nook.review.domain.Review;
 import umc.nook.search.domain.RecentQuery;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -35,6 +36,7 @@ public class User extends BaseTimeEntity {
     @Column(nullable = false)
     private RoleType role;
 
+    @Setter
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private Status status;
@@ -51,10 +53,22 @@ public class User extends BaseTimeEntity {
     private List<Review> reviews = new ArrayList<>();
 
     @Column(name = "is_kakao")
+    @Builder.Default
     private Boolean isKakao = false;
 
     @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private Profile profile;
+
+    @Setter
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    public void withdraw() {
+        this.deletedAt = LocalDateTime.now();
+    }
+
+    @Column(name = "kakao_user_id", unique = true)
+    private Long kakaoUserId;
 
     @Setter
     @Builder.Default

--- a/src/main/java/umc/nook/users/oauth/OAuth2Attribute.java
+++ b/src/main/java/umc/nook/users/oauth/OAuth2Attribute.java
@@ -14,6 +14,9 @@ public class OAuth2Attribute {
     private String attributeKey;
     private String nickname;
 
+    private String email;
+    private Long kakaoUserId;
+
     public static OAuth2Attribute of(String attributeKey, Map<String, Object> attributes) {
         return ofKakao(attributeKey, attributes);
     }
@@ -21,17 +24,23 @@ public class OAuth2Attribute {
     private static OAuth2Attribute ofKakao(String attributeKey, Map<String, Object> attributes) {
         Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
         String nickname = null;
+        String email = null;
 
         if (kakaoAccount != null) {
             Map<String, Object> kakaoProfile = (Map<String, Object>) kakaoAccount.get("profile");
             if (kakaoProfile != null) {
                 nickname = (String) kakaoProfile.get("nickname");
+                email = (String) kakaoProfile.get("email");
             }
         }
+
+        Long kakaoUserId = attributes.get("id") != null ? ((Number) attributes.get("id")).longValue() : null;
 
         return OAuth2Attribute.builder()
                 .nickname(nickname)
                 .attributes(attributes)
+                .email(email)
+                .kakaoUserId(kakaoUserId)
                 .attributeKey(attributeKey)
                 .build();
     }
@@ -40,6 +49,7 @@ public class OAuth2Attribute {
         Map<String, Object> map = new HashMap<>();
         map.put("attributeKey", attributeKey);
         map.put("nickname", nickname);
+        map.put("email", email);
         return map;
     }
 }

--- a/src/main/java/umc/nook/users/oauth/OAuthService.java
+++ b/src/main/java/umc/nook/users/oauth/OAuthService.java
@@ -8,6 +8,7 @@ import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClientResponseException;
 import org.springframework.web.client.RestTemplate;
 import umc.nook.common.exception.CustomException;
 import umc.nook.common.response.ErrorCode;
@@ -53,6 +54,9 @@ public class OAuthService {
 
     @Value("${auth.kakao.logout-uri}")
     private String kakaoLogoutUri;
+
+    @Value("${auth.kakao.unlink-uri}")
+    private String kakaoUnlinkUri;
 
     /**
      * 카카오 인가 코드로부터 액세스 토큰 받기
@@ -114,11 +118,11 @@ public class OAuthService {
      */
     private User saveUser(OAuth2Attribute oAuth2Attribute) {
         String nickName = oAuth2Attribute.getNickname();
-
         return User.builder()
                 .role(RoleType.USER)
-                .email(nickName)
+                .email(oAuth2Attribute.getEmail())
                 .nickname(nickName)
+                .kakaoUserId(oAuth2Attribute.getKakaoUserId())
                 .status(Status.ACTIVE)
                 .isKakao(true)
                 .build();
@@ -224,5 +228,45 @@ public class OAuthService {
             throw new CustomException(ErrorCode.INVALID_OAUTH_TOKEN);
         }
     }
+
+    /**
+     * 카카오 계정 연결 해제 (액세스 토큰 기반)
+     */
+    public void unlinkWithAccessToken(String userAccessToken, Long kakaoUserId) {
+        if (userAccessToken == null || userAccessToken.isBlank()) {
+            throw new CustomException(ErrorCode.INVALID_OAUTH_TOKEN);
+        }
+        try {
+            HttpHeaders headers = new HttpHeaders();
+            headers.set(AUTHORIZATION_HEADER, TOKEN_TYPE + userAccessToken);
+            headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+            MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+            body.add("target_id_type", "user_id");
+            body.add("target_id", String.valueOf(kakaoUserId));
+            HttpEntity<MultiValueMap<String, String>> requestEntity = new HttpEntity<>(body, headers);
+
+            ResponseEntity<Map> response = restTemplate.exchange(
+                    kakaoUnlinkUri,
+                    HttpMethod.POST,
+                    requestEntity,
+                    Map.class
+            );
+
+            if (!response.getStatusCode().is2xxSuccessful()) {
+                log.warn("Kakao unlink failed. status={}, body={}", response.getStatusCode(), response.getBody());
+                throw new CustomException(ErrorCode.INVALID_OAUTH_TOKEN);
+            }
+            Object id = response.getBody().get("id"); // 성공 시 해제된 사용자 회원번호
+            log.info("Kakao admin unlink success. kakaoUserId={}", id);
+        } catch (RestClientResponseException e) {
+            log.warn("Kakao unlink failed. status={}, body={}", e.getRawStatusCode(), e.getResponseBodyAsString());
+            throw new CustomException(ErrorCode.INVALID_OAUTH_TOKEN);
+        } catch (Exception e) {
+            log.warn("Kakao unlink unexpected error", e);
+            throw new CustomException(ErrorCode.INVALID_OAUTH_TOKEN);
+        }
+    }
+
 }
 

--- a/src/main/java/umc/nook/users/repository/KakaoRefreshTokenRepository.java
+++ b/src/main/java/umc/nook/users/repository/KakaoRefreshTokenRepository.java
@@ -18,4 +18,5 @@ public interface KakaoRefreshTokenRepository extends JpaRepository<KakaoRefreshT
     Optional<KakaoRefreshToken> findByRefreshToken(String refreshToken);
 
 
+    String findAccessTokenByUserId(Long userId);
 }

--- a/src/main/java/umc/nook/users/repository/UserRepository.java
+++ b/src/main/java/umc/nook/users/repository/UserRepository.java
@@ -1,8 +1,12 @@
 package umc.nook.users.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import umc.nook.users.domain.User;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User,Long> {
@@ -11,4 +15,11 @@ public interface UserRepository extends JpaRepository<User,Long> {
     boolean existsByEmail(String email);
 
     Optional<User> findByUserId(Long userId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("delete from User u " +
+            "where u.deletedAt is not null " +
+            "and   u.deletedAt <= :threshold " +
+            "and   u.status = umc.nook.users.domain.Status.INACTIVE")
+    int hardDeleteUsersOlderThan(@Param("threshold") LocalDateTime threshold);
 }

--- a/src/main/java/umc/nook/users/service/CustomUserDetailService.java
+++ b/src/main/java/umc/nook/users/service/CustomUserDetailService.java
@@ -7,6 +7,7 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Service;
 import umc.nook.common.exception.CustomException;
 import umc.nook.common.response.ErrorCode;
+import umc.nook.users.domain.Status;
 import umc.nook.users.domain.User;
 import umc.nook.users.repository.UserRepository;
 
@@ -21,11 +22,15 @@ public class CustomUserDetailService implements UserDetailsService {
     public UserDetails loadUserByUsername(String email) {
         log.info("loadUserByUsername() called with email: {}", email);
 
+
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> {
                     log.error("사용자를 찾을 수 없습니다: {}", email);
                     return new CustomException(ErrorCode.USER_NOT_FOUND);
                 });
+        if (user.getDeletedAt() != null || user.getStatus() == Status.INACTIVE) {
+            throw new CustomException(ErrorCode.USER_INACTIVE); // 탈퇴한 사용자의 로그인 차단
+        }
 
         return new CustomUserDetails(user);
     }

--- a/src/main/java/umc/nook/users/service/UserService.java
+++ b/src/main/java/umc/nook/users/service/UserService.java
@@ -22,6 +22,8 @@ import umc.nook.users.repository.KakaoRefreshTokenRepository;
 import umc.nook.users.repository.RefreshTokenRepository;
 import umc.nook.users.repository.UserRepository;
 
+import java.time.LocalDateTime;
+
 @Service
 @Slf4j
 @RequiredArgsConstructor
@@ -183,5 +185,24 @@ public class UserService {
         return null;
     }
 
+    // 회원 탈퇴
+    @Transactional
+    public String withdrawUser(User user) {
+        // 카카오 계정 즉시 연결 해제
+        if (Boolean.TRUE.equals(user.getIsKakao()) && user.getKakaoUserId() != null) {
+            log.info("카카오 연결 해제 진행");
+            oAuthService.unlinkWithAccessToken(
+                    kakaoRefreshTokenRepository.findAccessTokenByUserId(user.getUserId()),
+                    user.getKakaoUserId());
+        }
+        oAuthService.unlinkWithAccessToken(
+                kakaoRefreshTokenRepository.findAccessTokenByUserId(user.getUserId()),
+                user.getKakaoUserId());
+        user.setDeletedAt(LocalDateTime.now());
+        log.info("사용자 탈퇴 완료");
+        user.setStatus(Status.INACTIVE);
+        userRepository.save(user);
+        return "회원 탈퇴가 완료되었습니다.";
+    }
 
 }


### PR DESCRIPTION
## 📄 작업 내용 요약
<!-- 무엇을 작업했는지 간단하게 요약해주세요 -->
회원탈퇴 api 구현
매일 새벽 3시에 , 탈퇴 후 30일 경과 시 사용자 정보를 삭제하는 배치 작업을 구현
카카오 계정 연결 해제 구현
카카오 이메일 컬럼 추가 로직 보완
카카오 
- 예: 회원가입 API 구현
- 예: 예외 처리 공통화

---

## 📎 Issue 번호
<!-- 관련된 이슈가 있다면 닫히도록 연결해주세요 (ex: closed #1) -->

- closed #65 

---

## ✅ 작업 목록
<!-- 체크박스로 완료한 작업을 표시해주세요 -->

- [ ] 기능 구현
- [ ] 코드 리뷰 반영
- [ ] 테스트 코드 작성
- [ ] 문서 업데이트

---

## 📝 기타 참고사항
<!-- 리뷰어가 참고하면 좋을 추가 정보나 질문이 있다면 자유롭게 작성해주세요 -->