### PR TITLE
[FIX] bgm url 접근 오류 수정

### DIFF
--- a/src/main/java/umc/nook/common/config/WebSecurityConfig.java
+++ b/src/main/java/umc/nook/common/config/WebSecurityConfig.java
@@ -51,8 +51,8 @@ public class WebSecurityConfig {
                                 "/v3/api-docs/**",
                                 "/api/**",
                                 "/swagger-resources/**",
-                                "/readingroom-ws/**",
-                                "/ws/**" )
+                                "/ws/**" ,
+                                "/music/**")
                         .permitAll()
                         .anyRequest().authenticated());
 


### PR DESCRIPTION
## 📄 작업 내용 요약
<!-- 무엇을 작업했는지 간단하게 요약해주세요 -->

- bgm url 접근 오류 수정
---

## 📎 Issue 번호
<!-- 관련된 이슈가 있다면 닫히도록 연결해주세요 (ex: closed #1) -->

- closed #97 

---

## ✅ 작업 목록
<!-- 체크박스로 완료한 작업을 표시해주세요 -->

- [ ] 기능 구현
- [ ] 코드 리뷰 반영
- [ ] 테스트 코드 작성
- [ ] 문서 업데이트

---

## 📝 기타 참고사항
<!-- 리뷰어가 참고하면 좋을 추가 정보나 질문이 있다면 자유롭게 작성해주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * 음악 관련 엔드포인트가 공개로 추가되어 /music/** 경로에 인증 없이 접근할 수 있습니다.
* Chores
  * 공개 접근 허용 목록에서 /readingroom-ws/** 경로를 제거하여 해당 경로 이용 시 이제 인증이 필요합니다.
  * 공개 웹소켓 경로(/ws/**)는 그대로 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->