### PR TITLE
[REFACTOR] 눅톡 기록 조회 리팩토링

### DIFF
--- a/src/main/java/umc/nook/common/response/ErrorCode.java
+++ b/src/main/java/umc/nook/common/response/ErrorCode.java
@@ -26,7 +26,9 @@ public enum ErrorCode implements BaseCode {
     EMAIL_DUPLICATE(HttpStatus.CONFLICT, "ACCOUNT-008", "중복된 이메일입니다."),
     PERMISSION_DENIED(HttpStatus.FORBIDDEN, "ACCOUNT-009", "권한이 없습니다."),
     USER_INACTIVE(HttpStatus.FORBIDDEN,"ACCOUNT-010", "탈퇴한 사용자입니다."),
-
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "ACCOUNT-011","리프레시 토큰을 찾을 수 없습니다."),
+    REFRESH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "ACCOUNT-012","리프레시 토큰이 만료되었습니다."),
+    REFRESH_TOKEN_INVALID(HttpStatus.BAD_REQUEST, "ACCOUNT-013","리프레시 토큰이 유효하지 않습니다."),
     // 서재 관련
     DUPLICATE_BOOK_IN_SHELF(HttpStatus.CONFLICT, "BOOKSHELF-001", "이미 서재에 등록된 책입니다."),
     ALREADY_READING(HttpStatus.CONFLICT, "BOOKSHELF-002", "이미 독서중 상태입니다."),
@@ -80,6 +82,7 @@ public enum ErrorCode implements BaseCode {
     RECORD_NOT_FOUND(HttpStatus.NOT_FOUND, "RECORD-001","기록이 존재하지 않습니다." ),
     INVALID_RECORD_TYPE(HttpStatus.BAD_REQUEST, "RECORD-002", "유효하지 않은 기록 유형입니다."),
     RECORD_NOT_EXIST(HttpStatus.NOT_FOUND, "RECORD-003","기록이 없습니다." ),
+    CHAT_RECORD_MUST_BE_COMMENT(HttpStatus.BAD_REQUEST,"RECORD-004","감상의 경우에만 저장 가능합니다." ),
 
     CHAT_RECORD_NOT_FOUND(HttpStatus.NOT_FOUND,"RECORD-003","채팅 기록이 존재하지 않습니다." ),
 

--- a/src/main/java/umc/nook/records/controller/RecordController.java
+++ b/src/main/java/umc/nook/records/controller/RecordController.java
@@ -50,14 +50,14 @@ public class RecordController {
             description = "독서 중 인상 깊은 문장을 기록합니다."
     )
     @PostMapping("/sentence/save")
-    public ApiResponse<String> saveSentence(
+    public ApiResponse<?> saveSentence(
             @Parameter(hidden = true)
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestBody @Validated
             RecordDTO.RecordRequestDTO requestDTO
     ) {
-        recordService.saveSentence(userDetails.getUser(), requestDTO);
-        return ApiResponse.onSuccess("문장 기록이 저장되었습니다.", SuccessCode.CREATED);
+        var response = recordService.saveSentence(userDetails.getUser(), requestDTO);
+        return ApiResponse.onSuccess(response, SuccessCode.CREATED);
     }
 
     @Operation(

--- a/src/main/java/umc/nook/records/controller/RecordController.java
+++ b/src/main/java/umc/nook/records/controller/RecordController.java
@@ -177,10 +177,12 @@ public class RecordController {
     }
 
     @PostMapping("/chat/{chatRecordId}/save")
-    @Operation(summary = "눅톡 감상을 내 감상으로 저장", description = "눅톡으로 생성된 감상을 독서 기록 감상으로 저장합니다.")
+    @Operation(
+            summary = "눅톡 감상을 내 감상으로 저장",
+            description = "눅톡으로 생성된 감상을 독서 기록 감상으로 저장합니다. 채팅 기록의 타입이 감상(COMMENT)일 경우에만 저장 가능합니다.")
     public ApiResponse<RecordDTO.CommentResponseDTO> saveCommentFromChatRecord(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @Parameter(description = "채팅 기록 ID") @PathVariable Long chatRecordId
+            @Parameter(description = "눅톡 채팅 기록 ID") @PathVariable Long chatRecordId
     ) {
         return ApiResponse.onSuccess(
                 recordService.saveCommentFromChatRecord(userDetails.getUser(), chatRecordId),

--- a/src/main/java/umc/nook/records/dto/ChatDTO.java
+++ b/src/main/java/umc/nook/records/dto/ChatDTO.java
@@ -1,6 +1,9 @@
 package umc.nook.records.dto;
 
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,7 +21,12 @@ public class ChatDTO {
     @NoArgsConstructor
     @Getter
     public static class ChatRequestDTO {
+
+        @NotNull(message = "bookId는 필수입니다.")
+        @Positive(message = "bookId는 양수여야 합니다.")
         private Long bookId;
+
+        @NotBlank(message = "메세지는 필수입니다.")
         private String message;
         @Builder
         public ChatRecord toEntity(ChatType recordType, UserBookShelf userBookShelf) {
@@ -33,11 +41,13 @@ public class ChatDTO {
     @AllArgsConstructor
     @Getter
     public static class ChatResponseDTO {
+        private Long chatRecordId;
         private String message;
         private ChatType chatType;
         private LocalDateTime createdDate;
 
         public ChatResponseDTO(ChatRecord record){
+            this.chatRecordId = record.getId();
             this.message = record.getContent();
             this.createdDate = record.getCreatedDate();
             this.chatType = record.getRole();

--- a/src/main/java/umc/nook/records/service/RecordService.java
+++ b/src/main/java/umc/nook/records/service/RecordService.java
@@ -1,9 +1,9 @@
 package umc.nook.records.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import umc.nook.book.domain.Book;
 import umc.nook.book.repository.BookRepository;
 import umc.nook.bookshelves.domain.UserBookShelf;
@@ -40,6 +40,7 @@ public class RecordService {
 
 
 
+    // 눅톡 메세지 전송
     @Transactional
     public ChatDTO.ChatResponseDTO saveChatMessage(User user, ChatDTO.ChatRequestDTO requestDTO) throws JsonProcessingException {
         Book book = bookRepository.findByBookId(requestDTO.getBookId());
@@ -74,7 +75,7 @@ public class RecordService {
 
 
     // 선택한 책 눅톡 기록 조회
-    @Transactional
+    @Transactional(readOnly=true)
     public List<ChatDTO.ChatResponseDTO> viewChatMessages(User user, Long bookId) {
         Book book = bookRepository.findByBookId(bookId);
         if (book == null)
@@ -121,7 +122,7 @@ public class RecordService {
     }
 
     // 선택한 책 독서 기록 조회
-    @Transactional
+    @Transactional(readOnly = true)
     public List<RecordDTO.RecordResponseDTO> viewRecordsByBookId(User user, Long bookId) {
         Book book = bookRepository.findByBookId(bookId);
         UserBookShelf userBookShelf = userBookshelfRepository.findByUserAndBook(user, book);
@@ -183,7 +184,7 @@ public class RecordService {
     }
 
     // 독서 기록률 조회
-    @Transactional
+    @Transactional(readOnly = true)
     public RecordDTO.MonthlyRecordRateResponseDTO viewRecordRate(User user, Year year) {
         return bookRecordRepository.viewRecordRate(user,year);
     }
@@ -195,6 +196,8 @@ public class RecordService {
         // 채팅 기록 조회
         ChatRecord record = chatRecordRepository.findById(chatRecordId)
                 .orElseThrow(() -> new CustomException(ErrorCode.CHAT_RECORD_NOT_FOUND));
+        if (record.getRole() != ChatType.COMMENT)
+            throw new CustomException(ErrorCode.CHAT_RECORD_MUST_BE_COMMENT);
         // 내용 추출
         String content = record.getContent();
         // BookRecord 생성 및 저장
@@ -209,7 +212,7 @@ public class RecordService {
     }
 
     // 가장 최근 기록한 책 정보 조회
-    @Transactional
+    @Transactional(readOnly = true)
     public BookShelfDTO.BookThumbnail viewRecentlyRecordedBook(User user) {
         return bookRecordRepository.viewRecentRecordedBook(user)
                 .map(b -> new BookShelfDTO.BookThumbnail(


### PR DESCRIPTION
## 📄 작업 내용 요약
<!-- 무엇을 작업했는지 간단하게 요약해주세요 -->
- 눅톡 기록 조회 반환 DTO를 상세하게 수정합니다.
- 스웨거 설명을 추가합니다. 
- 예: 회원가입 API 구현
- 예: 예외 처리 공통화

---

## 📎 Issue 번호
<!-- 관련된 이슈가 있다면 닫히도록 연결해주세요 (ex: closed #1) -->

- closed #105 

---

## ✅ 작업 목록
<!-- 체크박스로 완료한 작업을 표시해주세요 -->

- [ ] 기능 구현
- [ ] 코드 리뷰 반영
- [ ] 테스트 코드 작성
- [ ] 문서 업데이트

---

## 📝 기타 참고사항
<!-- 리뷰어가 참고하면 좋을 추가 정보나 질문이 있다면 자유롭게 작성해주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 채팅 응답에 chatRecordId 포함하여 반환.
  * 문장 저장 API가 실제 생성 결과를 응답으로 반환.
  * 로그인 유지 관련 리프레시 토큰 오류를 세분화하여 명확한 안내 제공(미존재/만료/유효하지 않음).
  * 채팅 요청 값 검증 강화(bookId 필수·양수, message 필수).
* **Bug Fixes**
  * 댓글이 아닌 채팅 기록으로 저장 시도 시 올바른 오류 반환 및 저장 방지.
* **Documentation**
  * API 설명 보완(눅톡 채팅 기록 ID 명시, 제약 조건 서술 강화).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->