### PR TITLE
[FIX] 쿠키 갱신 로직 추가

### DIFF
--- a/src/main/java/umc/nook/users/domain/RefreshToken.java
+++ b/src/main/java/umc/nook/users/domain/RefreshToken.java
@@ -22,12 +22,10 @@ public class RefreshToken {
 
     private Long userId;
 
-    @Indexed
     private String refreshToken;
 
     @JsonDeserialize(using = LocalDateTimeDeserializer.class)
     private LocalDateTime expiration;
 
-    @Indexed
     private String accessToken;
 }

--- a/src/main/java/umc/nook/users/service/UserService.java
+++ b/src/main/java/umc/nook/users/service/UserService.java
@@ -81,12 +81,12 @@ public class UserService {
         // 쿠키에는 tokenId만 저장
         ResponseCookie refreshTokenCookie = ResponseCookie.from("refreshTokenId", newTokenId)
                 .httpOnly(true)
-                .secure(false)
+                .secure(true)
                 .sameSite("None")
                 .path("/")
                 .maxAge(Duration.ofDays(3))
                 .build();
-        response.setHeader("Set-Cookie", refreshTokenCookie.toString());
+        response.addHeader("Set-Cookie", refreshTokenCookie.toString());
         return new UserDTO.LoginResponseDTO(user, tokenResponseDto);
     }
 
@@ -146,7 +146,7 @@ public class UserService {
                     .path("/")
                     .maxAge(Duration.ofDays(3))
                     .build();
-            response.setHeader("Set-Cookie", refreshTokenCookie.toString());
+            response.addHeader("Set-Cookie", refreshTokenCookie.toString());
 
             finalTokenId = generatedNewTokenId;
         }
@@ -229,7 +229,7 @@ public class UserService {
                 .maxAge(Duration.ofDays(60))
                 .build();
 
-        response.setHeader("Set-Cookie", jwtRefreshTokenCookie.toString());
+        response.addHeader("Set-Cookie", jwtRefreshTokenCookie.toString());
         response.addHeader("Set-Cookie", kakaoRefreshTokenCookie.toString());
 
         return kakaoResponse;
@@ -286,7 +286,7 @@ public class UserService {
                     .path("/")
                     .maxAge(Duration.ofDays(60))
                     .build();
-            response.setHeader("Set-Cookie", kakaoRefreshTokenCookie.toString());
+            response.addHeader("Set-Cookie", kakaoRefreshTokenCookie.toString());
         }
 
         return UserDTO.TokenResponseDto.builder()


### PR DESCRIPTION
## 📄 작업 내용 요약
<!-- 무엇을 작업했는지 간단하게 요약해주세요 -->
쿠키 갱신 로직을 추가합니다.
- 예: 회원가입 API 구현
- 예: 예외 처리 공통화

---

## 📎 Issue 번호
<!-- 관련된 이슈가 있다면 닫히도록 연결해주세요 (ex: closed #1) -->

- closed #104 

---

## ✅ 작업 목록
<!-- 체크박스로 완료한 작업을 표시해주세요 -->

- [ ] 기능 구현
- [ ] 코드 리뷰 반영
- [ ] 테스트 코드 작성
- [ ] 문서 업데이트

---

## 📝 기타 참고사항
<!-- 리뷰어가 참고하면 좋을 추가 정보나 질문이 있다면 자유롭게 작성해주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능

- 버그 수정
  - 다중 쿠키를 한 응답에서 정상적으로 전송하도록 Set-Cookie 처리 방식을 개선하여 단일 쿠키 덮어쓰기 문제를 해소했습니다.
  - 로그인/재발급 및 카카오 로그인/재발급 흐름에서 refreshTokenId 등 쿠키의 보안 속성을 강화했습니다(secure=true).

- 리팩터
  - 내부 토큰 저장소의 인덱싱 설정을 정리했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->