### PR TITLE
[FIX] 리딩룸 생성할 때 최근 접속 기록 저장 안 되게 수정

### DIFF
--- a/src/main/java/umc/nook/readingrooms/service/ReadingRoomService.java
+++ b/src/main/java/umc/nook/readingrooms/service/ReadingRoomService.java
@@ -209,7 +209,6 @@ public class ReadingRoomService {
                 .readingRoom(readingRoom)
                 .user(user)
                 .role(Role.HOST)
-                .lastAccessedAt(LocalDateTime.now())
                 .build();
         readingRoomUserRepository.save(readingRoomUser);
 


### PR DESCRIPTION
## 📄 작업 내용 요약
<!-- 무엇을 작업했는지 간단하게 요약해주세요 -->

- 리딩룸 생성할 때 최근 접속 기록 저장 안 되게 수정

---

## 📎 Issue 번호
<!-- 관련된 이슈가 있다면 닫히도록 연결해주세요 (ex: closed #1) -->

- closed #143 

---

## ✅ 작업 목록
<!-- 체크박스로 완료한 작업을 표시해주세요 -->

- [ ] 기능 구현
- [ ] 코드 리뷰 반영
- [ ] 테스트 코드 작성
- [ ] 문서 업데이트

---

## 📝 기타 참고사항
<!-- 리뷰어가 참고하면 좋을 추가 정보나 질문이 있다면 자유롭게 작성해주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 독서 모임 방 생성 시 방장의 ‘최근 접속 시간’이 자동으로 현재 시각으로 설정되지 않도록 조정했습니다. 이제 방 생성 직후의 활동/접속 표시가 즉시 시간값으로 채워지지 않으며, 실제 접속이 발생한 이후에만 시간이 반영되어 사용자에게 보다 일관된 정보가 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->