### PR TITLE
[FIX] 카카오 로그인 시 프로필 저장되지 않는 버그 수정

### DIFF
--- a/src/main/java/umc/nook/users/oauth/OAuthService.java
+++ b/src/main/java/umc/nook/users/oauth/OAuthService.java
@@ -13,6 +13,7 @@ import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 import umc.nook.common.exception.CustomException;
 import umc.nook.common.response.ErrorCode;
+import umc.nook.profile.domain.Profile;
 import umc.nook.users.domain.KakaoRefreshToken;
 import umc.nook.users.domain.RoleType;
 import umc.nook.users.domain.Status;
@@ -136,7 +137,8 @@ public class OAuthService {
         String nickName = oAuth2Attribute.getNickname();
         String email = oAuth2Attribute.getEmail();
         Long kakaoUserId = oAuth2Attribute.getKakaoUserId();
-        return User.builder()
+
+        User user = User.builder()
                 .role(RoleType.USER)
                 .email(email)
                 .nickname(nickName)
@@ -144,6 +146,13 @@ public class OAuthService {
                 .status(Status.ACTIVE)
                 .isKakao(true)
                 .build();
+
+        Profile profile = Profile.builder()
+                .build();
+
+        user.setProfile(profile);
+
+        return user;
     }
 
     /**


### PR DESCRIPTION
## 📄 작업 내용 요약
<!-- 무엇을 작업했는지 간단하게 요약해주세요 -->

- 프로필 저장 코드 추가
---

## 📎 Issue 번호
<!-- 관련된 이슈가 있다면 닫히도록 연결해주세요 (ex: closed #1) -->

- closed #107 

---

## ✅ 작업 목록
<!-- 체크박스로 완료한 작업을 표시해주세요 -->

- [ ] 기능 구현
- [ ] 코드 리뷰 반영
- [ ] 테스트 코드 작성
- [ ] 문서 업데이트

---

## 📝 기타 참고사항
<!-- 리뷰어가 참고하면 좋을 추가 정보나 질문이 있다면 자유롭게 작성해주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신규 기능
  * 카카오로 새롭게 가입하는 사용자의 기본 프로필이 가입과 동시에 자동 생성됩니다. 별도 설정 없이 프로필 기반 기능을 즉시 이용할 수 있으며, 이후 프로필 정보(사진, 닉네임, 소개 등)는 자유롭게 수정할 수 있습니다. 기존 가입자에게는 변화가 없고, 추가 조치도 필요 없습니다. 프로필 생성 실패로 인한 초기 사용 제약이 줄어듭니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->