### PR TITLE
[REFACTOR] 카카오 토큰 레디스에 저장 방식 수정

### DIFF
--- a/src/main/java/umc/nook/users/redis/KakaoRefreshTokenRedisRepository.java
+++ b/src/main/java/umc/nook/users/redis/KakaoRefreshTokenRedisRepository.java
@@ -1,55 +1,95 @@
 package umc.nook.users.redis;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
 import umc.nook.users.domain.KakaoRefreshToken;
 
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 @Repository
+@Slf4j
 @RequiredArgsConstructor
 public class KakaoRefreshTokenRedisRepository {
 
     private final RedisTemplate<String, Object> redisTemplate;
+    private final ObjectMapper objectMapper;
 
-    private static final String PREFIX = "kakaoRefreshToken:"; // 본문 저장 키
-    private static final String USER_ID_INDEX = "kakaoRefreshToken:userId:";
-    private static final String REFRESH_TOKEN_INDEX = "kakaoRefreshToken:refreshToken:";
-    private static final long TTL_SECONDS = 60 * 60 * 24 * 60; // 60일
+    private static final String PREFIX = "kakaoRefreshToken:";                 // 본문 저장 키
+    private static final String USER_ID_INDEX = "kakaoRefreshToken:userId:";   // userId -> tokenId
+    private static final String REFRESH_TOKEN_INDEX = "kakaoRefreshToken:refreshToken:"; // refreshToken -> tokenId
 
-    public void save(KakaoRefreshToken kakaoRefreshToken) {
-        String mainKey = PREFIX + kakaoRefreshToken.getTokenId();
+    private static final long MAX_TTL_SECONDS = 60L * 60 * 24 * 60; // 60일
+
+    /** 저장: 필수값 검증 + 고정 TTL 적용 */
+    public void save(KakaoRefreshToken token) {
+        log.info("[KAKAO-LOGIN] tokenId={}, userId={}, refreshToken={}",
+                token.getTokenId(),
+                token.getUserId(),
+                token.getRefreshToken()
+        );
+
+        validateForSave(token);
+
+        String mainKey = PREFIX + token.getTokenId();
 
         // 본문 저장
-        redisTemplate.opsForValue().set(mainKey, kakaoRefreshToken, TTL_SECONDS, TimeUnit.SECONDS);
+        redisTemplate.opsForValue().set(mainKey, token, MAX_TTL_SECONDS, TimeUnit.SECONDS);
 
-        // 인덱스 저장
-        redisTemplate.opsForValue().set(USER_ID_INDEX + kakaoRefreshToken.getUserId(),
-                kakaoRefreshToken.getTokenId(), TTL_SECONDS, TimeUnit.SECONDS);
-        redisTemplate.opsForValue().set(REFRESH_TOKEN_INDEX + kakaoRefreshToken.getRefreshToken(),
-                kakaoRefreshToken.getTokenId(), TTL_SECONDS, TimeUnit.SECONDS);
+        // 인덱스 저장 (동일 TTL 유지)
+        redisTemplate.opsForValue().set(USER_ID_INDEX + token.getUserId(), token.getTokenId(), MAX_TTL_SECONDS, TimeUnit.SECONDS);
+        redisTemplate.opsForValue().set(REFRESH_TOKEN_INDEX + token.getRefreshToken(), token.getTokenId(), MAX_TTL_SECONDS, TimeUnit.SECONDS);
     }
 
+    /** tokenId로 조회 */
     public Optional<KakaoRefreshToken> findByTokenId(String tokenId) {
-        String mainKey = PREFIX + tokenId;
-        return Optional.ofNullable((KakaoRefreshToken) redisTemplate.opsForValue().get(mainKey));
+        if (!StringUtils.hasText(tokenId)) return Optional.empty();
+
+        Object value = redisTemplate.opsForValue().get(PREFIX + tokenId);
+        if (value == null) return Optional.empty();
+
+        KakaoRefreshToken token = convert(value);
+        if (isExpired(token)) { // 여기서는 사실상 항상 false (만료 판단 로직 없음)
+            deleteByTokenId(tokenId);
+            throw new KakaoRefreshTokenExpiredException();
+        }
+        return Optional.of(token);
     }
 
-    public Optional<KakaoRefreshToken> findByUserId(Long userId) {
-        String tokenId = (String) redisTemplate.opsForValue().get(USER_ID_INDEX + userId);
-        if (tokenId == null) return Optional.empty();
-        return findByTokenId(tokenId);
-    }
-
+    /** refreshToken으로 조회 */
     public Optional<KakaoRefreshToken> findByRefreshToken(String refreshToken) {
+        if (!StringUtils.hasText(refreshToken)) return Optional.empty();
+
         String tokenId = (String) redisTemplate.opsForValue().get(REFRESH_TOKEN_INDEX + refreshToken);
         if (tokenId == null) return Optional.empty();
+
         return findByTokenId(tokenId);
     }
 
+    /** userId로 조회 */
+    public Optional<KakaoRefreshToken> findByUserId(Long userId) {
+        if (userId == null) return Optional.empty();
+
+        String tokenId = (String) redisTemplate.opsForValue().get(USER_ID_INDEX + userId);
+        if (tokenId == null) return Optional.empty();
+
+        return findByTokenId(tokenId);
+    }
+
+    /** 없으면/만료면 예외 */
+    public KakaoRefreshToken getRequiredByRefreshToken(String refreshToken) {
+        return findByRefreshToken(refreshToken)
+                .orElseThrow(KakaoRefreshTokenNotFoundException::new);
+    }
+
+    /** 삭제 */
     public void deleteByTokenId(String tokenId) {
+        if (!StringUtils.hasText(tokenId)) return;
+
         findByTokenId(tokenId).ifPresent(token -> {
             redisTemplate.delete(USER_ID_INDEX + token.getUserId());
             redisTemplate.delete(REFRESH_TOKEN_INDEX + token.getRefreshToken());
@@ -57,11 +97,46 @@ public class KakaoRefreshTokenRedisRepository {
         redisTemplate.delete(PREFIX + tokenId);
     }
 
+    public void deleteByRefreshToken(String refreshToken) {
+        findByRefreshToken(refreshToken).ifPresent(token -> deleteByTokenId(token.getTokenId()));
+    }
+
     public void deleteByUserId(Long userId) {
         findByUserId(userId).ifPresent(token -> deleteByTokenId(token.getTokenId()));
     }
 
-    public void deleteByRefreshToken(String refreshToken) {
-        findByRefreshToken(refreshToken).ifPresent(token -> deleteByTokenId(token.getTokenId()));
+    /** ===== 내부 유틸 ===== */
+    private void validateForSave(KakaoRefreshToken token) {
+        if (token == null
+                || !StringUtils.hasText(token.getTokenId())
+                || !StringUtils.hasText(token.getRefreshToken())
+                || token.getUserId() == null) {
+            throw new KakaoRefreshTokenInvalidException("카카오 리프레시 토큰 정보가 올바르지 않습니다.");
+        }
+    }
+
+    private KakaoRefreshToken convert(Object value) {
+        if (value instanceof KakaoRefreshToken) return (KakaoRefreshToken) value;
+        try {
+            return objectMapper.convertValue(value, KakaoRefreshToken.class);
+        } catch (IllegalArgumentException e) {
+            throw new KakaoRefreshTokenInvalidException("카카오 토큰 역직렬화 실패");
+        }
+    }
+
+    /** 만료 판단: expiration 필드가 없으므로 무조건 false */
+    private boolean isExpired(KakaoRefreshToken token) {
+        return token == null;
+    }
+
+    /** ===== 커스텀 예외 ===== */
+    public static class KakaoRefreshTokenNotFoundException extends RuntimeException {
+        public KakaoRefreshTokenNotFoundException() { super("카카오 리프레시 토큰을 찾을 수 없습니다."); }
+    }
+    public static class KakaoRefreshTokenExpiredException extends RuntimeException {
+        public KakaoRefreshTokenExpiredException() { super("카카오 리프레시 토큰이 만료되었습니다."); }
+    }
+    public static class KakaoRefreshTokenInvalidException extends RuntimeException {
+        public KakaoRefreshTokenInvalidException(String msg) { super(msg); }
     }
 }


### PR DESCRIPTION
## 📄 작업 내용 요약
<!-- 무엇을 작업했는지 간단하게 요약해주세요 -->
카카오 로그인 로직에서 expiration 제거 후 고정 TTL(60일) 적용으로 단순화했습니다. 
- 예: 회원가입 API 구현
- 예: 예외 처리 공통화

---

## 📎 Issue 번호
<!-- 관련된 이슈가 있다면 닫히도록 연결해주세요 (ex: closed #1) -->

- closed #169 

---

## ✅ 작업 목록
<!-- 체크박스로 완료한 작업을 표시해주세요 -->

- [ ] 기능 구현
- [ ] 코드 리뷰 반영
- [ ] 테스트 코드 작성
- [ ] 문서 업데이트

---

## 📝 기타 참고사항
<!-- 리뷰어가 참고하면 좋을 추가 정보나 질문이 있다면 자유롭게 작성해주세요 -->