### PR TITLE
[FIX] 독서 기록 에러 수정

### DIFF
--- a/src/main/java/umc/nook/bookshelves/domain/UserBookShelf.java
+++ b/src/main/java/umc/nook/bookshelves/domain/UserBookShelf.java
@@ -2,10 +2,7 @@ package umc.nook.bookshelves.domain;
 
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import umc.nook.BaseTimeEntity;
 import umc.nook.book.domain.Book;
 import umc.nook.records.domain.BookRecord;
@@ -21,6 +18,7 @@ import java.util.List;
         @UniqueConstraint(columnNames = {"user_id", "book_id"})
 })
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserBookShelf extends BaseTimeEntity {
 
     @Id
@@ -45,11 +43,9 @@ public class UserBookShelf extends BaseTimeEntity {
     @Column(name="recorded_at", nullable=false)
     private LocalDate recordedAt;
 
-    @Builder.Default
     @OneToMany(mappedBy = "bookshelf", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<BookRecord> bookRecords = new ArrayList<>();
 
-    @Builder.Default
     @OneToMany(mappedBy = "bookshelf", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ChatRecord> chatRecords = new ArrayList<>();
 

--- a/src/main/java/umc/nook/bookshelves/repository/BookshelfCustomRepositoryImpl.java
+++ b/src/main/java/umc/nook/bookshelves/repository/BookshelfCustomRepositoryImpl.java
@@ -192,12 +192,17 @@ class BookShelfCustomRepositoryImpl implements BookShelfCustomRepository {
         QUserBookShelf ub = QUserBookShelf.userBookShelf;
         QBookRecord record = bookRecord;
 
-        Long totalCount = Optional.ofNullable(queryFactory
-                .select(ub.count())
-                .from(ub)
-                .where(ub.user.eq(user))
-                .fetchOne()
+        Long totalCount = Optional.ofNullable(
+                queryFactory
+                        .select(ub.count())
+                        .from(ub)
+                        .where(
+                                ub.user.eq(user)
+                                        .and(ub.readingStatus.ne(ReadingStatus.BOOKMARK))
+                        )
+                        .fetchOne()
         ).orElse(0L);
+
 
         Long recordCount = Optional.ofNullable(queryFactory
                 .select(record.count())

--- a/src/main/java/umc/nook/bookshelves/service/BookShelfService.java
+++ b/src/main/java/umc/nook/bookshelves/service/BookShelfService.java
@@ -122,7 +122,7 @@ public class BookShelfService {
     public BookShelfDTO.RegisteredBookListResponseDTO viewRegisteredDatesInMonth(User user, YearMonth yearMonth) {
         List<LocalDate> dates = userBookshelfRepository.findAllByUser(user).stream()
                 .filter(b -> b.getBook() != null)
-                .map(b -> b.getCreatedDate().toLocalDate())
+                .map(b -> b.getRecordedAt())
                 .filter(date -> YearMonth.from(date).equals(yearMonth))
                 .sorted()
                 .collect(Collectors.toList());

--- a/src/main/java/umc/nook/common/exception/ExceptionAdvice.java
+++ b/src/main/java/umc/nook/common/exception/ExceptionAdvice.java
@@ -1,5 +1,6 @@
 package umc.nook.common.exception;
 
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
@@ -16,6 +17,7 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 import umc.nook.common.response.ApiResponse;
 import umc.nook.common.response.ErrorCode;
 
+import java.time.LocalDate;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -79,4 +81,17 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
         WebRequest webRequest = new ServletWebRequest(request);
         return handleExceptionInternal(e, body, new HttpHeaders(), e.getErrorCode().getHttpStatus(), webRequest);
     }
+
+    @ExceptionHandler({InvalidFormatException.class})
+    public ResponseEntity<ApiResponse<Object>> handleInvalidDateFormat(InvalidFormatException ex) {
+        if (ex.getTargetType() == LocalDate.class) {
+            return ResponseEntity.badRequest().body(
+                    ApiResponse.onFailure(ErrorCode.INVALID_DATE, null)
+            );
+        }
+        return ResponseEntity.badRequest().body(
+                ApiResponse.onFailure(ErrorCode.INVALID_FORMAT, null)
+        );
+    }
+
 }

--- a/src/main/java/umc/nook/common/response/ErrorCode.java
+++ b/src/main/java/umc/nook/common/response/ErrorCode.java
@@ -11,6 +11,8 @@ public enum ErrorCode implements BaseCode {
     // 서버 에러
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON-001", "서버 오류가 발생했습니다."),
     INVALID_REQUEST(HttpStatus.BAD_REQUEST, "COMMON-002", "요청 파라미터가 올바르지 않습니다."),
+    INVALID_DATE(HttpStatus.BAD_REQUEST, "DATE-001", "유효하지 않은 날짜입니다."),
+    INVALID_FORMAT(HttpStatus.BAD_REQUEST, "FORMAT-001", "형식이 올바르지 않습니다."),
 
     // 사용자
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "ACCOUNT-001", "사용자를 찾을 수 없습니다."),

--- a/src/main/java/umc/nook/records/domain/BookRecordType.java
+++ b/src/main/java/umc/nook/records/domain/BookRecordType.java
@@ -1,5 +1,0 @@
-package umc.nook.records.domain;
-
-public enum BookRecordType {
-    BOOK,CHAT
-}

--- a/src/main/java/umc/nook/records/dto/GptDTO.java
+++ b/src/main/java/umc/nook/records/dto/GptDTO.java
@@ -1,5 +1,6 @@
 package umc.nook.records.dto;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,6 +11,7 @@ public class GptDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class GptResponseDTO {
+
         private String content;
     }
 
@@ -26,6 +28,8 @@ public class GptDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class GptRequestDTO {
+
+        @NotBlank(message = "채팅 내용은 필수입니다.")
         String message;
     }
 

--- a/src/main/java/umc/nook/records/repository/BookRecordRepository.java
+++ b/src/main/java/umc/nook/records/repository/BookRecordRepository.java
@@ -14,28 +14,5 @@ public interface BookRecordRepository extends JpaRepository<BookRecord,Long> , R
 
     List<BookRecord> findAllByParent(BookRecord record);
 
-    @Query(value = """
-        SELECT b.book_id AS bookId,
-               b.title AS title,
-               b.cover_image_url AS coverImageUrl
-        FROM (
-            SELECT br.created_date, bs.book_id
-            FROM book_record br
-            JOIN user_bookshelf bs ON br.user_book_id = bs.user_book_id
-            WHERE bs.user_id = :userId
-        
-            UNION ALL
-        
-            SELECT cr.created_date, bs.book_id
-            FROM chat_record cr
-            JOIN user_bookshelf bs ON cr.bookshelf_id = bs.user_book_id
-            WHERE bs.user_id = :userId
-        ) AS recent
-        JOIN book b ON b.book_id = recent.book_id
-        ORDER BY recent.created_date DESC
-        LIMIT 1;
-        """, nativeQuery = true)
-    Optional<RecentRecordProjection> findMostRecentBookByUserId(@Param("userId") Long userId);
-
     void deleteAllByBookshelf(UserBookShelf userBook);
 }

--- a/src/main/java/umc/nook/records/repository/RecordCustomRepository.java
+++ b/src/main/java/umc/nook/records/repository/RecordCustomRepository.java
@@ -1,11 +1,16 @@
 package umc.nook.records.repository;
 
+import umc.nook.bookshelves.dto.BookShelfDTO;
 import umc.nook.records.dto.RecordDTO;
+import umc.nook.search.dto.SearchResponseDTO;
 import umc.nook.users.domain.User;
 
 import java.time.Year;
+import java.util.Optional;
 
 public interface RecordCustomRepository {
     RecordDTO.MonthlyRecordRateResponseDTO viewRecordRate(User user, Year year);
+
+    Optional<BookShelfDTO.BookThumbnail> viewRecentRecordedBook(User user);
 
 }

--- a/src/main/java/umc/nook/records/repository/RecordCustomRepositoryImpl.java
+++ b/src/main/java/umc/nook/records/repository/RecordCustomRepositoryImpl.java
@@ -4,8 +4,10 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
+import umc.nook.book.domain.QBook;
 import umc.nook.bookshelves.domain.QUserBookShelf;
-import umc.nook.bookshelves.domain.UserBookShelf;
+import umc.nook.bookshelves.dto.BookShelfDTO;
+import umc.nook.records.domain.QBookRecord;
 import umc.nook.records.dto.RecordDTO;
 import umc.nook.users.domain.User;
 
@@ -13,6 +15,7 @@ import java.time.Year;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Repository
@@ -21,40 +24,82 @@ public class RecordCustomRepositoryImpl implements RecordCustomRepository{
 
     private final JPAQueryFactory queryFactory;
 
-    @Transactional
+    @Override
+    @Transactional(readOnly = true)
     public RecordDTO.MonthlyRecordRateResponseDTO viewRecordRate(User user, Year year) {
         QUserBookShelf ub = QUserBookShelf.userBookShelf;
+        QBookRecord record = QBookRecord.bookRecord;
 
-        Map<Integer, List<UserBookShelf>> booksByMonth = queryFactory
-                .selectFrom(ub)
+        // 월별 책 등록 수
+        Map<Integer, Long> totalBooksByMonth = queryFactory
+                .select(ub.createdDate.month(), ub.count())
+                .from(ub)
                 .where(
                         ub.user.eq(user),
                         ub.createdDate.year().eq(year.getValue())
                 )
+                .groupBy(ub.createdDate.month())
                 .fetch()
                 .stream()
-                .collect(Collectors.groupingBy(b -> b.getCreatedDate().getMonthValue()));
+                .collect(Collectors.toMap(
+                        t -> t.get(0, Integer.class),
+                        t -> t.get(1, Long.class)
+                ));
 
+        // 월별 기록 수 (bookRecord만)
+        Map<Integer, Long> recordedBooksByMonth = queryFactory
+                .select(record.createdDate.month(), record.countDistinct())
+                .from(record)
+                .where(
+                        record.bookshelf.user.eq(user),
+                        record.createdDate.year().eq(year.getValue())
+                )
+                .groupBy(record.createdDate.month())
+                .fetch()
+                .stream()
+                .collect(Collectors.toMap(
+                        t -> t.get(0, Integer.class),
+                        t -> t.get(1, Long.class)
+                ));
+
+        // 1~12월 기록률 계산
         List<RecordDTO.MonthlyRecordRateResponseDTO.MonthRate> rates = new ArrayList<>();
-
         for (int month = 1; month <= 12; month++) {
-            List<UserBookShelf> booksInMonth = booksByMonth.getOrDefault(month, List.of());
+            long total = totalBooksByMonth.getOrDefault(month, 0L);
+            long recorded = recordedBooksByMonth.getOrDefault(month, 0L);
 
-            if (booksInMonth.isEmpty()) {
-                rates.add(new RecordDTO.MonthlyRecordRateResponseDTO.MonthRate(month, 0.0));
-                continue;
-            }
-
-            long total = booksInMonth.size();
-            long recorded = booksInMonth.stream()
-                    .filter(b -> b.getRecordedAt() != null)
-                    .count();
-
-            double rate = (recorded * 100.0) / total;
+            double rate = (total == 0) ? 0.0 : (recorded * 100.0) / total;
             rates.add(new RecordDTO.MonthlyRecordRateResponseDTO.MonthRate(month, rate));
         }
 
         return new RecordDTO.MonthlyRecordRateResponseDTO(rates);
     }
+
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<BookShelfDTO.BookThumbnail> viewRecentRecordedBook(User user) {
+        QBookRecord record = QBookRecord.bookRecord;
+        QBook book = QBook.book;
+
+        return Optional.ofNullable(
+                queryFactory
+                        .select(
+                                book.bookId,
+                                book.title,
+                                book.coverImageUrl
+                        )
+                        .from(record)
+                        .join(record.bookshelf.book, book)
+                        .where(record.bookshelf.user.eq(user))
+                        .orderBy(record.createdDate.desc())
+                        .fetchFirst()
+        ).map(tuple -> new BookShelfDTO.BookThumbnail(
+                tuple.get(book.bookId),
+                tuple.get(book.title),
+                tuple.get(book.coverImageUrl)
+        ));
+    }
+
 
 }

--- a/src/main/java/umc/nook/records/service/RecordService.java
+++ b/src/main/java/umc/nook/records/service/RecordService.java
@@ -211,11 +211,11 @@ public class RecordService {
     // 가장 최근 기록한 책 정보 조회
     @Transactional
     public BookShelfDTO.BookThumbnail viewRecentlyRecordedBook(User user) {
-        return bookRecordRepository.findMostRecentBookByUserId(user.getUserId())
+        return bookRecordRepository.viewRecentRecordedBook(user)
                 .map(b -> new BookShelfDTO.BookThumbnail(
                         b.getBookId(),
                         b.getTitle(),
-                        b.getCoverImageUrl()))
+                        b.getThumbnailUrl()))
                 .orElseThrow(()->new CustomException(ErrorCode.RECORD_NOT_EXIST));
     }
 


### PR DESCRIPTION
## 📄 작업 내용 요약
<!-- 무엇을 작업했는지 간단하게 요약해주세요 -->
- 가장 최근에 기록한 책 조회 수정
- 기록률 조회 수정
- 책 통계 조회 수정
- 예: 회원가입 API 구현
- 예: 예외 처리 공통화

---

## 📎 Issue 번호
<!-- 관련된 이슈가 있다면 닫히도록 연결해주세요 (ex: closed #1) -->

- closed #99 

---

## ✅ 작업 목록
<!-- 체크박스로 완료한 작업을 표시해주세요 -->

- [ ] 기능 구현
- [ ] 코드 리뷰 반영
- [ ] 테스트 코드 작성
- [ ] 문서 업데이트

---

## 📝 기타 참고사항
<!-- 리뷰어가 참고하면 좋을 추가 정보나 질문이 있다면 자유롭게 작성해주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 최근 기록한 도서의 썸네일을 조회할 수 있습니다.
- Bug Fixes
  - 잘못된 날짜/형식 입력 시 400 오류를 세분화해 명확한 안내를 제공합니다.
  - 월별 등록일 집계가 생성일이 아닌 기록일 기준으로 더 정확해졌습니다.
  - 독서 인사이트 총계에서 북마크 상태가 제외됩니다.
  - 채팅 요청에 메시지 필수 검증을 추가했습니다.
- Refactor
  - 월별 기록률 계산 로직을 최적화해 성능과 안정성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->