### PR TITLE
Fix/#77 withdraw fix

### DIFF
--- a/src/main/java/umc/nook/users/oauth/OAuth2Attribute.java
+++ b/src/main/java/umc/nook/users/oauth/OAuth2Attribute.java
@@ -51,6 +51,7 @@ public class OAuth2Attribute {
         map.put("attributeKey", attributeKey);
         map.put("nickname", nickname);
         map.put("email", email);
+        map.put("kakaoUserId",kakaoUserId);
         return map;
     }
 }

--- a/src/main/java/umc/nook/users/oauth/OAuthService.java
+++ b/src/main/java/umc/nook/users/oauth/OAuthService.java
@@ -121,9 +121,10 @@ public class OAuthService {
      */
     private User saveUser(OAuth2Attribute oAuth2Attribute) {
         String nickName = oAuth2Attribute.getNickname();
+        String email = oAuth2Attribute.getEmail();
         return User.builder()
                 .role(RoleType.USER)
-                .email(oAuth2Attribute.getEmail())
+                .email(email)
                 .nickname(nickName)
                 .kakaoUserId(oAuth2Attribute.getKakaoUserId())
                 .status(Status.ACTIVE)
@@ -140,13 +141,13 @@ public class OAuthService {
         Map<String, Object> userAttribute = getKakaoUserAttributes(newToken.getAccessToken());
         OAuth2Attribute attributes = OAuth2Attribute.of("kakao", userAttribute);
 
-        Optional<User> findUser = userRepository.findByEmail(attributes.getNickname());
+        Optional<User> findUser = userRepository.findByEmail(attributes.getEmail());
         User user;
         if (findUser.isPresent()) {
             user = findUser.get();
             log.info("기존 사용자 로그인: {}", user.getEmail());
         } else {
-            log.info("새로운 사용자 생성: {}", attributes.getNickname());
+            log.info("새로운 사용자 생성: {}", attributes.getEmail());
             user = saveUser(attributes);
             userRepository.save(user);
         }
@@ -167,8 +168,6 @@ public class OAuthService {
                         .refreshTokenExpiresIn((long) newToken.getRefreshTokenExpiresIn())
                         .build());
         kakaoRefreshTokenRepository.save(token);
-
-        // 6. 응답 DTO 반환
         return new UserDTO.KakaoLoginResponseDTO(user, jwtTokenResponse, newToken.getRefreshToken());
     }
 

--- a/src/main/java/umc/nook/users/oauth/OAuthService.java
+++ b/src/main/java/umc/nook/users/oauth/OAuthService.java
@@ -10,6 +10,7 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClientResponseException;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
 import umc.nook.common.exception.CustomException;
 import umc.nook.common.response.ErrorCode;
 import umc.nook.users.domain.KakaoRefreshToken;
@@ -21,6 +22,7 @@ import umc.nook.users.repository.KakaoRefreshTokenRepository;
 import umc.nook.users.repository.UserRepository;
 import umc.nook.users.service.JwtProvider;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -100,21 +102,32 @@ public class OAuthService {
         try {
             HttpHeaders headers = new HttpHeaders();
             headers.set(AUTHORIZATION_HEADER, TOKEN_TYPE + accessToken);
-            headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+            headers.setAccept(List.of(MediaType.APPLICATION_JSON));
 
-            HttpEntity<Object> requestEntity = new HttpEntity<>(headers);
-            return restTemplate.exchange(
-                    kakaoMemberInfoRequestUri,
-                    HttpMethod.GET,
-                    requestEntity,
+            HttpEntity<?> req = new HttpEntity<>(headers);
+
+            ResponseEntity<Map> res = restTemplate.exchange(
+                    kakaoMemberInfoRequestUri, // ex) https://kapi.kakao.com/v2/user/me
+                    HttpMethod.POST,
+                    req,
                     Map.class
-            ).getBody();
+            );
 
+            Map body = res.getBody();
+            if (!res.getStatusCode().is2xxSuccessful() || body == null) {
+                log.error("카카오 사용자 정보 요청 실패 status={}, body={}", res.getStatusCode(), body);
+                throw new CustomException(ErrorCode.INVALID_OAUTH_TOKEN);
+            }
+            return body;
+        } catch (RestClientResponseException e) {
+            log.error("카카오 사용자 정보 요청 실패 status={}, body={}", e.getRawStatusCode(), e.getResponseBodyAsString());
+            throw new CustomException(ErrorCode.INVALID_OAUTH_TOKEN);
         } catch (Exception e) {
-            log.error("카카오 사용자 정보 요청 실패", e);
+            log.error("카카오 사용자 정보 요청 예외", e);
             throw new CustomException(ErrorCode.INVALID_OAUTH_TOKEN);
         }
     }
+
 
     /**
      * 사용자 저장 로직
@@ -141,7 +154,7 @@ public class OAuthService {
         Map<String, Object> userAttribute = getKakaoUserAttributes(newToken.getAccessToken());
         OAuth2Attribute attributes = OAuth2Attribute.of("kakao", userAttribute);
 
-        Optional<User> findUser = userRepository.findByEmail(attributes.getEmail());
+        Optional<User> findUser = userRepository.findAnyByEmail(attributes.getEmail());
         User user;
         if (findUser.isPresent()) {
             user = findUser.get();
@@ -208,28 +221,14 @@ public class OAuthService {
 
 
     // 카카오 로그아웃
-    public void kakaoLogout(String accessToken) {
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
-
-        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
-        params.add("client_id", kakaoClientId);
-        params.add("logout_redirect_uri", kakaoLogoutUri);
-
-        HttpEntity<MultiValueMap<String, String>> requestEntity = new HttpEntity<>(params, headers);
-
-        try {
-            restTemplate.exchange(
-                    kakaoLogoutUri,
-                    HttpMethod.POST,
-                    requestEntity,
-                    String.class
-            );
-        } catch (Exception e) {
-            log.error("카카오 로그아웃 요청 실패", e);
-            throw new CustomException(ErrorCode.INVALID_OAUTH_TOKEN);
-        }
+    public String buildKakaoLogoutRedirectUrl() {
+        // kakaoLogoutUri 예: https://kauth.kakao.com/oauth/logout
+        UriComponentsBuilder b = UriComponentsBuilder.fromHttpUrl(kakaoLogoutUri)
+                .queryParam("client_id", kakaoClientId)
+                .queryParam("logout_redirect_uri", kakaoRedirectUri); // 로그아웃 후 돌아올 URL
+        return b.toUriString();
     }
+
 
     /**
      * 카카오 계정 연결 해제 (Admin Key 기반)
@@ -241,7 +240,7 @@ public class OAuthService {
 
         try {
             HttpHeaders headers = new HttpHeaders();
-            headers.set(AUTHORIZATION_HEADER, "KakaoAK " + kakaoAdminKey); // Admin Key 사용
+            headers.set(AUTHORIZATION_HEADER, "KakaoAK " + kakaoAdminKey);
             headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
 
             MultiValueMap<String, String> body = new LinkedMultiValueMap<>();

--- a/src/main/java/umc/nook/users/repository/UserRepository.java
+++ b/src/main/java/umc/nook/users/repository/UserRepository.java
@@ -16,6 +16,9 @@ public interface UserRepository extends JpaRepository<User,Long> {
 
     Optional<User> findByUserId(Long userId);
 
+    @Query(value = "SELECT * FROM user WHERE email = :email LIMIT 1", nativeQuery = true)
+    Optional<User> findAnyByEmail(@Param("email") String email);
+
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("delete from User u " +
             "where u.deletedAt is not null " +

--- a/src/main/java/umc/nook/users/service/UserService.java
+++ b/src/main/java/umc/nook/users/service/UserService.java
@@ -168,7 +168,7 @@ public class UserService {
         KakaoRefreshToken token = kakaoRefreshTokenRepository.findByUserId(user.getUserId())
                 .orElseThrow(() -> new CustomException(ErrorCode.INVALID_REFRESH_TOKEN));
         // 카카오 서버에 로그아웃 요청
-        oAuthService.kakaoLogout(token.getAccessToken());
+        oAuthService.buildKakaoLogoutRedirectUrl();
         // 저장된 토큰 삭제
         kakaoRefreshTokenRepository.deleteByUserId(user.getUserId());
     }


### PR DESCRIPTION
## 📄 작업 내용 요약
<!-- 무엇을 작업했는지 간단하게 요약해주세요 -->
카카오 로그인 시, 로그인한 사용지인지 확인하는 부분에서 발생하는 오류 수정

- 예: 회원가입 API 구현
- 예: 예외 처리 공통화

---

## 📎 Issue 번호
<!-- 관련된 이슈가 있다면 닫히도록 연결해주세요 (ex: closed #1) -->

- closed #77 

---

## ✅ 작업 목록
<!-- 체크박스로 완료한 작업을 표시해주세요 -->

- [ ] 기능 구현
- [ ] 코드 리뷰 반영
- [ ] 테스트 코드 작성
- [ ] 문서 업데이트

---

## 📝 기타 참고사항
<!-- 리뷰어가 참고하면 좋을 추가 정보나 질문이 있다면 자유롭게 작성해주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 카카오 로그아웃 리다이렉트 URL 생성 기능 추가로, 앱에서 카카오 로그아웃 페이지로 바로 이동할 수 있습니다.

* 리팩터링
  * 카카오 사용자 정보 조회의 응답 검증과 오류 처리 강화로 로그인 안정성이 향상되었습니다.
  * 로그인 시 이메일 기준으로 기존 계정 매칭을 수행해 중복 계정 발생 가능성을 줄였습니다.
  * 사용자 프로필 데이터에 카카오 사용자 ID가 포함되어, 계정 연동 정보의 확인이 용이해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->