### PR TITLE
[FIX] 검색 최대 페이지 오류 수정

### DIFF
--- a/src/main/java/umc/nook/search/service/SearchService.java
+++ b/src/main/java/umc/nook/search/service/SearchService.java
@@ -28,6 +28,8 @@ import java.util.stream.Collectors;
 public class SearchService {
 
     private static final int LIMIT = 10;
+    private static final int MAX_ITEMS = 200;
+    private static final int MAX_PAGES = 10;
 
     private final AladinService aladinService;
     private final BookService bookService;
@@ -68,10 +70,21 @@ public class SearchService {
         }
 
         int totalItems = response != null ? response.getTotalResults() : 0;
+
+        if (totalItems > MAX_ITEMS) {
+            totalItems = MAX_ITEMS;
+        }
+
         int totalPages = totalItems > 0 ? (int) Math.ceil((double) totalItems / fetchSize): 0;
+
+        if (totalPages > MAX_PAGES) {
+            totalPages = MAX_PAGES;
+        }
+
         if ((totalPages == 0 && page > 0) || (totalPages > 0 && page >= totalPages)) {
             throw new CustomException(ErrorCode.PAGE_OUT_OF_RANGE);
         }
+        
         recentQueryService.saveRecentQuery(user, query);
         return SearchResponseDTO.SearchResultDTO.builder()
                 .books(books)


### PR DESCRIPTION
## 📄 작업 내용 요약
<!-- 무엇을 작업했는지 간단하게 요약해주세요 -->

- 검색 최대 페이지 오류 수정

---

## 📎 Issue 번호
<!-- 관련된 이슈가 있다면 닫히도록 연결해주세요 (ex: closed #1) -->

- closed #145 

---

## ✅ 작업 목록
<!-- 체크박스로 완료한 작업을 표시해주세요 -->

- [ ] 기능 구현
- [ ] 코드 리뷰 반영
- [ ] 테스트 코드 작성
- [ ] 문서 업데이트

---

## 📝 기타 참고사항
<!-- 리뷰어가 참고하면 좋을 추가 정보나 질문이 있다면 자유롭게 작성해주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 검색 결과의 총 항목 수와 페이지 수에 상한을 적용해 과도한 페이지 탐색으로 인한 오류를 방지했습니다.
  - 대규모 결과가 있는 경우에도 페이지네이션 동작이 보다 예측 가능해졌습니다.
  - 페이지 범위 검증을 개선해 유효하지 않은 페이지 요청 시 더 일관된 안내를 제공합니다.
  - 불필요한 대용량 처리를 줄여 응답 안정성과 체감 성능을 향상했습니다.
  - 기존 검색 흐름과 공개 API 동작은 변경되지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->