### PR TITLE
[FIX] CORS 도메인 추가

### DIFF
--- a/src/main/java/umc/nook/common/config/WebSecurityConfig.java
+++ b/src/main/java/umc/nook/common/config/WebSecurityConfig.java
@@ -68,7 +68,7 @@ public class WebSecurityConfig {
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.setAllowCredentials(true);
         configuration.setAllowedOrigins(
-                List.of("http://localhost:3000", "https://readingnook.netlify.app")
+                List.of("http://localhost:3000", "https://readingnook.netlify.app",  "https://nook-app.shop")
         );
         configuration.addAllowedHeader("*");
         configuration.addAllowedMethod("*");


### PR DESCRIPTION
## 📄 작업 내용 요약
<!-- 무엇을 작업했는지 간단하게 요약해주세요 -->
CORS 도메인을 접근하려는 경로만으로 수정합니다.
- 예: 회원가입 API 구현
- 예: 예외 처리 공통화

---

## 📎 Issue 번호
<!-- 관련된 이슈가 있다면 닫히도록 연결해주세요 (ex: closed #1) -->

- closed #104 

---

## ✅ 작업 목록
<!-- 체크박스로 완료한 작업을 표시해주세요 -->

- [ ] 기능 구현
- [ ] 코드 리뷰 반영
- [ ] 테스트 코드 작성
- [ ] 문서 업데이트

---

## 📝 기타 참고사항
<!-- 리뷰어가 참고하면 좋을 추가 정보나 질문이 있다면 자유롭게 작성해주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * https://nook-app.shop 도메인에서의 교차 출처 API 요청을 허용했습니다. 이제 해당 도메인에서 앱을 접속·사용할 때 네트워크 차단 없이 원활히 동작합니다. 신규 배포 도메인을 공식 지원합니다.
* Chores
  * 기존 도메인(로컬호스트, Netlify) 사용 경험은 변함없으며, 인증·헤더·메서드 허용 범위 등 CORS 동작은 기존과 동일하게 유지됩니다. 사용자는 설정 변경 없이 기존과 동일한 방식으로 이용할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->