### PR TITLE
[FIX] 리딩룸 가입 로직 수정

### DIFF
--- a/src/main/java/umc/nook/common/response/ErrorCode.java
+++ b/src/main/java/umc/nook/common/response/ErrorCode.java
@@ -43,6 +43,7 @@ public enum ErrorCode implements BaseCode {
     ROOM_CAPACITY_EXCEEDED(HttpStatus.CONFLICT, "ROOM-003", "리딩룸의 최대 인원 수를 초과했습니다."),
     HOST_ONLY(HttpStatus.FORBIDDEN, "ROOM-004" ,"리딩룸의 호스트만 수행할 수 있습니다." ),
     USER_NOT_JOINED_ROOM(HttpStatus.NOT_FOUND, "ROOM-005" ,"리딩룸에 가입하지 않은 사용자입니다." ),
+    TOO_MANY_JOINED_ROOM(HttpStatus.CONFLICT, "ROOM-006", "리딩룸은 최대 4개까지 가입 가능합니다." ),
 
     //테마 관련
     THEME_NOT_FOUND(HttpStatus.NOT_FOUND, "THEME-001", "테마를 찾을 수 없습니다."),

--- a/src/main/java/umc/nook/readingrooms/controller/ReadingRoomController.java
+++ b/src/main/java/umc/nook/readingrooms/controller/ReadingRoomController.java
@@ -31,8 +31,8 @@ public class ReadingRoomController {
 
     @Operation(summary = "사용자가 가입한 리딩룸 조회")
     @GetMapping("/join")
-    public ApiResponse<List<ReadingRoomDTO.ReadingRoomResponseDTO>> joinedReadingRoom(@RequestParam(defaultValue = "0") int page, @AuthenticationPrincipal CustomUserDetails user) {
-        return ApiResponse.onSuccess(readingRoomService.getJoinedReadingRooms(page, user),SuccessCode.OK);
+    public ApiResponse<List<ReadingRoomDTO.ReadingRoomResponseDTO>> joinedReadingRoom(@AuthenticationPrincipal CustomUserDetails user) {
+        return ApiResponse.onSuccess(readingRoomService.getJoinedReadingRooms(user),SuccessCode.OK);
     }
 
     @Operation(summary = "리딩룸 가입", description = "가입한 리딩룸 ID를 반환합니다.")

--- a/src/main/java/umc/nook/readingrooms/repository/ReadingRoomUserRepository.java
+++ b/src/main/java/umc/nook/readingrooms/repository/ReadingRoomUserRepository.java
@@ -13,10 +13,11 @@ import java.util.Optional;
 
 public interface ReadingRoomUserRepository extends JpaRepository<ReadingRoomUser, Long> {
     boolean existsByReadingRoomAndUser(ReadingRoom room, User user);
-    Page<ReadingRoomUser> findByUser(User user, Pageable pageable);
+    List<ReadingRoomUser> findByUser(User user);
     int countByReadingRoom(ReadingRoom readingRoom);
     boolean existsByReadingRoomAndUserAndRole(ReadingRoom readingRoom, User user, Role role);
     Optional<ReadingRoomUser> findByReadingRoomAndUser(ReadingRoom readingRoom, User user);
     List<ReadingRoomUser> findAllByReadingRoom(ReadingRoom readingRoom);
     Optional<ReadingRoomUser> findTopByUserOrderByLastAccessedAtDesc(User user);
+    int countByUser(User user);
 }

--- a/src/main/java/umc/nook/readingrooms/service/ReadingRoomService.java
+++ b/src/main/java/umc/nook/readingrooms/service/ReadingRoomService.java
@@ -113,13 +113,11 @@ public class ReadingRoomService {
 
     //사용자가 가입한 리딩룸 조회
     @Transactional(readOnly = true)
-    public List<ReadingRoomDTO.ReadingRoomResponseDTO> getJoinedReadingRooms(int page, CustomUserDetails userDetails) {
+    public List<ReadingRoomDTO.ReadingRoomResponseDTO> getJoinedReadingRooms(CustomUserDetails userDetails) {
 
         User user = userDetails.getUser();
 
-        int pageSize = 12;
-        PageRequest pageRequest = PageRequest.of(page, pageSize);
-        Page<ReadingRoomUser> joinedReadingRooms = readingRoomUserRepository.findByUser(user, pageRequest);
+        List<ReadingRoomUser> joinedReadingRooms = readingRoomUserRepository.findByUser(user);
 
         return joinedReadingRooms.stream()
                 .map(join -> {
@@ -162,6 +160,12 @@ public class ReadingRoomService {
         int memberCount = readingRoomUserRepository.countByReadingRoom(room);
         if (memberCount >= MAX_NUMBER) {
             throw new CustomException(ErrorCode.ROOM_CAPACITY_EXCEEDED);
+        }
+
+        // 리딩룸 최대 4개까지만 가입 가능하도록
+        int userJoinedCount = readingRoomUserRepository.countByUser(user);
+        if (userJoinedCount >= MAX_NUMBER) {
+            throw new CustomException(ErrorCode.TOO_MANY_JOINED_ROOM);
         }
 
         // 중복 가입 방지


### PR DESCRIPTION
## 📄 작업 내용 요약
<!-- 무엇을 작업했는지 간단하게 요약해주세요 -->

- 사용자가 가입한 리딩룸 조회 페이징 삭제
- 최대 4개 리딩룸만 가입되도록

---

## 📎 Issue 번호
<!-- 관련된 이슈가 있다면 닫히도록 연결해주세요 (ex: closed #1) -->

- closed #138 

---

## ✅ 작업 목록
<!-- 체크박스로 완료한 작업을 표시해주세요 -->

- [ ] 기능 구현
- [ ] 코드 리뷰 반영
- [ ] 테스트 코드 작성
- [ ] 문서 업데이트

---

## 📝 기타 참고사항
<!-- 리뷰어가 참고하면 좋을 추가 정보나 질문이 있다면 자유롭게 작성해주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 리딩룸 가입 제한 도입: 한 사용자당 최대 4개 리딩룸까지 가입 가능합니다. 초과 시 가입이 차단되며 안내 메시지가 표시됩니다.
  - 가입한 리딩룸 조회 개선: 페이지 입력 없이 한 번에 전체 목록을 확인할 수 있어 탐색이 더 간편해졌습니다. 스크롤만으로 모든 가입된 리딩룸을 연속해서 볼 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->