### PR TITLE
[FIX] 로그인/토큰 재발급 컨트롤러 로직 수정

### DIFF
--- a/src/main/java/umc/nook/users/controller/UserController.java
+++ b/src/main/java/umc/nook/users/controller/UserController.java
@@ -37,17 +37,7 @@ public class UserController {
     @PostMapping("/login")
     @Operation(summary = "로그인", description = "이메일과 비밀번호로 로그인 후 토큰을 발급합니다.")
     public ApiResponse<UserDTO.LoginResponseDTO> login(@RequestBody @Validated UserDTO.LoginDto request, HttpServletResponse response) {
-        UserDTO.LoginResponseDTO responseWithToken = userService.login(request);
-
-        ResponseCookie refreshTokenCookie = ResponseCookie.from("refreshToken", responseWithToken.getToken().getRefreshToken())
-                .httpOnly(true)
-                .secure(false)
-                .sameSite("Lax")
-                .path("/")
-                .maxAge(Duration.ofDays(14))
-                .build();
-
-        response.setHeader("Set-Cookie", refreshTokenCookie.toString());
+        UserDTO.LoginResponseDTO responseWithToken = userService.login(request,response);
         return ApiResponse.onSuccess(responseWithToken, SuccessCode.OK);
     }
 
@@ -56,14 +46,6 @@ public class UserController {
     @Operation(summary = "엑세스 토큰 재발급")
     public ApiResponse<UserDTO.TokenResponseDto> recreateAccessToken(HttpServletRequest request, HttpServletResponse response) {
         UserDTO.TokenResponseDto responseDto = userService.reissue(request,response);
-        ResponseCookie refreshTokenCookie = ResponseCookie.from("refreshToken", responseDto.getRefreshToken())
-                .httpOnly(true)
-                .secure(true)
-                .sameSite("Lax")
-                .path("/")
-                .maxAge(Duration.ofDays(14))
-                .build();
-        response.setHeader("Set-Cookie", refreshTokenCookie.toString());
         return ApiResponse.onSuccess(responseDto, SuccessCode.OK);
     }
 


### PR DESCRIPTION
## 📄 작업 내용 요약
<!-- 무엇을 작업했는지 간단하게 요약해주세요 -->
로그인/토큰 재발급 컨트롤러 로직 수정
- 예: 회원가입 API 구현
- 예: 예외 처리 공통화

---

## 📎 Issue 번호
<!-- 관련된 이슈가 있다면 닫히도록 연결해주세요 (ex: closed #1) -->

- closed #

---

## ✅ 작업 목록
<!-- 체크박스로 완료한 작업을 표시해주세요 -->

- [ ] 기능 구현
- [ ] 코드 리뷰 반영
- [ ] 테스트 코드 작성
- [ ] 문서 업데이트

---

## 📝 기타 참고사항
<!-- 리뷰어가 참고하면 좋을 추가 정보나 질문이 있다면 자유롭게 작성해주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 버그 수정
  * 로그인 및 토큰 재발급 시 새로고침 토큰 쿠키가 간헐적으로 누락되거나 갱신되지 않던 문제를 수정했습니다. 자동 로그인 유지가 더 안정적이며, 일부 환경에서 불필요한 재로그인 요청이 줄어듭니다.
* 리팩터링
  * 인증 쿠키 관리 로직을 서버 측에서 일관되게 처리하도록 정리했습니다. 사용자 경험은 동일하나, 오류 가능성이 낮아지고 응답 일관성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->