### PR TITLE
[FIX] 전체 리딩룸 조회 수정

### DIFF
--- a/src/main/java/umc/nook/readingrooms/controller/ReadingRoomController.java
+++ b/src/main/java/umc/nook/readingrooms/controller/ReadingRoomController.java
@@ -25,8 +25,8 @@ public class ReadingRoomController {
 
     @Operation(summary = "전체 리딩룸 조회", description = "쿼리 스트링으로 원하는 페이지를 넘겨주시면 됩니다. 페이지 번호는 0부터 시작합니다.")
     @GetMapping
-    public ApiResponse<List<ReadingRoomDTO.ReadingRoomResponseDTO>> getAllReadingRooms(@RequestParam(defaultValue = "0") int page) {
-        return ApiResponse.onSuccess(readingRoomService.getAllReadingRooms(page), SuccessCode.OK);
+    public ApiResponse<List<ReadingRoomDTO.ReadingRoomResponseDTO>> getAllReadingRooms(@RequestParam(defaultValue = "0") int page, @AuthenticationPrincipal CustomUserDetails user) {
+        return ApiResponse.onSuccess(readingRoomService.getAllReadingRooms(page, user), SuccessCode.OK);
     }
 
     @Operation(summary = "사용자가 가입한 리딩룸 조회")

--- a/src/main/java/umc/nook/readingrooms/repository/ReadingRoomUserRepository.java
+++ b/src/main/java/umc/nook/readingrooms/repository/ReadingRoomUserRepository.java
@@ -3,6 +3,8 @@ package umc.nook.readingrooms.repository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import umc.nook.readingrooms.domain.ReadingRoom;
 import umc.nook.readingrooms.domain.ReadingRoomUser;
 import umc.nook.readingrooms.domain.Role;
@@ -20,4 +22,7 @@ public interface ReadingRoomUserRepository extends JpaRepository<ReadingRoomUser
     List<ReadingRoomUser> findAllByReadingRoom(ReadingRoom readingRoom);
     Optional<ReadingRoomUser> findTopByUserOrderByLastAccessedAtDesc(User user);
     int countByUser(User user);
+    @Query("SELECT r FROM ReadingRoom r WHERE r.id NOT IN " +
+            "(SELECT rru.readingRoom.id FROM ReadingRoomUser rru WHERE rru.user = :user)")
+    Page<ReadingRoom> findAllExcludingUserJoinedRooms(@Param("user") User user, Pageable pageable);
 }

--- a/src/main/java/umc/nook/readingrooms/service/ReadingRoomService.java
+++ b/src/main/java/umc/nook/readingrooms/service/ReadingRoomService.java
@@ -79,11 +79,14 @@ public class ReadingRoomService {
 
     // 전체 리딩룸 조회
     @Transactional(readOnly = true)
-    public List<ReadingRoomDTO.ReadingRoomResponseDTO> getAllReadingRooms(int page) {
+    public List<ReadingRoomDTO.ReadingRoomResponseDTO> getAllReadingRooms(int page, CustomUserDetails userDetails) {
 
         int pageSize = 12;
         PageRequest pageRequest = PageRequest.of(page, pageSize);
-        Page<ReadingRoom> readingRooms = readingRoomRepository.findAll(pageRequest);
+
+        User user = userDetails.getUser();
+
+        Page<ReadingRoom> readingRooms = readingRoomUserRepository.findAllExcludingUserJoinedRooms(user, pageRequest);
 
         return readingRooms.stream().map(room -> {
 


### PR DESCRIPTION
## 📄 작업 내용 요약
<!-- 무엇을 작업했는지 간단하게 요약해주세요 -->

- 가입한 리딩룸은 전체 조회할 때 제외되도록 수정

---

## 📎 Issue 번호
<!-- 관련된 이슈가 있다면 닫히도록 연결해주세요 (ex: closed #1) -->

- closed #152 

---

## ✅ 작업 목록
<!-- 체크박스로 완료한 작업을 표시해주세요 -->

- [ ] 기능 구현
- [ ] 코드 리뷰 반영
- [ ] 테스트 코드 작성
- [ ] 문서 업데이트

---

## 📝 기타 참고사항
<!-- 리뷰어가 참고하면 좋을 추가 정보나 질문이 있다면 자유롭게 작성해주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 읽기방 목록이 로그인 사용자를 기준으로 개인화되어, 사용자가 이미 참여 중인 읽기방을 자동으로 제외하고 보여줍니다.
  - 페이지네이션은 동일하게 유지되며(페이지 크기 12), 노출되는 항목 정보(방 상세, 해시태그, 카운트 등)는 기존과 동일합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->