### PR TITLE
[REFACTOR] 카카오 토큰 저장 방식 수정

### DIFF
--- a/src/main/java/umc/nook/users/domain/KakaoRefreshToken.java
+++ b/src/main/java/umc/nook/users/domain/KakaoRefreshToken.java
@@ -8,7 +8,7 @@ import org.springframework.data.redis.core.RedisHash;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-@RedisHash(value = "kakaoRefreshToken", timeToLive = 60 * 60 * 24 * 30) // 30일 TTL 예시
+@RedisHash(value = "kakaoRefreshToken", timeToLive = 60 * 60 * 24 * 3)
 public class KakaoRefreshToken {
 
     @Id

--- a/src/main/java/umc/nook/users/domain/User.java
+++ b/src/main/java/umc/nook/users/domain/User.java
@@ -13,7 +13,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Entity
-@Table(name = "user")
+@Table(name = "users")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor

--- a/src/main/java/umc/nook/users/dto/UserDTO.java
+++ b/src/main/java/umc/nook/users/dto/UserDTO.java
@@ -103,22 +103,31 @@ public class UserDTO {
         private Long userId;
         private String email;
         private String nickname;
+
+        private Long refreshTokenExpiresIn;
         private KakaoTokenResponseDTO token;
 
         private String kakaoRefreshToken;
+        private String refreshTokenId;
+        private String kakaoRefreshTokenId;
 
-        public KakaoLoginResponseDTO(User user, KakaoTokenResponseDTO token, String kakaoRefreshToken) {
+        public KakaoLoginResponseDTO(
+                User user,
+                KakaoTokenResponseDTO token,
+                String kakaoRefreshToken,
+                String refreshTokenId,
+                String kakaoRefreshTokenId
+        ) {
             this.userId = user.getUserId();
             this.email = user.getEmail();
             this.nickname = user.getNickname();
             this.token = token;
             this.kakaoRefreshToken = kakaoRefreshToken;
-        }
-
-        public UserDTO.LoginResponseDTO toLoginDTO(User user, TokenResponseDto token) {
-            return new UserDTO.LoginResponseDTO(user,token);
+            this.refreshTokenId = refreshTokenId;
+            this.kakaoRefreshTokenId = kakaoRefreshTokenId;
         }
     }
+
 
 }
 

--- a/src/main/java/umc/nook/users/oauth/OAuthService.java
+++ b/src/main/java/umc/nook/users/oauth/OAuthService.java
@@ -26,6 +26,7 @@ import umc.nook.users.service.JwtProvider;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 
 @Service
 @Slf4j
@@ -159,7 +160,7 @@ public class OAuthService {
      * 로그인 및 회원가입 통합 처리 (인가코드 기반)
      */
     @Transactional
-    public UserDTO.KakaoLoginResponseDTO loginWithKakaoCode(String code, String tokenId) {
+    public UserDTO.KakaoLoginResponseDTO loginWithKakaoCode(String code, String tokenId, String kakaoTokenId) {
         KakaoResponseParams newToken = getKakaoAccessToken(code);
         Map<String, Object> userAttribute = getKakaoUserAttributes(newToken.getAccessToken());
         OAuth2Attribute attributes = OAuth2Attribute.of("kakao", userAttribute);
@@ -173,30 +174,44 @@ public class OAuthService {
         } else if (findUser.isPresent()){
             user = findUser.get();
             log.info("기존 사용자 로그인: {}", user.getKakaoUserId());
-        }else {
+        } else {
             log.info("새로운 사용자 생성: {}", attributes.getEmail());
             user = saveUser(attributes);
             userRepository.save(user);
         }
 
+        // JWT 토큰 발급
         String accessToken = jwtProvider.createAccessToken(user);
-        String refreshToken = jwtProvider.createRefreshToken(user,accessToken, tokenId);
-        UserDTO.KakaoTokenResponseDTO jwtTokenResponse = new UserDTO.KakaoTokenResponseDTO(accessToken,refreshToken);
+        String refreshToken = jwtProvider.createRefreshToken(user, accessToken, tokenId);
+        UserDTO.KakaoTokenResponseDTO jwtTokenResponse = new UserDTO.KakaoTokenResponseDTO(accessToken, refreshToken);
 
         KakaoRefreshToken token = kakaoRefreshTokenRedisRepository.findByUserId(user.getUserId())
                 .map(existing -> {
-                    existing.updateToken(newToken.getRefreshToken(), newToken.getAccessToken(), (long) newToken.getRefreshTokenExpiresIn()); // update 메서드 활용
+                    existing.updateToken(
+                            newToken.getRefreshToken(),
+                            newToken.getAccessToken(),
+                            (long) newToken.getRefreshTokenExpiresIn()
+                    );
                     return existing;
                 })
                 .orElseGet(() -> KakaoRefreshToken.builder()
+                        .tokenId(kakaoTokenId)
                         .userId(user.getUserId())
                         .refreshToken(newToken.getRefreshToken())
                         .accessToken(newToken.getAccessToken())
                         .refreshTokenExpiresIn((long) newToken.getRefreshTokenExpiresIn())
                         .build());
         kakaoRefreshTokenRedisRepository.save(token);
-        return new UserDTO.KakaoLoginResponseDTO(user, jwtTokenResponse, newToken.getRefreshToken());
+
+        return new UserDTO.KakaoLoginResponseDTO(
+                user,
+                jwtTokenResponse,
+                newToken.getRefreshToken(),
+                tokenId,
+                kakaoTokenId
+        );
     }
+
 
 
     /**

--- a/src/main/java/umc/nook/users/service/UserService.java
+++ b/src/main/java/umc/nook/users/service/UserService.java
@@ -185,35 +185,36 @@ public class UserService {
     // 카카오 로그인
     @Transactional
     public UserDTO.KakaoLoginResponseDTO kakaoLogin(String code, HttpServletResponse response) {
-        String tokenId = UUID.randomUUID().toString();
+        // tokenId 발급
+        String jwtTokenId = UUID.randomUUID().toString();
+        String kakaoTokenId = UUID.randomUUID().toString();
 
-        UserDTO.KakaoLoginResponseDTO kakaoResponse = oAuthService.loginWithKakaoCode(code,tokenId);
+        UserDTO.KakaoLoginResponseDTO kakaoResponse = oAuthService.loginWithKakaoCode(code, jwtTokenId,kakaoTokenId);
         Long userId = kakaoResponse.getUserId();
 
-        // 1. JWT RefreshToken 저장 (tokenId 생성)
+        // 2. JWT RefreshToken 저장
         refreshTokenRepository.save(
                 RefreshToken.builder()
-                        .tokenId(tokenId)
+                        .tokenId(jwtTokenId)
                         .userId(userId)
                         .refreshToken(kakaoResponse.getToken().getRefreshToken())
                         .expiration(LocalDateTime.now().plusDays(3))
                         .build()
         );
 
-        // 2. Kakao RefreshToken 저장 (tokenId 생성)
-        String kakaoTokenId = UUID.randomUUID().toString();
+        // 3. Kakao RefreshToken 저장
         kakaoRefreshTokenRedisRepository.save(
                 KakaoRefreshToken.builder()
                         .tokenId(kakaoTokenId)
                         .userId(userId)
                         .refreshToken(kakaoResponse.getKakaoRefreshToken())
                         .accessToken(kakaoResponse.getToken().getAccessToken())
-                        .refreshTokenExpiresIn(60L * 24 * 60 * 60) // 60일
+                        .refreshTokenExpiresIn((long) kakaoResponse.getRefreshTokenExpiresIn())
                         .build()
         );
 
-        // 3. 쿠키에는 tokenId만 저장
-        ResponseCookie jwtRefreshTokenCookie = ResponseCookie.from("refreshTokenId", tokenId)
+        // 4. 쿠키 내려주기 (JWT RefreshTokenId, Kakao RefreshTokenId)
+        ResponseCookie jwtRefreshTokenCookie = ResponseCookie.from("refreshTokenId", jwtTokenId)
                 .httpOnly(true)
                 .secure(true)
                 .sameSite("None")


### PR DESCRIPTION
## 📄 작업 내용 요약
<!-- 무엇을 작업했는지 간단하게 요약해주세요 -->
카카오 토큰을 레디스에 저장하는 방식으로 수정했습니다.
- 예: 회원가입 API 구현
- 예: 예외 처리 공통화

---

## 📎 Issue 번호
<!-- 관련된 이슈가 있다면 닫히도록 연결해주세요 (ex: closed #1) -->

- closed #169 

---

## ✅ 작업 목록
<!-- 체크박스로 완료한 작업을 표시해주세요 -->

- [ ] 기능 구현
- [ ] 코드 리뷰 반영
- [ ] 테스트 코드 작성
- [ ] 문서 업데이트

---

## 📝 기타 참고사항
<!-- 리뷰어가 참고하면 좋을 추가 정보나 질문이 있다면 자유롭게 작성해주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 카카오 로그인 응답에 JWT 리프레시 토큰 ID와 카카오 토큰 ID를 함께 제공하며, 두 토큰을 별도 쿠키로 발급·관리합니다.
  - 카카오 리프레시 토큰의 만료 정보를 응답에 포함합니다.

- 변경
  - 카카오 리프레시 토큰의 기본 만료 기간을 3일로 단축했습니다.
  - 로그인 흐름에서 토큰 식별자 관리와 쿠키 처리 방식을 분리·명확화했습니다.

- 리팩터
  - 사용자 데이터베이스 테이블 명칭을 정돈했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->