### PR TITLE
[FIX] 회원 탈퇴 로직 수정

### DIFF
--- a/src/main/java/umc/nook/common/response/ErrorCode.java
+++ b/src/main/java/umc/nook/common/response/ErrorCode.java
@@ -18,7 +18,6 @@ public enum ErrorCode implements BaseCode {
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "ACCOUNT-007", "인증이 필요합니다."),
     EMAIL_DUPLICATE(HttpStatus.BAD_REQUEST,"ACCOUNT-008" ,"중복된 이메일입니다." ),
     PERMISSION_DENIED(HttpStatus.FORBIDDEN, "ACCOUNT-009", "권한이 없습니다."),
-
     USER_INACTIVE(HttpStatus.FORBIDDEN,"ACCOUNT-010", "탈퇴한 사용자입니다."),
 
     // 서재 관련
@@ -84,6 +83,8 @@ public enum ErrorCode implements BaseCode {
     // OAUTH
     INVALID_OAUTH_TOKEN(HttpStatus.BAD_REQUEST, "OAUTH-001", "유효하지 않은 카카오 토큰입니다."),
     INVALID_KAKAO_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "OAUTH-002", "유효하지 않은 카카오 리프레시 토큰입니다."),
+    INVALID_USER_ID(HttpStatus.BAD_REQUEST,"OAUTH-003","유효하지 않은 카카오ID입니다."),
+    KAKAO_UNLINK_FAILED(HttpStatus.BAD_REQUEST,"OAUTH-004","카카오 계정 연결 해제에 실패하였습니다." ),
 
     // GPT
     GPT_RESPONSE_FORMAT_ERROR(HttpStatus.BAD_GATEWAY, "GPT-001", "GPT 응답 포맷이 올바르지 않습니다.");

--- a/src/main/java/umc/nook/users/controller/UserController.java
+++ b/src/main/java/umc/nook/users/controller/UserController.java
@@ -196,7 +196,6 @@ public class UserController {
         return ApiResponse.onSuccess(null, SuccessCode.OK);
     }
 
-
     @DeleteMapping("/me")
     @Operation(summary = "회원 탈퇴",
             description = "로그인한 본인 계정을 탈퇴 처리합니다. 계정 정보는 30일 후에 자동 삭제됩니다.")

--- a/src/main/java/umc/nook/users/oauth/OAuthService.java
+++ b/src/main/java/umc/nook/users/oauth/OAuthService.java
@@ -58,6 +58,9 @@ public class OAuthService {
     @Value("${auth.kakao.unlink-uri}")
     private String kakaoUnlinkUri;
 
+    @Value("${auth.kakao.admin-key}")
+    private String kakaoAdminKey;
+
     /**
      * 카카오 인가 코드로부터 액세스 토큰 받기
      */
@@ -230,20 +233,22 @@ public class OAuthService {
     }
 
     /**
-     * 카카오 계정 연결 해제 (액세스 토큰 기반)
+     * 카카오 계정 연결 해제 (Admin Key 기반)
      */
-    public void unlinkWithAccessToken(String userAccessToken, Long kakaoUserId) {
-        if (userAccessToken == null || userAccessToken.isBlank()) {
-            throw new CustomException(ErrorCode.INVALID_OAUTH_TOKEN);
+    public void unlinkWithAdminKey(Long kakaoUserId) {
+        if (kakaoUserId == null) {
+            throw new CustomException(ErrorCode.INVALID_USER_ID);
         }
+
         try {
             HttpHeaders headers = new HttpHeaders();
-            headers.set(AUTHORIZATION_HEADER, TOKEN_TYPE + userAccessToken);
+            headers.set(AUTHORIZATION_HEADER, "KakaoAK " + kakaoAdminKey); // Admin Key 사용
             headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
 
             MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
             body.add("target_id_type", "user_id");
             body.add("target_id", String.valueOf(kakaoUserId));
+
             HttpEntity<MultiValueMap<String, String>> requestEntity = new HttpEntity<>(body, headers);
 
             ResponseEntity<Map> response = restTemplate.exchange(
@@ -254,17 +259,21 @@ public class OAuthService {
             );
 
             if (!response.getStatusCode().is2xxSuccessful()) {
-                log.warn("Kakao unlink failed. status={}, body={}", response.getStatusCode(), response.getBody());
-                throw new CustomException(ErrorCode.INVALID_OAUTH_TOKEN);
+                log.warn("Kakao admin unlink failed. status={}, body={}",
+                        response.getStatusCode(), response.getBody());
+                throw new CustomException(ErrorCode.KAKAO_UNLINK_FAILED);
             }
+
             Object id = response.getBody().get("id"); // 성공 시 해제된 사용자 회원번호
             log.info("Kakao admin unlink success. kakaoUserId={}", id);
+
         } catch (RestClientResponseException e) {
-            log.warn("Kakao unlink failed. status={}, body={}", e.getRawStatusCode(), e.getResponseBodyAsString());
-            throw new CustomException(ErrorCode.INVALID_OAUTH_TOKEN);
+            log.warn("Kakao admin unlink failed. status={}, body={}",
+                    e.getRawStatusCode(), e.getResponseBodyAsString());
+            throw new CustomException(ErrorCode.KAKAO_UNLINK_FAILED);
         } catch (Exception e) {
-            log.warn("Kakao unlink unexpected error", e);
-            throw new CustomException(ErrorCode.INVALID_OAUTH_TOKEN);
+            log.warn("Kakao admin unlink unexpected error", e);
+            throw new CustomException(ErrorCode.KAKAO_UNLINK_FAILED);
         }
     }
 

--- a/src/main/java/umc/nook/users/repository/KakaoRefreshTokenRepository.java
+++ b/src/main/java/umc/nook/users/repository/KakaoRefreshTokenRepository.java
@@ -2,6 +2,8 @@ package umc.nook.users.repository;
 
 import com.querydsl.core.group.GroupBy;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import umc.nook.users.domain.KakaoRefreshToken;
 
 import java.util.Optional;
@@ -16,7 +18,4 @@ public interface KakaoRefreshTokenRepository extends JpaRepository<KakaoRefreshT
     KakaoRefreshToken findRefreshTokenByUserId(Long userId);
 
     Optional<KakaoRefreshToken> findByRefreshToken(String refreshToken);
-
-
-    String findAccessTokenByUserId(Long userId);
 }

--- a/src/main/java/umc/nook/users/repository/RefreshTokenRepository.java
+++ b/src/main/java/umc/nook/users/repository/RefreshTokenRepository.java
@@ -2,6 +2,7 @@ package umc.nook.users.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import umc.nook.users.domain.RefreshToken;
+import umc.nook.users.domain.User;
 
 import java.util.Optional;
 
@@ -9,4 +10,6 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken,Long>
     Optional<RefreshToken> findByRefreshToken(String refreshToken);
 
     void deleteByRefreshToken(String refreshToken);
+
+    void deleteByUser(User user);
 }

--- a/src/main/java/umc/nook/users/service/UserService.java
+++ b/src/main/java/umc/nook/users/service/UserService.java
@@ -188,20 +188,22 @@ public class UserService {
     // 회원 탈퇴
     @Transactional
     public String withdrawUser(User user) {
-        // 카카오 계정 즉시 연결 해제
-        if (Boolean.TRUE.equals(user.getIsKakao()) && user.getKakaoUserId() != null) {
-            log.info("카카오 연결 해제 진행");
-            oAuthService.unlinkWithAccessToken(
-                    kakaoRefreshTokenRepository.findAccessTokenByUserId(user.getUserId()),
-                    user.getKakaoUserId());
+        // 이미 탈퇴 처리된 경우
+        if (user.getDeletedAt() != null || user.getStatus() == Status.INACTIVE) {
+            throw new CustomException(ErrorCode.USER_INACTIVE);
         }
-        oAuthService.unlinkWithAccessToken(
-                kakaoRefreshTokenRepository.findAccessTokenByUserId(user.getUserId()),
-                user.getKakaoUserId());
+        if (Boolean.TRUE.equals(user.getIsKakao()) && user.getKakaoUserId() != null) {
+            try {
+                oAuthService.unlinkWithAdminKey(user.getUserId());
+            } catch (Exception e) {
+                log.error("카카오 unlink 실패 (탈퇴는 계속 진행). userId={}, err={}", user.getUserId(), e.getMessage(), e);
+            }
+        }
         user.setDeletedAt(LocalDateTime.now());
         log.info("사용자 탈퇴 완료");
         user.setStatus(Status.INACTIVE);
         userRepository.save(user);
+        refreshTokenRepository.deleteByUser(user);
         return "회원 탈퇴가 완료되었습니다.";
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,7 +23,6 @@ spring:
 jwt:
   secret: ${JWTSECRET}
 
-
 aladin:
   base-url: http://www.aladin.co.kr/ttb/api
   ttbkey: ${ALADIN_TTBKEY}


### PR DESCRIPTION
## 📄 작업 내용 요약
<!-- 무엇을 작업했는지 간단하게 요약해주세요 -->
회원 탈퇴 로직 수정
- 예: 회원가입 API 구현
- 예: 예외 처리 공통화

---

## 📎 Issue 번호
<!-- 관련된 이슈가 있다면 닫히도록 연결해주세요 (ex: closed #1) -->

- closed #77 

---

## ✅ 작업 목록
<!-- 체크박스로 완료한 작업을 표시해주세요 -->

- [ ] 기능 구현
- [ ] 코드 리뷰 반영
- [ ] 테스트 코드 작성
- [ ] 문서 업데이트

---

## 📝 기타 참고사항
<!-- 리뷰어가 참고하면 좋을 추가 정보나 질문이 있다면 자유롭게 작성해주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added specific error messages for invalid Kakao ID and unlink failures.
- Improvements
  - Switched Kakao unlink to a more reliable admin-key flow, improving account unlink stability.
  - Enhanced account deletion: prevents duplicate withdrawals for already inactive users and clears all associated refresh tokens.
- Bug Fixes
  - Improved resilience of the withdrawal process; failures in external unlink no longer block completion.
- Chores
  - Minor formatting and configuration cleanups with no functional impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->