### PR TITLE
[FIX] 홈 화면 API 반환 컬럼 수정

### DIFF
--- a/src/main/java/umc/nook/bookshelves/controller/BookShelfController.java
+++ b/src/main/java/umc/nook/bookshelves/controller/BookShelfController.java
@@ -126,7 +126,7 @@ public class BookShelfController {
     // 홈 화면 독서중인 책 조회
     @GetMapping("/reading")
     @Operation(summary = "홈 화면 독서중인 책 조회", description = "사용자가 현재 읽고 있는 책을 조회합니다.")
-    public ApiResponse<BookShelfDTO.BookThumbnail> viewReadingBook(
+    public ApiResponse<BookShelfDTO.RecentBookDTO> viewReadingBook(
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         return ApiResponse.onSuccess(

--- a/src/main/java/umc/nook/bookshelves/dto/BookShelfDTO.java
+++ b/src/main/java/umc/nook/bookshelves/dto/BookShelfDTO.java
@@ -86,12 +86,12 @@ public class BookShelfDTO {
 
     @Getter
     @AllArgsConstructor
-    public static class RecentRecordDTO {
+    public static class RecentBookDTO {
         private Long bookId;
         private String title;
         private String author;
 
-        public RecentRecordDTO(Book book) {
+        public RecentBookDTO(Book book) {
             this.bookId = book.getBookId();
             this.title = book.getTitle();
             this.author = book.getAuthor();

--- a/src/main/java/umc/nook/bookshelves/service/BookShelfService.java
+++ b/src/main/java/umc/nook/bookshelves/service/BookShelfService.java
@@ -155,12 +155,12 @@ public class BookShelfService {
 
     // 지금 독서중인 책
     @Transactional(readOnly = true)
-    public BookShelfDTO.BookThumbnail viewReadingBooks(User user) {
+    public BookShelfDTO.RecentBookDTO viewReadingBooks(User user) {
         List<UserBookShelf> userBookShelfList = userBookshelfRepository.findByUserAndReadingStatusOrderByCreatedDateDesc(user,ReadingStatus.READING);
         if (userBookShelfList.isEmpty()) {
             throw new CustomException(ErrorCode.BOOKSHELF_IS_EMPTY);
         }
-        return new BookShelfDTO.BookThumbnail(userBookShelfList.get(0).getBook());
+        return new BookShelfDTO.RecentBookDTO(userBookShelfList.get(0).getBook());
     }
 
     // 이번주 서재에 등록한 책

--- a/src/main/java/umc/nook/records/controller/RecordController.java
+++ b/src/main/java/umc/nook/records/controller/RecordController.java
@@ -192,10 +192,10 @@ public class RecordController {
 
     @GetMapping("/recent")
     @Operation(summary = "홈 화면 가장 최근에 기록한 책 정보 조회", description = "홈 화면에서 가장 최근에 독서 기록을 남긴 책 정보를 조회합니다.")
-    public ApiResponse<BookShelfDTO.RecentRecordDTO> viewRecentlyRecordedBook(
+    public ApiResponse<BookShelfDTO.RecentBookDTO> viewRecentlyRecordedBook(
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-        BookShelfDTO.RecentRecordDTO response = recordService.viewRecentlyRecordedBook(userDetails.getUser());
+        BookShelfDTO.RecentBookDTO response = recordService.viewRecentlyRecordedBook(userDetails.getUser());
         if (response == null)
             return ApiResponse.onSuccess(response,SuccessCode.NO_CONTENT);
         return ApiResponse.onSuccess(

--- a/src/main/java/umc/nook/records/repository/RecordCustomRepository.java
+++ b/src/main/java/umc/nook/records/repository/RecordCustomRepository.java
@@ -10,6 +10,6 @@ import java.util.Optional;
 public interface RecordCustomRepository {
     RecordDTO.MonthlyRecordRateResponseDTO viewRecordRate(User user, Year year);
 
-    Optional<BookShelfDTO.RecentRecordDTO> viewRecentRecordedBook(User user);
+    Optional<BookShelfDTO.RecentBookDTO> viewRecentRecordedBook(User user);
 
 }

--- a/src/main/java/umc/nook/records/repository/RecordCustomRepositoryImpl.java
+++ b/src/main/java/umc/nook/records/repository/RecordCustomRepositoryImpl.java
@@ -81,7 +81,7 @@ public class RecordCustomRepositoryImpl implements RecordCustomRepository{
 
     @Override
     @Transactional(readOnly = true)
-    public Optional<BookShelfDTO.RecentRecordDTO> viewRecentRecordedBook(User user) {
+    public Optional<BookShelfDTO.RecentBookDTO> viewRecentRecordedBook(User user) {
         QBookRecord record = QBookRecord.bookRecord;
         QBook book = QBook.book;
 
@@ -97,7 +97,7 @@ public class RecordCustomRepositoryImpl implements RecordCustomRepository{
                         .where(record.bookshelf.user.eq(user))
                         .orderBy(record.createdDate.desc())
                         .fetchFirst()
-        ).map(tuple -> new BookShelfDTO.RecentRecordDTO(
+        ).map(tuple -> new BookShelfDTO.RecentBookDTO(
                 tuple.get(book.bookId),
                 tuple.get(book.title),
                 tuple.get(book.author)

--- a/src/main/java/umc/nook/records/service/RecordService.java
+++ b/src/main/java/umc/nook/records/service/RecordService.java
@@ -229,9 +229,9 @@ public class RecordService {
 
     // 가장 최근 기록한 책 정보 조회
     @Transactional(readOnly = true)
-    public BookShelfDTO.RecentRecordDTO viewRecentlyRecordedBook(User user) {
+    public BookShelfDTO.RecentBookDTO viewRecentlyRecordedBook(User user) {
         return bookRecordRepository.viewRecentRecordedBook(user)
-                .map(b -> new BookShelfDTO.RecentRecordDTO(
+                .map(b -> new BookShelfDTO.RecentBookDTO(
                         b.getBookId(),
                         b.getTitle(),
                         b.getAuthor()))


### PR DESCRIPTION
## 📄 작업 내용 요약
<!-- 무엇을 작업했는지 간단하게 요약해주세요 -->
홈 화면 API 반환 컬럼에 저자명을 추가합니다. 
- 예: 회원가입 API 구현
- 예: 예외 처리 공통화

---

## 📎 Issue 번호
<!-- 관련된 이슈가 있다면 닫히도록 연결해주세요 (ex: closed #1) -->

- closed #

---

## ✅ 작업 목록
<!-- 체크박스로 완료한 작업을 표시해주세요 -->

- [ ] 기능 구현
- [ ] 코드 리뷰 반영
- [ ] 테스트 코드 작성
- [ ] 문서 업데이트

---

## 📝 기타 참고사항
<!-- 리뷰어가 참고하면 좋을 추가 정보나 질문이 있다면 자유롭게 작성해주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 개선
  - “최근 기록” 관련 응답 명칭을 “최근 도서”로 통일해 표현을 일관화했습니다. 기능과 응답 필드는 동일하며(식별자, 제목, 저자), 클라이언트 연동에 영향이 거의 없습니다.
  - 독서 중 도서 조회와 최근 도서 조회의 응답 구조를 정돈해 가독성을 높였습니다.

- 버그 수정
  - 최근 도서가 없을 때 더 이상 빈 결과/모호한 상태가 아닌 명확한 오류 응답을 반환해 사용자 피드백을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->