### PR TITLE
[FIX] 카카오 로그인 유저 식별 방법 수정

### DIFF
--- a/src/main/java/umc/nook/bookshelves/service/BookShelfService.java
+++ b/src/main/java/umc/nook/bookshelves/service/BookShelfService.java
@@ -100,6 +100,7 @@ public class BookShelfService {
         return bookShelfQueryService.getBooksInsight(user);
     }
 
+    @Transactional(readOnly = true)
     public BookShelfDTO.RegisteredBookListResponseDTO viewRegisteredDatesInMonth(User user, YearMonth yearMonth) {
         List<LocalDate> dates = userBookshelfRepository.findAllByUser(user).stream()
                 .filter(b -> b.getBook() != null)
@@ -143,6 +144,7 @@ public class BookShelfService {
     }
 
     // 이번주 서재에 등록한 책
+    @Transactional(readOnly = true)
     public List<BookShelfDTO.WeeklyBooksDTO> viewWeeklyBookShelf(User user) {
         LocalDate now = LocalDate.now();
         LocalDate monday = now.with(DayOfWeek.MONDAY);

--- a/src/main/java/umc/nook/records/repository/BookRecordRepository.java
+++ b/src/main/java/umc/nook/records/repository/BookRecordRepository.java
@@ -21,19 +21,19 @@ public interface BookRecordRepository extends JpaRepository<BookRecord,Long> {
         FROM (
             SELECT br.created_date, bs.book_id
             FROM book_record br
-            JOIN bookshelf bs ON br.bookshelf_id = bs.bookshelf_id
+            JOIN user_bookshelf bs ON br.user_book_id = bs.user_book_id
             WHERE bs.user_id = :userId
-
+        
             UNION ALL
-
+        
             SELECT cr.created_date, bs.book_id
             FROM chat_record cr
-            JOIN bookshelf bs ON cr.bookshelf_id = bs.bookshelf_id
+            JOIN user_bookshelf bs ON cr.bookshelf_id = bs.user_book_id
             WHERE bs.user_id = :userId
         ) AS recent
         JOIN book b ON b.book_id = recent.book_id
         ORDER BY recent.created_date DESC
-        LIMIT 1
+        LIMIT 1;
         """, nativeQuery = true)
     Optional<RecentRecordProjection> findMostRecentBookByUserId(@Param("userId") Long userId);
 

--- a/src/main/java/umc/nook/users/oauth/OAuthService.java
+++ b/src/main/java/umc/nook/users/oauth/OAuthService.java
@@ -135,11 +135,12 @@ public class OAuthService {
     private User saveUser(OAuth2Attribute oAuth2Attribute) {
         String nickName = oAuth2Attribute.getNickname();
         String email = oAuth2Attribute.getEmail();
+        Long kakaoUserId = oAuth2Attribute.getKakaoUserId();
         return User.builder()
                 .role(RoleType.USER)
                 .email(email)
                 .nickname(nickName)
-                .kakaoUserId(oAuth2Attribute.getKakaoUserId())
+                .kakaoUserId(kakaoUserId)
                 .status(Status.ACTIVE)
                 .isKakao(true)
                 .build();
@@ -155,8 +156,9 @@ public class OAuthService {
         OAuth2Attribute attributes = OAuth2Attribute.of("kakao", userAttribute);
 
         Optional<User> findUser = userRepository.findAnyByEmail(attributes.getEmail());
+        Optional<User> findKakaoUser = userRepository.findByKakaoUserId(attributes.getKakaoUserId());
         User user;
-        if (findUser.isPresent()) {
+        if (findKakaoUser.isPresent()) {
             user = findUser.get();
             log.info("기존 사용자 로그인: {}", user.getEmail());
         } else {

--- a/src/main/java/umc/nook/users/repository/UserRepository.java
+++ b/src/main/java/umc/nook/users/repository/UserRepository.java
@@ -25,4 +25,6 @@ public interface UserRepository extends JpaRepository<User,Long> {
             "and   u.deletedAt <= :threshold " +
             "and   u.status = umc.nook.users.domain.Status.INACTIVE")
     int hardDeleteUsersOlderThan(@Param("threshold") LocalDateTime threshold);
+
+    Optional<User> findByKakaoUserId(Long kaKaoUserId);
 }


### PR DESCRIPTION
## 📄 작업 내용 요약
<!-- 무엇을 작업했는지 간단하게 요약해주세요 -->
카카오 로그인된 사용지인지 확인하는 방법을 수정합니다. 
- 예: 회원가입 API 구현
- 예: 예외 처리 공통화

---

## 📎 Issue 번호
<!-- 관련된 이슈가 있다면 닫히도록 연결해주세요 (ex: closed #1) -->

- closed #77 

---

## ✅ 작업 목록
<!-- 체크박스로 완료한 작업을 표시해주세요 -->

- [ ] 기능 구현
- [ ] 코드 리뷰 반영
- [ ] 테스트 코드 작성
- [ ] 문서 업데이트

---

## 📝 기타 참고사항
<!-- 리뷰어가 참고하면 좋을 추가 정보나 질문이 있다면 자유롭게 작성해주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 최근 읽은 도서 표시가 일부 상황에서 부정확하게 보이던 문제를 수정하여, 올바른 최신 도서가 안정적으로 노출됩니다.
  - 카카오 로그인 시 계정 매칭이 간헐적으로 실패하던 현상을 개선하여 로그인 성공률을 높였습니다.

- 리팩터링
  - 데이터 조회 작업의 트랜잭션 구성을 정비해 조회 성능과 안정성을 향상했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->