### PR TITLE
[FIX] 토큰id 레디스에 중복 저장되는 오류 수정

### DIFF
--- a/src/main/java/umc/nook/users/oauth/OAuthService.java
+++ b/src/main/java/umc/nook/users/oauth/OAuthService.java
@@ -159,7 +159,7 @@ public class OAuthService {
      * 로그인 및 회원가입 통합 처리 (인가코드 기반)
      */
     @Transactional
-    public UserDTO.KakaoLoginResponseDTO loginWithKakaoCode(String code) {
+    public UserDTO.KakaoLoginResponseDTO loginWithKakaoCode(String code, String tokenId) {
         KakaoResponseParams newToken = getKakaoAccessToken(code);
         Map<String, Object> userAttribute = getKakaoUserAttributes(newToken.getAccessToken());
         OAuth2Attribute attributes = OAuth2Attribute.of("kakao", userAttribute);
@@ -180,7 +180,7 @@ public class OAuthService {
         }
 
         String accessToken = jwtProvider.createAccessToken(user);
-        String refreshToken = jwtProvider.createRefreshToken(user,accessToken);
+        String refreshToken = jwtProvider.createRefreshToken(user,accessToken, tokenId);
         UserDTO.KakaoTokenResponseDTO jwtTokenResponse = new UserDTO.KakaoTokenResponseDTO(accessToken,refreshToken);
 
         KakaoRefreshToken token = kakaoRefreshTokenRedisRepository.findByUserId(user.getUserId())

--- a/src/main/java/umc/nook/users/service/JwtProvider.java
+++ b/src/main/java/umc/nook/users/service/JwtProvider.java
@@ -60,7 +60,7 @@ public class JwtProvider {
                 .compact();
     }
 
-    public String createRefreshToken(User user, String accessToken) {
+    public String createRefreshToken(User user, String accessToken, String tokenId) {
         Date now = new Date();
         Date expiry = new Date(now.getTime() + REFRESH_EXP);
 
@@ -72,7 +72,6 @@ public class JwtProvider {
                 .signWith(key, SignatureAlgorithm.HS256)
                 .compact();
 
-        String tokenId = UUID.randomUUID().toString();
 
         RefreshToken refreshToken = RefreshToken.builder()
                 .tokenId(tokenId)

--- a/src/main/java/umc/nook/users/service/UserService.java
+++ b/src/main/java/umc/nook/users/service/UserService.java
@@ -71,13 +71,15 @@ public class UserService {
             throw new CustomException(ErrorCode.INVALID_PASSWORD);
         }
 
+        String newTokenId = UUID.randomUUID().toString();
+
         String accessToken = jwtProvider.createAccessToken(user);
-        String refreshToken = jwtProvider.createRefreshToken(user,accessToken);
+        String refreshToken = jwtProvider.createRefreshToken(user,accessToken,newTokenId);
 
         UserDTO.TokenResponseDto tokenResponseDto = new UserDTO.TokenResponseDto(accessToken);
 
         // 쿠키에는 tokenId만 저장
-        ResponseCookie refreshTokenCookie = ResponseCookie.from("refreshTokenId", refreshToken)
+        ResponseCookie refreshTokenCookie = ResponseCookie.from("refreshTokenId", newTokenId)
                 .httpOnly(true)
                 .secure(false)
                 .sameSite("None")
@@ -123,14 +125,13 @@ public class UserService {
         // Refresh Token 교체 여부 판단, 남은 기간이 1일 이하일 경우 Rolling
         String finalTokenId = tokenId;
         if (remainingDays <= 1) {
-            String newRefreshToken = jwtProvider.createRefreshToken(user,tokenId);
-            String newTokenId = UUID.randomUUID().toString();
-
+            String generatedNewTokenId = UUID.randomUUID().toString();
+            String newRefreshToken = jwtProvider.createRefreshToken(user, newAccessToken, generatedNewTokenId);
             // Redis 갱신
             refreshTokenRepository.deleteByTokenId(tokenId);
             refreshTokenRepository.save(
                     RefreshToken.builder()
-                            .tokenId(newTokenId)
+                            .tokenId(generatedNewTokenId)
                             .userId(user.getUserId())
                             .refreshToken(newRefreshToken)
                             .expiration(LocalDateTime.now().plusDays(3))
@@ -138,7 +139,7 @@ public class UserService {
             );
 
             // 쿠키 갱신
-            ResponseCookie refreshTokenCookie = ResponseCookie.from("refreshTokenId", newTokenId)
+            ResponseCookie refreshTokenCookie = ResponseCookie.from("refreshTokenId", generatedNewTokenId)
                     .httpOnly(true)
                     .secure(true)
                     .sameSite("None")
@@ -147,7 +148,7 @@ public class UserService {
                     .build();
             response.setHeader("Set-Cookie", refreshTokenCookie.toString());
 
-            finalTokenId = newTokenId;
+            finalTokenId = generatedNewTokenId;
         }
 
         // Access Token 반환 (Refresh Token은 쿠키로만 관리)
@@ -184,12 +185,12 @@ public class UserService {
     // 카카오 로그인
     @Transactional
     public UserDTO.KakaoLoginResponseDTO kakaoLogin(String code, HttpServletResponse response) {
+        String tokenId = UUID.randomUUID().toString();
 
-        UserDTO.KakaoLoginResponseDTO kakaoResponse = oAuthService.loginWithKakaoCode(code);
+        UserDTO.KakaoLoginResponseDTO kakaoResponse = oAuthService.loginWithKakaoCode(code,tokenId);
         Long userId = kakaoResponse.getUserId();
 
         // 1. JWT RefreshToken 저장 (tokenId 생성)
-        String tokenId = UUID.randomUUID().toString();
         refreshTokenRepository.save(
                 RefreshToken.builder()
                         .tokenId(tokenId)


### PR DESCRIPTION
## 📄 작업 내용 요약
<!-- 무엇을 작업했는지 간단하게 요약해주세요 -->
 리프레시 토큰id가 레디스에 중복 저장되는 오류를 수정합니다.
- 예: 회원가입 API 구현
- 예: 예외 처리 공통화

---

## 📎 Issue 번호
<!-- 관련된 이슈가 있다면 닫히도록 연결해주세요 (ex: closed #1) -->

- closed #104 

---

## ✅ 작업 목록
<!-- 체크박스로 완료한 작업을 표시해주세요 -->

- [x] 기능 구현
- [ ] 코드 리뷰 반영
- [ ] 테스트 코드 작성
- [ ] 문서 업데이트

---

## 📝 기타 참고사항
<!-- 리뷰어가 참고하면 좋을 추가 정보나 질문이 있다면 자유롭게 작성해주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 세션 보안 강화: 쿠키에 실제 리프레시 토큰 대신 식별자만 저장하여 노출 위험을 줄였습니다.
  - 원활한 로그인 유지: 만료 임박 시 자동으로 토큰을 재발급·로테이션해 중단 없는 사용 경험을 제공합니다.
  - 카카오 로그인 개선: 카카오 로그인/재발급 흐름에 동일한 보안·갱신 체계를 적용해 안정성을 높였습니다.
  - 쿠키 설정 개선: 경로 및 만료 시간 속성 정교화로 다양한 화면과 환경에서 로그인 상태 유지가 더 안정적입니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->