### PR TITLE
[FIX] 엑세스 토큰 재발급 중복 오류 수정

### DIFF
--- a/src/main/java/umc/nook/users/domain/RefreshToken.java
+++ b/src/main/java/umc/nook/users/domain/RefreshToken.java
@@ -13,10 +13,9 @@ import java.time.LocalDateTime;
 @Getter
 @Builder
 @AllArgsConstructor
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
 @RedisHash(value = "jwtToken", timeToLive = 60*60*24*3)
-public class RefreshToken extends BaseTimeEntity {
-
+public class RefreshToken {
 
     @Id
     private String tokenId;

--- a/src/main/java/umc/nook/users/oauth/OAuthService.java
+++ b/src/main/java/umc/nook/users/oauth/OAuthService.java
@@ -180,7 +180,7 @@ public class OAuthService {
         }
 
         String accessToken = jwtProvider.createAccessToken(user);
-        String refreshToken = jwtProvider.createRefreshToken(user);
+        String refreshToken = jwtProvider.createRefreshToken(user,accessToken);
         UserDTO.KakaoTokenResponseDTO jwtTokenResponse = new UserDTO.KakaoTokenResponseDTO(accessToken,refreshToken);
 
         KakaoRefreshToken token = kakaoRefreshTokenRedisRepository.findByUserId(user.getUserId())

--- a/src/main/java/umc/nook/users/redis/RefreshTokenRedisRepository.java
+++ b/src/main/java/umc/nook/users/redis/RefreshTokenRedisRepository.java
@@ -2,6 +2,7 @@ package umc.nook.users.redis;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Repository;
 import org.springframework.util.StringUtils;
@@ -15,6 +16,7 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 @Repository
+@Slf4j
 @RequiredArgsConstructor
 public class RefreshTokenRedisRepository {
 
@@ -29,6 +31,13 @@ public class RefreshTokenRedisRepository {
 
     /** 저장: 필수값 검증 + 만료 검증 + TTL(만료시각과 동기화) */
     public void save(RefreshToken refreshToken) {
+        log.info("[LOGIN] tokenId={}, userId={}, refreshToken={}, accessToken={}, exp={}",
+                refreshToken.getTokenId(),
+                refreshToken.getUserId(),
+                refreshToken.getRefreshToken(),
+                refreshToken.getAccessToken(),
+                LocalDateTime.now().plusDays(3));
+
         validateForSave(refreshToken);
 
         long ttl = ttlFromExpiration(refreshToken.getExpiration());
@@ -80,7 +89,6 @@ public class RefreshTokenRedisRepository {
     /** userId로 조회 (만료 시 예외) */
     public Optional<RefreshToken> findByUserId(Long userId) {
         if (userId == null) return Optional.empty();
-
         String tokenId = (String) redisTemplate.opsForValue().get(USER_ID_INDEX + userId);
         if (tokenId == null) return Optional.empty();
 
@@ -120,8 +128,14 @@ public class RefreshTokenRedisRepository {
             throw new CustomException(ErrorCode.REFRESH_TOKEN_INVALID);
         }
 
-        if (!token.getExpiration().isAfter(LocalDateTime.now())) {
-            throw new CustomException(ErrorCode.REFRESH_TOKEN_INVALID);
+        if (token.getExpiration().isBefore(LocalDateTime.now())) {
+            log.warn("[RefreshToken-Expired] tokenId={}, userId={}, expiration={}, now={}",
+                    token.getTokenId(),
+                    token.getUserId(),
+                    token.getExpiration(),
+                    LocalDateTime.now()
+            );
+            throw new CustomException(ErrorCode.REFRESH_TOKEN_EXPIRED);
         }
     }
     private RefreshToken convert(Object value) {

--- a/src/main/java/umc/nook/users/service/JwtProvider.java
+++ b/src/main/java/umc/nook/users/service/JwtProvider.java
@@ -7,6 +7,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseCookie;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
@@ -18,12 +19,10 @@ import umc.nook.users.domain.User;
 import umc.nook.users.redis.RefreshTokenRedisRepository;
 
 import java.security.Key;
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.util.Arrays;
-import java.util.Base64;
-import java.util.Date;
-import java.util.Optional;
+import java.util.*;
 
 @Component
 @Slf4j
@@ -61,7 +60,7 @@ public class JwtProvider {
                 .compact();
     }
 
-    public String createRefreshToken(User user) {
+    public String createRefreshToken(User user, String accessToken) {
         Date now = new Date();
         Date expiry = new Date(now.getTime() + REFRESH_EXP);
 
@@ -73,14 +72,18 @@ public class JwtProvider {
                 .signWith(key, SignatureAlgorithm.HS256)
                 .compact();
 
+        String tokenId = UUID.randomUUID().toString();
+
         RefreshToken refreshToken = RefreshToken.builder()
+                .tokenId(tokenId)
                 .userId(user.getUserId())
+                .accessToken(accessToken)
                 .refreshToken(token)
                 .expiration(LocalDateTime.ofInstant(expiry.toInstant(), ZoneId.systemDefault()))
                 .build();
 
         refreshTokenRepository.save(refreshToken);
-        return token;
+        return tokenId;
     }
 
     public UsernamePasswordAuthenticationToken getAuthentication(String email) {

--- a/src/main/java/umc/nook/users/service/UserService.java
+++ b/src/main/java/umc/nook/users/service/UserService.java
@@ -48,7 +48,6 @@ public class UserService {
         if (userRepository.existsByEmail(request.getEmail())) {
             throw new CustomException(ErrorCode.EMAIL_DUPLICATE);
         }
-
         User user = User.builder()
                 .email(request.getEmail())
                 .password(passwordEncoder.encode(request.getPassword()))
@@ -68,40 +67,27 @@ public class UserService {
     public UserDTO.LoginResponseDTO login(UserDTO.LoginDto request, HttpServletResponse response) {
         User user = userRepository.findByEmail(request.getEmail())
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-
+        log.info("이메일로찾기 : " + request.getEmail());
         if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
             throw new CustomException(ErrorCode.INVALID_PASSWORD);
         }
 
         String accessToken = jwtProvider.createAccessToken(user);
-        String refreshToken = jwtProvider.createRefreshToken(user);
+        String refreshToken = jwtProvider.createRefreshToken(user,accessToken);
 
-        // 토큰 매핑 키 생성
-        String tokenId = UUID.randomUUID().toString();
-
-        // Redis에 저장
-        RefreshToken tokenEntity = RefreshToken.builder()
-                .tokenId(tokenId)
-                .userId(user.getUserId())
-                .expiration(LocalDateTime.now().plusDays(3))
-                .refreshToken(refreshToken)
-                .build();
-        refreshTokenRepository.save(tokenEntity);
+        UserDTO.TokenResponseDto tokenResponseDto = new UserDTO.TokenResponseDto(accessToken);
 
         // 쿠키에는 tokenId만 저장
-        ResponseCookie refreshTokenCookie = ResponseCookie.from("refreshTokenId", tokenId)
+        ResponseCookie refreshTokenCookie = ResponseCookie.from("refreshTokenId", refreshToken)
                 .httpOnly(true)
-                .secure(false) // 운영에서는 true
+                .secure(false)
                 .sameSite("Lax")
                 .path("/")
                 .maxAge(Duration.ofDays(3))
                 .build();
         response.setHeader("Set-Cookie", refreshTokenCookie.toString());
-
-        UserDTO.TokenResponseDto tokenResponseDto = new UserDTO.TokenResponseDto(accessToken);
         return new UserDTO.LoginResponseDTO(user, tokenResponseDto);
     }
-
 
     // 엑세스 토큰 재발급
     @Transactional
@@ -111,7 +97,6 @@ public class UserService {
         if (tokenId == null) {
             throw new CustomException(ErrorCode.INVALID_REFRESH_TOKEN);
         }
-
         // Redis에서 Refresh Token 조회
         RefreshToken tokenEntity = refreshTokenRepository.findByTokenId(tokenId)
                 .orElseThrow(() -> new CustomException(ErrorCode.INVALID_REFRESH_TOKEN));
@@ -132,7 +117,7 @@ public class UserService {
         // Refresh Token 교체 여부 판단, 남은 기간이 1일 이하일 경우 Rolling
         String finalTokenId = tokenId;
         if (remainingDays <= 1) {
-            String newRefreshToken = jwtProvider.createRefreshToken(user);
+            String newRefreshToken = jwtProvider.createRefreshToken(user,tokenId);
             String newTokenId = UUID.randomUUID().toString();
 
             // Redis 갱신


### PR DESCRIPTION
## 📄 작업 내용 요약
<!-- 무엇을 작업했는지 간단하게 요약해주세요 -->
엑세스 토큰 재발급이 중복되는 오류를 수정합니다.
- 예: 회원가입 API 구현
- 예: 예외 처리 공통화

---

## 📎 Issue 번호
<!-- 관련된 이슈가 있다면 닫히도록 연결해주세요 (ex: closed #1) -->

- #104 

---

## ✅ 작업 목록
<!-- 체크박스로 완료한 작업을 표시해주세요 -->

- [ ] 기능 구현
- [ ] 코드 리뷰 반영
- [ ] 테스트 코드 작성
- [ ] 문서 업데이트

---

## 📝 기타 참고사항
<!-- 리뷰어가 참고하면 좋을 추가 정보나 질문이 있다면 자유롭게 작성해주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 회원가입 시 닉네임·역할·상태가 기본값으로 자동 설정되어 프로필 생성이 더 일관적입니다.
  - 로그인 및 토큰 재발급 흐름을 개선하여 세션 유지와 쿠키 관리 안정성을 높였습니다.
- 버그 수정
  - 만료된 토큰에 대한 처리와 메시지를 명확히 해 재로그인 안내가 일관됩니다.
- 기타
  - 운영 로그를 강화해 장애 원인 파악과 지원 속도를 개선했습니다.
  - 카카오 로그인/재발급 동작은 기존과 동일합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->