### PR TITLE
[FIX] 카카오 로그인 버그 수정

### DIFF
--- a/src/main/java/umc/nook/users/controller/UserController.java
+++ b/src/main/java/umc/nook/users/controller/UserController.java
@@ -59,7 +59,7 @@ public class UserController {
         UserDTO.TokenResponseDto responseDto = userService.reissue(request);
         ResponseCookie refreshTokenCookie = ResponseCookie.from("refreshToken", responseDto.getRefreshToken())
                 .httpOnly(true)
-                .secure(false)
+                .secure(true)
                 .sameSite("Lax")
                 .path("/")
                 .maxAge(Duration.ofDays(14))

--- a/src/main/java/umc/nook/users/oauth/OAuthService.java
+++ b/src/main/java/umc/nook/users/oauth/OAuthService.java
@@ -155,13 +155,16 @@ public class OAuthService {
         Map<String, Object> userAttribute = getKakaoUserAttributes(newToken.getAccessToken());
         OAuth2Attribute attributes = OAuth2Attribute.of("kakao", userAttribute);
 
-        Optional<User> findUser = userRepository.findAnyByEmail(attributes.getEmail());
+        Optional<User> findUser = userRepository.findByEmail(attributes.getEmail());
         Optional<User> findKakaoUser = userRepository.findByKakaoUserId(attributes.getKakaoUserId());
         User user;
         if (findKakaoUser.isPresent()) {
             user = findKakaoUser.get();
             log.info("기존 사용자 로그인: {}", user.getEmail());
-        } else {
+        } else if (findUser.isPresent()){
+            user = findUser.get();
+            log.info("기존 사용자 로그인: {}", user.getKakaoUserId());
+        }else {
             log.info("새로운 사용자 생성: {}", attributes.getEmail());
             user = saveUser(attributes);
             userRepository.save(user);

--- a/src/main/java/umc/nook/users/repository/UserRepository.java
+++ b/src/main/java/umc/nook/users/repository/UserRepository.java
@@ -16,9 +16,6 @@ public interface UserRepository extends JpaRepository<User,Long> {
 
     Optional<User> findByUserId(Long userId);
 
-    @Query(value = "SELECT * FROM user WHERE email = :email LIMIT 1", nativeQuery = true)
-    Optional<User> findAnyByEmail(@Param("email") String email);
-
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("delete from User u " +
             "where u.deletedAt is not null " +


### PR DESCRIPTION
## 📄 작업 내용 요약
<!-- 무엇을 작업했는지 간단하게 요약해주세요 -->
카카오 로그인 시 카카오 사용자 id, 이메일을 통해 기존 사용자 로그인 여부를 검사합니다.
- 예: 회원가입 API 구현
- 예: 예외 처리 공통화

---

## 📎 Issue 번호
<!-- 관련된 이슈가 있다면 닫히도록 연결해주세요 (ex: closed #1) -->

- closed #

---

## ✅ 작업 목록
<!-- 체크박스로 완료한 작업을 표시해주세요 -->

- [ ] 기능 구현
- [ ] 코드 리뷰 반영
- [ ] 테스트 코드 작성
- [ ] 문서 업데이트

---

## 📝 기타 참고사항
<!-- 리뷰어가 참고하면 좋을 추가 정보나 질문이 있다면 자유롭게 작성해주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 카카오 로그인 시 이메일이 동일한 기존 계정을 자동으로 인식해 중복 계정 생성 없이 바로 로그인/연동됩니다. 로그인 경험이 더 매끄럽고 계정 관리가 간편해집니다.
- 보안
  - 액세스 토큰 재발급 시 설정되는 refreshToken 쿠키에 Secure 속성을 적용하여 HTTPS에서만 전송되도록 강화했습니다. 세션 보안이 향상됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->