### PR TITLE
[FIX] 토큰 400 에러 해결을 위한 CORS 설정 수정

### DIFF
--- a/src/main/java/umc/nook/common/config/WebSecurityConfig.java
+++ b/src/main/java/umc/nook/common/config/WebSecurityConfig.java
@@ -71,7 +71,10 @@ public class WebSecurityConfig {
         configuration.addAllowedMethod("*");
         configuration.setAllowCredentials(true);
         configuration.addAllowedHeader("Authorization");
-        configuration.setAllowedOrigins(List.of("https://readingnook.netlify.app"));
+        configuration.addExposedHeader("Set-Cookie");
+        configuration.setAllowedOrigins(
+                List.of("http://localhost:3000", "https://readingnook.netlify.app")
+        );
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);
         return source;


### PR DESCRIPTION
## 📄 작업 내용 요약
<!-- 무엇을 작업했는지 간단하게 요약해주세요 -->
- allowCredentials(true)와 addAllowedOriginPattern("*") 충돌 제거
- Netlify 및 localhost 도메인만 명시적으로 허용
- Set-Cookie 헤더를 노출하도록 exposedHeaders 추가

- 예: 회원가입 API 구현
- 예: 예외 처리 공통화

---

## 📎 Issue 번호
<!-- 관련된 이슈가 있다면 닫히도록 연결해주세요 (ex: closed #1) -->

- closed #104 

---

## ✅ 작업 목록
<!-- 체크박스로 완료한 작업을 표시해주세요 -->

- [ ] 기능 구현
- [ ] 코드 리뷰 반영
- [ ] 테스트 코드 작성
- [ ] 문서 업데이트

---

## 📝 기타 참고사항
<!-- 리뷰어가 참고하면 좋을 추가 정보나 질문이 있다면 자유롭게 작성해주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 없음
- 버그 수정
  - 일부 환경에서 로그인 후 세션이 유지되지 않거나 쿠키가 정상적으로 처리되지 않던 문제를 해결했습니다(Set-Cookie 헤더 노출).
- 기타(작업)
  - CORS 설정을 업데이트하여 허용 도메인을 확장했습니다(https://readingnook.netlify.app, http://localhost:3000). 이로써 브라우저에서의 접속 및 인증 흐름이 더욱 안정적으로 동작합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->