### PR TITLE
[FIX] 페이징 버그 수정

### DIFF
--- a/src/main/java/umc/nook/bookshelves/repository/BookshelfCustomRepositoryImpl.java
+++ b/src/main/java/umc/nook/bookshelves/repository/BookshelfCustomRepositoryImpl.java
@@ -2,6 +2,7 @@ package umc.nook.bookshelves.repository;
 
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.Tuple;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -11,25 +12,20 @@ import org.springframework.transaction.annotation.Transactional;
 import umc.nook.book.domain.QBook;
 import umc.nook.bookshelves.domain.QUserBookShelf;
 import umc.nook.bookshelves.domain.ReadingStatus;
-import umc.nook.bookshelves.domain.UserBookShelf;
 import umc.nook.bookshelves.dto.BookShelfDTO;
 import umc.nook.bookshelves.dto.SortType;
-import umc.nook.bookshelves.repository.BookShelfCustomRepository;
 import umc.nook.records.domain.QBookRecord;
 import umc.nook.records.domain.QChatRecord;
-import umc.nook.records.dto.RecordDTO;
 import umc.nook.review.domain.QReview;
 import umc.nook.users.domain.User;
 
 import java.time.LocalDate;
-import java.time.Year;
 import java.time.YearMonth;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static umc.nook.records.domain.QBookRecord.bookRecord;
-import static umc.nook.records.domain.QChatRecord.chatRecord;
 
 @Repository
 @Transactional(readOnly = true)
@@ -38,107 +34,67 @@ class BookShelfCustomRepositoryImpl implements BookShelfCustomRepository {
 
     private final JPAQueryFactory queryFactory;
 
-    @Transactional
-    public List<BookShelfDTO.UserBookListResponseDTO> getUserBooks(User user, ReadingStatus status, int page, int size, SortType sort) {
+    @Transactional(readOnly = true)
+    public List<BookShelfDTO.UserBookListResponseDTO> getUserBooks(
+            User user,
+            ReadingStatus status,
+            int page,
+            int size,
+            SortType sort
+    ) {
         QUserBookShelf ub = QUserBookShelf.userBookShelf;
         QBook book = QBook.book;
         QReview review = QReview.review;
         QBookRecord bookRecord = QBookRecord.bookRecord;
-        QChatRecord chatRecord = QChatRecord.chatRecord;
 
         BooleanBuilder condition = new BooleanBuilder()
                 .and(ub.user.eq(user))
                 .and(ub.readingStatus.eq(status));
 
-        List<Tuple> tuples;
+        OrderSpecifier<?> primaryOrder;
+        OrderSpecifier<?> secondaryOrder = book.bookId.desc();
 
-        // 내가 준 별점순
-        if (sort.equals(SortType.RATING)) {
-            tuples = queryFactory
-                    .select(
-                            book.bookId,
-                            book.title,
-                            book.author,
-                            book.publisher,
-                            book.coverImageUrl,
-                            ub.readingStatus.stringValue(),
-                            book.isbn13,
-                            review.rating,
-                            book.publicationDate
-                    )
-                    .from(ub)
-                    .join(ub.book, book)
-                    .leftJoin(review).on(
-                            review.book.eq(book),
-                            review.user.eq(user)
-                    )
-                    .where(condition)
-                    .orderBy(review.rating.desc().nullsLast())
-                    .limit(size + 1)
-                    .fetch();
-        } else if (sort.equals(SortType.RECENT)) {
-            tuples = queryFactory
-                    .select(
-                            book.bookId,
-                            book.title,
-                            book.author,
-                            book.publisher,
-                            book.coverImageUrl,
-                            ub.readingStatus.stringValue(),
-                            book.isbn13,
-                            review.rating,
-                            book.publicationDate,
-                            Expressions.stringTemplate(
-                                    "COALESCE(GREATEST({0}, {1}), {2})",
-                                    JPAExpressions
-                                            .select(chatRecord.createdDate.max())
-                                            .from(chatRecord)
-                                            .where(chatRecord.bookshelf.eq(ub)),
-                                    JPAExpressions
-                                            .select(bookRecord.createdDate.max())
-                                            .from(bookRecord)
-                                            .where(bookRecord.bookshelf.eq(ub)),
-                                    ub.recordedAt  // fallback
-                            ).as("latestRecordDate")
-                    )
-                    .from(ub)
-                    .join(ub.book, book)
-                    .leftJoin(review).on(
-                            review.book.eq(book),
-                            review.user.eq(user)
-                    )
-                    .where(condition)
-                    .orderBy(Expressions.stringPath("latestRecordDate").desc().nullsLast())
-                    .limit(size + 1)
-                    .fetch();
-        } else {
-            tuples = queryFactory
-                    .select(
-                            book.bookId,
-                            book.title,
-                            book.author,
-                            book.publisher,
-                            book.coverImageUrl,
-                            ub.readingStatus.stringValue(),
-                            book.isbn13,
-                            review.rating,
-                            book.publicationDate
-                    )
-                    .from(ub)
-                    .join(ub.book, book)
-                    .leftJoin(review).on(
-                            review.book.eq(book),
-                            review.user.eq(user)
-                    )
-                    .where(condition)
-                    .orderBy(switch (sort) {
-                        case TITLE -> book.title.asc();
-                        case LATEST -> ub.createdDate.desc();
-                        default -> ub.recordedAt.desc();
-                    })
-                    .limit(size + 1)
-                    .fetch();
+        switch (sort) {
+            case RATING -> primaryOrder = review.rating.desc().nullsLast();
+            case RECENT -> primaryOrder = Expressions.stringPath("latestRecordDate").desc().nullsLast();
+            case TITLE -> {
+                primaryOrder = book.title.asc();
+                secondaryOrder = book.bookId.asc();
+            }
+            case LATEST -> primaryOrder = ub.createdDate.desc();
+            default -> primaryOrder = ub.recordedAt.desc();
         }
+
+        List<Tuple> tuples = queryFactory
+                .select(
+                        book.bookId,
+                        book.title,
+                        book.author,
+                        book.publisher,
+                        book.coverImageUrl,
+                        ub.readingStatus.stringValue(),
+                        book.isbn13,
+                        review.rating,
+                        book.publicationDate,
+                        Expressions.stringTemplate(
+                                "COALESCE({0}, {1})",
+                                JPAExpressions.select(bookRecord.createdDate.max())
+                                        .from(bookRecord)
+                                        .where(bookRecord.bookshelf.eq(ub)),
+                                ub.recordedAt
+                        ).as("latestRecordDate")
+                )
+                .from(ub)
+                .join(ub.book, book)
+                .leftJoin(review).on(
+                        review.book.eq(book),
+                        review.user.eq(user)
+                )
+                .where(condition)
+                .orderBy(primaryOrder, secondaryOrder)
+                .offset(page * size)
+                .limit(size + 1)
+                .fetch();
 
         return tuples.stream()
                 .map(t -> new BookShelfDTO.UserBookListResponseDTO(
@@ -154,7 +110,6 @@ class BookShelfCustomRepositoryImpl implements BookShelfCustomRepository {
                 ))
                 .toList();
     }
-
     // 월별 책 조회
     @Transactional
     public List<BookShelfDTO.DailyBooksResponseDTO> getMonthlyBooks(User user, YearMonth yearMonth) {

--- a/src/main/java/umc/nook/bookshelves/repository/UserBookshelfRepository.java
+++ b/src/main/java/umc/nook/bookshelves/repository/UserBookshelfRepository.java
@@ -1,7 +1,11 @@
 package umc.nook.bookshelves.repository;
 
 import com.querydsl.core.Tuple;
+import org.springframework.data.domain.Page;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 import umc.nook.book.domain.Book;
 import umc.nook.bookshelves.domain.ReadingStatus;
 import umc.nook.bookshelves.domain.UserBookShelf;
@@ -18,7 +22,7 @@ import org.springframework.data.repository.query.Param;
 import umc.nook.book.domain.CategoryCount;
 import umc.nook.book.domain.CategoryCountByName;
 
-public interface UserBookshelfRepository extends JpaRepository<UserBookShelf,Long> , BookShelfCustomRepository{
+public interface UserBookshelfRepository extends JpaRepository<UserBookShelf,Long> , BookShelfCustomRepository, QuerydslPredicateExecutor<UserBookShelf> {
     boolean existsByUserAndBook(User user, Book book);
 
     UserBookShelf findByUserAndBook(User user, Book book);
@@ -94,4 +98,12 @@ public interface UserBookshelfRepository extends JpaRepository<UserBookShelf,Lon
 
 
     boolean existsByUserAndRecordedAt(User user, LocalDate date);
+
+    @EntityGraph(attributePaths = {
+            "book",          // 책 정보
+            "book.reviews",  // 리뷰
+            "records",       // 독서 기록
+            "chatRecords"    // 대화 기록
+    })
+    Page<UserBookShelf> findAll(Specification<UserBookShelf> spec, Pageable pageable);
 }

--- a/src/main/java/umc/nook/bookshelves/service/BookShelfService.java
+++ b/src/main/java/umc/nook/bookshelves/service/BookShelfService.java
@@ -8,7 +8,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import umc.nook.book.domain.Book;
 import umc.nook.book.repository.BookRepository;
-import umc.nook.bookshelves.controller.BookShelfController;
 import umc.nook.bookshelves.domain.ReadingStatus;
 import umc.nook.bookshelves.domain.UserBookShelf;
 import umc.nook.bookshelves.dto.BookShelfDTO;


### PR DESCRIPTION
## 📄 작업 내용 요약
<!-- 무엇을 작업했는지 간단하게 요약해주세요 -->
- 서재 페이징 버그를 수정했습니다.
- EntityGraph를 사용하여 N+1 문제를 해결했습니다. 
- 정렬 방식을 Orderspecifier를 통해 구현했습니다. 
- 예: 회원가입 API 구현
- 예: 예외 처리 공통화

---

## 📎 Issue 번호
<!-- 관련된 이슈가 있다면 닫히도록 연결해주세요 (ex: closed #1) -->

- closed #171 

---

## ✅ 작업 목록
<!-- 체크박스로 완료한 작업을 표시해주세요 -->

- [ ] 기능 구현
- [ ] 코드 리뷰 반영
- [ ] 테스트 코드 작성
- [ ] 문서 업데이트

---

## 📝 기타 참고사항
<!-- 리뷰어가 참고하면 좋을 추가 정보나 질문이 있다면 자유롭게 작성해주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 책장 목록의 ‘최신순’ 정렬이 실제 최신 활동 기준으로 더 정확하게 표시됩니다.
- 리팩터링
  - 정렬·페이지네이션 로직을 단일 흐름으로 통합해 목록 로딩 일관성과 성능을 개선했습니다.
  - 읽기 전용 트랜잭션 적용으로 안정성과 조회 성능을 향상했습니다.
- 문서
  - 외부 동작에는 변화가 없으며, 내부 의존성 정리가 반영되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->