### PR TITLE
[CHORE] 책, 서재 조회 공통 private 메서드로 분리

### DIFF
--- a/src/main/java/umc/nook/bookshelves/controller/BookShelfController.java
+++ b/src/main/java/umc/nook/bookshelves/controller/BookShelfController.java
@@ -99,7 +99,6 @@ public class BookShelfController {
         return ApiResponse.onSuccess(response,SuccessCode.OK);
     }
 
-
     @GetMapping("/registered-dates")
     @Operation(summary = "해당 월의 책 등록 날짜 목록 조회")
     @Parameter(

--- a/src/main/java/umc/nook/bookshelves/service/BookShelfService.java
+++ b/src/main/java/umc/nook/bookshelves/service/BookShelfService.java
@@ -33,13 +33,23 @@ public class BookShelfService {
     private final ChatRecordRepository chatRecordRepository;
     private final BookRecordRepository bookRecordRepository;
 
+    private Book getBookOrThrow(Long bookId) {
+        return bookRepository.findById(bookId)
+                .orElseThrow(() -> new CustomException(ErrorCode.BOOK_NOT_FOUND));
+    }
+
+    private UserBookShelf getUserBookShelfOrThrow(User user, Book book) {
+        UserBookShelf userBook = userBookshelfRepository.findByUserAndBook(user, book);
+        if (userBook == null) {
+            throw new CustomException(ErrorCode.BOOK_NOT_EXIST);
+        }
+        return userBook;
+    }
+
     // 서재에 책 등록
     @Transactional
     public String registerBook(BookShelfDTO.RegisterBookDTO registerBookDTO, User user) {
-        Book thisBook = bookRepository.findByBookId(registerBookDTO.getBookId());
-        if (thisBook == null) {
-            throw new CustomException(ErrorCode.BOOK_NOT_FOUND);
-        }
+        Book thisBook = getBookOrThrow(registerBookDTO.getBookId());
         // 해당 날짜에 등록 가능한지 확인
         boolean alreadyRegisteredToday = userBookshelfRepository.existsByUserAndRecordedAt(
                 user,
@@ -72,12 +82,8 @@ public class BookShelfService {
     // 책 삭제
     @Transactional
     public String deleteBook(Long bookId, User user) {
-        Book thisBook = bookRepository.findByBookId(bookId);
-        if (thisBook == null) {
-            throw new CustomException(ErrorCode.BOOK_NOT_FOUND);
-        }
-        UserBookShelf userBook = userBookshelfRepository.findByUserAndBook(user, thisBook);
-        if (userBook == null) throw new CustomException(ErrorCode.BOOK_NOT_EXIST);
+        Book thisBook = getBookOrThrow(bookId);
+        UserBookShelf userBook = getUserBookShelfOrThrow(user,thisBook);
         // ChatRecord 삭제
         chatRecordRepository.deleteAllByBookshelf(userBook);
         // BookRecord 삭제
@@ -89,12 +95,8 @@ public class BookShelfService {
     // 독서중으로 상태 변경
     @Transactional
     public String changeBookState(Long bookId, User user){
-        Book book = bookRepository.findById(bookId)
-                .orElseThrow(() -> new CustomException(ErrorCode.BOOK_NOT_EXIST));
-        UserBookShelf userBook = userBookshelfRepository.findByUserAndBook(user, book);
-        if (userBook == null)
-            throw new CustomException(ErrorCode.BOOK_NOT_EXIST);
-
+        Book book = getBookOrThrow(bookId);
+        UserBookShelf userBook = getUserBookShelfOrThrow(user,book);
         ReadingStatus currentStatus = userBook.getReadingStatus();
         if (currentStatus == ReadingStatus.READING) {
             throw new CustomException(ErrorCode.ALREADY_READING);
@@ -124,6 +126,7 @@ public class BookShelfService {
                 .filter(b -> b.getBook() != null)
                 .map(b -> b.getRecordedAt())
                 .filter(date -> YearMonth.from(date).equals(yearMonth))
+                .distinct()
                 .sorted()
                 .collect(Collectors.toList());
         return new BookShelfDTO.RegisteredBookListResponseDTO(dates);


### PR DESCRIPTION
## 📄 작업 내용 요약
<!-- 무엇을 작업했는지 간단하게 요약해주세요 -->
책, 서재 조회 공통 private 메서드로 분리
월별 서재에 책 등록한 날짜 조회 중복 제거
- 예: 회원가입 API 구현
- 예: 예외 처리 공통화

---

## 📎 Issue 번호
<!-- 관련된 이슈가 있다면 닫히도록 연결해주세요 (ex: closed #1) -->

- #82 

---

## ✅ 작업 목록
<!-- 체크박스로 완료한 작업을 표시해주세요 -->

- [x] 기능 구현
- [x] 코드 리뷰 반영
- [ ] 테스트 코드 작성
- [ ] 문서 업데이트

---

## 📝 기타 참고사항
<!-- 리뷰어가 참고하면 좋을 추가 정보나 질문이 있다면 자유롭게 작성해주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 월간 등록일 조회에서 중복 날짜가 표시되던 문제를 제거해 달력/리스트에 중복 없이 보여집니다.
* **Refactor**
  * 예외 처리 경로를 정비하여, 존재하지 않는 도서/서가 요청 시 오류 응답이 더 일관된 형식으로 반환됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->