### PR TITLE
[FIX] 크로스 사이트 요청에도 쿠키 전송하도록 수정

### DIFF
--- a/src/main/java/umc/nook/users/service/UserService.java
+++ b/src/main/java/umc/nook/users/service/UserService.java
@@ -80,7 +80,7 @@ public class UserService {
         ResponseCookie refreshTokenCookie = ResponseCookie.from("refreshTokenId", refreshToken)
                 .httpOnly(true)
                 .secure(false)
-                .sameSite("Lax")
+                .sameSite("None")
                 .path("/")
                 .maxAge(Duration.ofDays(3))
                 .build();


### PR DESCRIPTION
## 📄 작업 내용 요약
<!-- 무엇을 작업했는지 간단하게 요약해주세요 -->
크로스 사이트 요청에도 쿠키 전송하도록 수정합니다. 
- 예: 회원가입 API 구현
- 예: 예외 처리 공통화

---

## 📎 Issue 번호
<!-- 관련된 이슈가 있다면 닫히도록 연결해주세요 (ex: closed #1) -->

- closed #104 

---

## ✅ 작업 목록
<!-- 체크박스로 완료한 작업을 표시해주세요 -->

- [ ] 기능 구현
- [ ] 코드 리뷰 반영
- [ ] 테스트 코드 작성
- [ ] 문서 업데이트

---

## 📝 기타 참고사항
<!-- 리뷰어가 참고하면 좋을 추가 정보나 질문이 있다면 자유롭게 작성해주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능: 없음
- 버그 수정: 없음
- 문서: 없음
- 리팩터: 없음
- 스타일: 없음
- 테스트: 없음
- 작업(Chores)
  - 로그인 시 발급되는 리프레시 토큰 쿠키의 SameSite 속성을 Lax에서 None으로 업데이트했습니다. 다른 속성(HttpOnly, Secure, Path, Max-Age)은 그대로 유지됩니다. 이로 인해 크로스 도메인/서드파티 컨텍스트에서 세션 동작이 달라질 수 있으며, HTTPS 환경에서 정상적으로 동작합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->