### PR TITLE
[FIX] 카카오 로그인 버그 수정

### DIFF
--- a/src/main/java/umc/nook/users/domain/KakaoRefreshToken.java
+++ b/src/main/java/umc/nook/users/domain/KakaoRefreshToken.java
@@ -20,11 +20,9 @@ public class KakaoRefreshToken {
 
     private String accessToken; // Kakao access token
 
-    private Long refreshTokenExpiresIn; // 만료 시간(초 단위)
 
-    public void updateToken(String refreshToken, String accessToken, Long refreshTokenExpiresIn) {
+    public void updateToken(String refreshToken, String accessToken) {
         this.refreshToken = refreshToken;
         this.accessToken = accessToken;
-        this.refreshTokenExpiresIn = refreshTokenExpiresIn;
     }
 }

--- a/src/main/java/umc/nook/users/dto/UserDTO.java
+++ b/src/main/java/umc/nook/users/dto/UserDTO.java
@@ -103,8 +103,6 @@ public class UserDTO {
         private Long userId;
         private String email;
         private String nickname;
-
-        private Long refreshTokenExpiresIn;
         private KakaoTokenResponseDTO token;
 
         private String kakaoRefreshToken;

--- a/src/main/java/umc/nook/users/oauth/OAuthService.java
+++ b/src/main/java/umc/nook/users/oauth/OAuthService.java
@@ -189,8 +189,7 @@ public class OAuthService {
                 .map(existing -> {
                     existing.updateToken(
                             newToken.getRefreshToken(),
-                            newToken.getAccessToken(),
-                            (long) newToken.getRefreshTokenExpiresIn()
+                            newToken.getAccessToken()
                     );
                     return existing;
                 })
@@ -199,7 +198,6 @@ public class OAuthService {
                         .userId(user.getUserId())
                         .refreshToken(newToken.getRefreshToken())
                         .accessToken(newToken.getAccessToken())
-                        .refreshTokenExpiresIn((long) newToken.getRefreshTokenExpiresIn())
                         .build());
         kakaoRefreshTokenRedisRepository.save(token);
 


### PR DESCRIPTION
## 📄 작업 내용 요약
<!-- 무엇을 작업했는지 간단하게 요약해주세요 -->
카카오 로그인 시 만료일자를 필수로 받는 로직을 수정합니다. 
- 예: 회원가입 API 구현
- 예: 예외 처리 공통화

---

## 📎 Issue 번호
<!-- 관련된 이슈가 있다면 닫히도록 연결해주세요 (ex: closed #1) -->

- closed #169 

---

## ✅ 작업 목록
<!-- 체크박스로 완료한 작업을 표시해주세요 -->

- [ ] 기능 구현
- [ ] 코드 리뷰 반영
- [ ] 테스트 코드 작성
- [ ] 문서 업데이트

---

## 📝 기타 참고사항
<!-- 리뷰어가 참고하면 좋을 추가 정보나 질문이 있다면 자유롭게 작성해주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - 카카오 로그인 토큰 저장/갱신 로직을 단순화해 유지보수성을 높였습니다.
  - 리프레시 토큰 만료값 저장을 제거하고, 갱신 시 필요한 값만 업데이트하도록 정리했습니다.
  - 응답 데이터에서 불필요한 만료 관련 필드를 제거해 전송 데이터를 경량화했습니다.
  - 이로써 로그인/재인증 과정의 일관성을 개선하고 잠재적 오류 가능성을 줄였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->