### PR TITLE
[FEAT] 서재 페이징 DTO 수정

### DIFF
--- a/src/main/java/umc/nook/bookshelves/dto/BookShelfDTO.java
+++ b/src/main/java/umc/nook/bookshelves/dto/BookShelfDTO.java
@@ -115,6 +115,7 @@ public class BookShelfDTO {
         private int page;         // 현재 페이지 번호 (0부터 시작)
         private int size;         // 페이지 크기
         private boolean hasNext;  // 다음 페이지 존재 여부
+        private Long totalPage;  // 전체 페이지
     }
 
     @Getter

--- a/src/main/java/umc/nook/bookshelves/repository/BookShelfCustomRepository.java
+++ b/src/main/java/umc/nook/bookshelves/repository/BookShelfCustomRepository.java
@@ -1,20 +1,16 @@
 package umc.nook.bookshelves.repository;
 
 
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Repository;
 import umc.nook.bookshelves.domain.ReadingStatus;
 import umc.nook.bookshelves.dto.BookShelfDTO;
 import umc.nook.bookshelves.dto.SortType;
-import umc.nook.records.dto.RecordDTO;
 import umc.nook.users.domain.User;
 
-import java.time.Year;
 import java.time.YearMonth;
 import java.util.List;
 
 public interface BookShelfCustomRepository {
-    List<BookShelfDTO.UserBookListResponseDTO> getUserBooks(
+    BookShelfDTO.PageDTO<BookShelfDTO.UserBookListResponseDTO> getUserBooks(
             User user, ReadingStatus status, int page, int size, SortType sort);
 
     List<BookShelfDTO.DailyBooksResponseDTO> getMonthlyBooks(

--- a/src/main/java/umc/nook/bookshelves/repository/BookshelfCustomRepositoryImpl.java
+++ b/src/main/java/umc/nook/bookshelves/repository/BookshelfCustomRepositoryImpl.java
@@ -15,7 +15,6 @@ import umc.nook.bookshelves.domain.ReadingStatus;
 import umc.nook.bookshelves.dto.BookShelfDTO;
 import umc.nook.bookshelves.dto.SortType;
 import umc.nook.records.domain.QBookRecord;
-import umc.nook.records.domain.QChatRecord;
 import umc.nook.review.domain.QReview;
 import umc.nook.users.domain.User;
 
@@ -35,7 +34,7 @@ class BookShelfCustomRepositoryImpl implements BookShelfCustomRepository {
     private final JPAQueryFactory queryFactory;
 
     @Transactional(readOnly = true)
-    public List<BookShelfDTO.UserBookListResponseDTO> getUserBooks(
+    public BookShelfDTO.PageDTO<BookShelfDTO.UserBookListResponseDTO> getUserBooks(
             User user,
             ReadingStatus status,
             int page,
@@ -51,6 +50,7 @@ class BookShelfCustomRepositoryImpl implements BookShelfCustomRepository {
                 .and(ub.user.eq(user))
                 .and(ub.readingStatus.eq(status));
 
+        // 정렬 조건
         OrderSpecifier<?> primaryOrder;
         OrderSpecifier<?> secondaryOrder = book.bookId.desc();
 
@@ -65,6 +65,16 @@ class BookShelfCustomRepositoryImpl implements BookShelfCustomRepository {
             default -> primaryOrder = ub.recordedAt.desc();
         }
 
+        // ✅ 전체 개수 (totalPage 계산용)
+        long totalCount = queryFactory
+                .select(ub.count())
+                .from(ub)
+                .where(condition)
+                .fetchOne();
+
+        long totalPage = (long) Math.ceil((double) totalCount / size);
+
+        // ✅ 데이터 조회 (size+1로 hasNext 확인)
         List<Tuple> tuples = queryFactory
                 .select(
                         book.bookId,
@@ -96,7 +106,12 @@ class BookShelfCustomRepositoryImpl implements BookShelfCustomRepository {
                 .limit(size + 1)
                 .fetch();
 
-        return tuples.stream()
+        boolean hasNext = tuples.size() > size;
+        if (hasNext) {
+            tuples = tuples.subList(0, size);
+        }
+
+        List<BookShelfDTO.UserBookListResponseDTO> content = tuples.stream()
                 .map(t -> new BookShelfDTO.UserBookListResponseDTO(
                         t.get(book.bookId),
                         t.get(book.title),
@@ -109,6 +124,14 @@ class BookShelfCustomRepositoryImpl implements BookShelfCustomRepository {
                         t.get(book.publicationDate)
                 ))
                 .toList();
+
+        return new BookShelfDTO.PageDTO<>(
+                content,
+                page,
+                size,
+                hasNext,
+                totalPage
+        );
     }
     // 월별 책 조회
     @Transactional

--- a/src/main/java/umc/nook/bookshelves/service/BookShelfService.java
+++ b/src/main/java/umc/nook/bookshelves/service/BookShelfService.java
@@ -145,22 +145,7 @@ public class BookShelfService {
         int safeSize = (size == null || size <= 0) ? 8 : size;
         SortType safeSort = (sort == null) ? SortType.RECENT : sort;
 
-        // size + 1로 조회
-        List<BookShelfDTO.UserBookListResponseDTO> content =
-                userBookshelfRepository.getUserBooks(user, status, safePage, safeSize + 1, safeSort);
-
-        // hasNext 계산
-        boolean hasNext = content.size() > safeSize;
-        if (hasNext) {
-            content = content.subList(0, safeSize);
-        }
-
-        return new BookShelfDTO.PageDTO<>(
-                content,
-                safePage,
-                safeSize,
-                hasNext
-        );
+        return userBookshelfRepository.getUserBooks(user, status, safePage, safeSize, sort);
     }
 
     // 월별 책 조회


### PR DESCRIPTION
## 📄 작업 내용 요약
<!-- 무엇을 작업했는지 간단하게 요약해주세요 -->
서재 페이징 시 전체 페이지 반환 부분을 추가했습니다. 
- 예: 회원가입 API 구현
- 예: 예외 처리 공통화

---

## 📎 Issue 번호
<!-- 관련된 이슈가 있다면 닫히도록 연결해주세요 (ex: closed #1) -->

- closed #174 

---

## ✅ 작업 목록
<!-- 체크박스로 완료한 작업을 표시해주세요 -->

- [ ] 기능 구현
- [ ] 코드 리뷰 반영
- [ ] 테스트 코드 작성
- [ ] 문서 업데이트

---

## 📝 기타 참고사항
<!-- 리뷰어가 참고하면 좋을 추가 정보나 질문이 있다면 자유롭게 작성해주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 사용자 책장 목록에 페이지네이션 메타데이터(totalPage 포함)를 제공하여 전체 페이지 수 확인이 가능합니다.
  - 페이지 크기 지정과 정렬 옵션(평점순, 최신 활동순, 제목순, 최근 추가순 등)을 지원합니다.
- 개선/리팩터링
  - 페이지네이션 로직을 일관화해 다음 페이지 여부 판단과 목록 잘림 가능성을 줄였습니다.
  - 응답 구조를 단순화하여 목록 조회의 안정성과 일관성을 향상했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->