### PR TITLE
[CHORE] 월별 조회 시 반환 요소 추가

### DIFF
--- a/src/main/java/umc/nook/bookshelves/dto/BookShelfDTO.java
+++ b/src/main/java/umc/nook/bookshelves/dto/BookShelfDTO.java
@@ -83,9 +83,25 @@ public class BookShelfDTO {
 
     @Getter
     @AllArgsConstructor
+    public static class MonthlyBookThumbnail {
+        private Long bookId;
+        private String title;
+        private String thumbnailUrl;
+        private String author;
+
+        public MonthlyBookThumbnail(Book book) {
+            this.bookId = book.getBookId();
+            this.title = book.getTitle();
+            this.thumbnailUrl = book.getCoverImageUrl();
+            this.author = book.getAuthor();
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
     public static class DailyBooksResponseDTO {
         private LocalDate date;
-        private List<BookThumbnail> books;
+        private MonthlyBookThumbnail bookInfo;
     }
 
     @Getter

--- a/src/main/java/umc/nook/bookshelves/repository/BookshelfCustomRepositoryImpl.java
+++ b/src/main/java/umc/nook/bookshelves/repository/BookshelfCustomRepositoryImpl.java
@@ -155,6 +155,7 @@ class BookShelfCustomRepositoryImpl implements BookShelfCustomRepository {
                 .toList();
     }
 
+    // 월별 책 조회
     @Transactional
     public List<BookShelfDTO.DailyBooksResponseDTO> getMonthlyBooks(User user, YearMonth yearMonth) {
         QUserBookShelf ub = QUserBookShelf.userBookShelf;
@@ -164,7 +165,7 @@ class BookShelfCustomRepositoryImpl implements BookShelfCustomRepository {
         LocalDate endDate = yearMonth.atEndOfMonth();
 
         List<Tuple> result = queryFactory
-                .select(ub.recordedAt, book.bookId, book.coverImageUrl)
+                .select(ub.recordedAt, book.bookId, book.title, book.coverImageUrl, book.author)
                 .from(ub)
                 .join(ub.book, book)
                 .where(
@@ -172,28 +173,28 @@ class BookShelfCustomRepositoryImpl implements BookShelfCustomRepository {
                         ub.recordedAt.isNotNull(),
                         ub.recordedAt.between(startDate, endDate)
                 )
-                .orderBy(ub.recordedAt.asc())
+                .orderBy(ub.recordedAt.asc(), ub.createdDate.desc())
                 .fetch();
 
-        Map<LocalDate, List<BookShelfDTO.BookThumbnail>> grouped = result.stream()
+        Map<LocalDate, BookShelfDTO.MonthlyBookThumbnail> byDate = result.stream()
                 .filter(t -> t.get(ub.recordedAt) != null)
-                .collect(Collectors.groupingBy(
+                .collect(Collectors.toMap(
                         t -> t.get(ub.recordedAt),
-                        LinkedHashMap::new,
-                        Collectors.mapping(
-                                t -> new BookShelfDTO.BookThumbnail(
-                                        t.get(book.bookId),
-                                        t.get(book.title),
-                                        t.get(book.coverImageUrl)
-                                ),
-                                Collectors.toList()
-                        )
+                        t -> new BookShelfDTO.MonthlyBookThumbnail(
+                                t.get(book.bookId),
+                                t.get(book.title),
+                                t.get(book.coverImageUrl),
+                                t.get(book.author)
+                        ),
+                        (existing, ignored) -> existing,
+                        LinkedHashMap::new
                 ));
 
-        return grouped.entrySet().stream()
-                .map(entry -> new BookShelfDTO.DailyBooksResponseDTO(entry.getKey(), entry.getValue()))
+        return byDate.entrySet().stream()
+                .map(e -> new BookShelfDTO.DailyBooksResponseDTO(e.getKey(), e.getValue()))
                 .toList();
     }
+
 
     @Transactional
     public BookShelfDTO.BooksInsightDTO getBooksInsight(User user) {


### PR DESCRIPTION
## 📄 작업 내용 요약
<!-- 무엇을 작업했는지 간단하게 요약해주세요 -->
서재 월별 조회 시 작가 정보를 추가합니다.
- 예: 회원가입 API 구현
- 예: 예외 처리 공통화

---

## 📎 Issue 번호
<!-- 관련된 이슈가 있다면 닫히도록 연결해주세요 (ex: closed #1) -->

- #82 

---

## ✅ 작업 목록
<!-- 체크박스로 완료한 작업을 표시해주세요 -->

- [ ] 기능 구현
- [ ] 코드 리뷰 반영
- [ ] 테스트 코드 작성
- [ ] 문서 업데이트

---

## 📝 기타 참고사항
<!-- 리뷰어가 참고하면 좋을 추가 정보나 질문이 있다면 자유롭게 작성해주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 월별 책장에서 날짜별 대표 도서 썸네일을 제공하며 표지, 제목, 저자 정보를 함께 표시합니다.
- Refactor
  - 월별 목록 정렬을 개선해 기록일 오름차순 정렬, 동일 날짜 내 최신 항목을 우선 노출합니다.
  - 응답 구조를 단일 도서 정보로 단순화해 화면 표시 일관성과 응답 해석을 향상했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->