### PR TITLE
[CHORE] 카카오 토큰 만료일자 수정

### DIFF
--- a/src/main/java/umc/nook/users/redis/KakaoRefreshTokenRedisRepository.java
+++ b/src/main/java/umc/nook/users/redis/KakaoRefreshTokenRedisRepository.java
@@ -17,7 +17,7 @@ public class KakaoRefreshTokenRedisRepository {
     private static final String PREFIX = "kakaoRefreshToken:"; // 본문 저장 키
     private static final String USER_ID_INDEX = "kakaoRefreshToken:userId:";
     private static final String REFRESH_TOKEN_INDEX = "kakaoRefreshToken:refreshToken:";
-    private static final long TTL_SECONDS = 60 * 60 * 24 * 30; // 30일
+    private static final long TTL_SECONDS = 60 * 60 * 24 * 60; // 60일
 
     public void save(KakaoRefreshToken kakaoRefreshToken) {
         String mainKey = PREFIX + kakaoRefreshToken.getTokenId();

--- a/src/main/java/umc/nook/users/service/UserService.java
+++ b/src/main/java/umc/nook/users/service/UserService.java
@@ -209,7 +209,6 @@ public class UserService {
                         .userId(userId)
                         .refreshToken(kakaoResponse.getKakaoRefreshToken())
                         .accessToken(kakaoResponse.getToken().getAccessToken())
-                        .refreshTokenExpiresIn((long) kakaoResponse.getRefreshTokenExpiresIn())
                         .build()
         );
 
@@ -249,51 +248,24 @@ public class UserService {
 
         KakaoResponseParams newToken = oAuthService.reissueKakaoToken(savedToken.getRefreshToken());
 
-        // RefreshToken 업데이트 (변경 있을 경우만)
         String updatedRefreshToken = newToken.getRefreshToken() != null
                 ? newToken.getRefreshToken()
                 : savedToken.getRefreshToken();
 
-        savedToken.updateToken(
-                updatedRefreshToken,
-                newToken.getAccessToken(),
-                (long) newToken.getRefreshTokenExpiresIn()
-        );
+        savedToken.updateToken(updatedRefreshToken, newToken.getAccessToken());
 
-        Long userId = savedToken.getUserId();
-        User user = userRepository.findById(userId)
+        kakaoRefreshTokenRedisRepository.save(savedToken);
+
+        User user = userRepository.findById(savedToken.getUserId())
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         String newAccessToken = jwtProvider.createAccessToken(user);
-
-        // TTL이 얼마 안 남았으면 kakaoTokenId 롤링
-        if (savedToken.getRefreshTokenExpiresIn() <= (24 * 60 * 60)) { // 하루 이하
-            String newKakaoTokenId = UUID.randomUUID().toString();
-            kakaoRefreshTokenRedisRepository.deleteByTokenId(kakaoTokenId);
-            kakaoRefreshTokenRedisRepository.save(
-                    KakaoRefreshToken.builder()
-                            .tokenId(newKakaoTokenId)
-                            .userId(userId)
-                            .refreshToken(updatedRefreshToken)
-                            .accessToken(newToken.getAccessToken())
-                            .refreshTokenExpiresIn((long) newToken.getRefreshTokenExpiresIn())
-                            .build()
-            );
-
-            ResponseCookie kakaoRefreshTokenCookie = ResponseCookie.from("kakaoRefreshTokenId", newKakaoTokenId)
-                    .httpOnly(true)
-                    .secure(true)
-                    .sameSite("None")
-                    .path("/")
-                    .maxAge(Duration.ofDays(60))
-                    .build();
-            response.addHeader("Set-Cookie", kakaoRefreshTokenCookie.toString());
-        }
 
         return UserDTO.TokenResponseDto.builder()
                 .accessToken(newAccessToken)
                 .build();
     }
+
 
 
     // 카카오 로그아웃


### PR DESCRIPTION
## 📄 작업 내용 요약
<!-- 무엇을 작업했는지 간단하게 요약해주세요 -->
카카오 리프레시 토큰의 만료일자를 2달로 수정합니다. 
- 예: 회원가입 API 구현
- 예: 예외 처리 공통화

---

## 📎 Issue 번호
<!-- 관련된 이슈가 있다면 닫히도록 연결해주세요 (ex: closed #1) -->

- closed #169 

---

## ✅ 작업 목록
<!-- 체크박스로 완료한 작업을 표시해주세요 -->

- [ ] 기능 구현
- [ ] 코드 리뷰 반영
- [ ] 테스트 코드 작성
- [ ] 문서 업데이트

---

## 📝 기타 참고사항
<!-- 리뷰어가 참고하면 좋을 추가 정보나 질문이 있다면 자유롭게 작성해주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 카카오 로그인 사용자의 세션/자동 로그인 유지 기간을 30일에서 60일로 연장하여 재로그인 빈도를 줄였습니다. 앱 전반의 로그인 지속성이 향상되었습니다.
- Refactor
  - 카카오 토큰 재발급 흐름을 단순화해 처리 안정성과 일관성을 개선했습니다.
- Chores
  - 카카오 로그인 응답에서 리프레시 토큰 만료 정보 노출을 중단해 응답 포맷을 단순화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->