### PR TITLE
[FEAT] 독서 상태를 완독으로 변경하는 API 구현

### DIFF
--- a/src/main/java/umc/nook/bookshelves/controller/BookShelfController.java
+++ b/src/main/java/umc/nook/bookshelves/controller/BookShelfController.java
@@ -48,12 +48,19 @@ public class BookShelfController {
 
     @PatchMapping("/start-reading/{bookId}")
     @Operation(summary = "독서 시작", description = "독서 상태를 시작으로 변경합니다.")
-    public ApiResponse<String> changeBookState(@PathVariable Long bookId,
+    public ApiResponse<String> changeBookStateToStart(@PathVariable Long bookId,
                                                @AuthenticationPrincipal CustomUserDetails userDetails) {
         String result = bookshelfService.changeBookState(bookId, userDetails.getUser());
         return ApiResponse.onSuccess(result, SuccessCode.OK);
     }
 
+    @PatchMapping("/finish-reading/{bookId}")
+    @Operation(summary = "독서 종료", description = "독서중인 책 상태를 완독으로 변경합니다.")
+    public ApiResponse<String> changeBookStateToEnd(@PathVariable Long bookId,
+                                               @AuthenticationPrincipal CustomUserDetails userDetails) {
+        String result = bookshelfService.changeBookStateToEnd(bookId, userDetails.getUser());
+        return ApiResponse.onSuccess(result, SuccessCode.OK);
+    }
     @GetMapping("/my-books/monthly")
     @Operation(
             summary = "월별 서재 조회",
@@ -145,6 +152,5 @@ public class BookShelfController {
                 SuccessCode.OK
         );
     }
-
 
 }

--- a/src/main/java/umc/nook/bookshelves/service/BookShelfService.java
+++ b/src/main/java/umc/nook/bookshelves/service/BookShelfService.java
@@ -3,6 +3,7 @@ package umc.nook.bookshelves.service;
 
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.parameters.P;
 import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -111,6 +112,25 @@ public class BookShelfService {
         return "해당 책이 '독서중' 상태로 변경되었습니다.";
     }
 
+    // 완독으로 상태 변경
+    @Transactional
+    public String changeBookStateToEnd(Long bookId, User user) {
+        Book book = getBookOrThrow(bookId);
+        UserBookShelf userBook = getUserBookShelfOrThrow(user,book);
+        ReadingStatus currentStatus = userBook.getReadingStatus();
+        // 완독 상태가 아니면
+        if (currentStatus == ReadingStatus.BOOKMARK) {
+            throw new CustomException(ErrorCode.INVALID_STATE);
+        } else if (currentStatus == ReadingStatus.FINISHED) {
+            throw new CustomException(ErrorCode.ALREADY_FINISHED);
+        }
+        else {
+            userBook.updateReadingStatus(ReadingStatus.FINISHED);
+            userBookshelfRepository.save(userBook);
+        }
+        return "해당 책이 '완독' 상태로 변경되었습니다.";
+    }
+
 
     // 서재 통계 조회
     @Transactional(readOnly = true)
@@ -186,5 +206,6 @@ public class BookShelfService {
                 ))
                 .collect(Collectors.toList());
     }
+
 
 }

--- a/src/main/java/umc/nook/common/response/ErrorCode.java
+++ b/src/main/java/umc/nook/common/response/ErrorCode.java
@@ -36,8 +36,9 @@ public enum ErrorCode implements BaseCode {
     BOOK_NOT_EXIST(HttpStatus.NOT_FOUND,"BOOKSHELF-004" ,"서재에 등록되지 않은 책입니다." ),
     INVALID_MONTH(HttpStatus.BAD_REQUEST,"BOOKSHELF-005", "형식이 잘못되었습니다. yyyy-MM 형식으로 입력해주세요." ),
     BOOKSHELF_IS_EMPTY(HttpStatus.NOT_FOUND, "BOOKSHELF-006", "현재 읽고 있는 책이 없습니다."),
-    ALREADY_REGISTERED_TODAY(HttpStatus.BAD_REQUEST, "BOOK-003", "해당 날짜에는 이미 책이 등록되었습니다."),
+    ALREADY_REGISTERED_TODAY(HttpStatus.BAD_REQUEST, "BOOK-007", "해당 날짜에는 이미 책이 등록되었습니다."),
 
+    INVALID_STATE(HttpStatus.BAD_REQUEST,"BOOKSHELF-008" , "독서 상태를 변경할 수 없습니다."),
 
     //리딩룸 관련
     READING_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "ROOM-001", "리딩룸을 찾을 수 없습니다."),


### PR DESCRIPTION
## 📄 작업 내용 요약
<!-- 무엇을 작업했는지 간단하게 요약해주세요 -->
독서 상태를 완독으로 변경하는 API를 구현했습니다.
- 예: 회원가입 API 구현
- 예: 예외 처리 공통화

---

## 📎 Issue 번호
<!-- 관련된 이슈가 있다면 닫히도록 연결해주세요 (ex: closed #1) -->

- closed #

---

## ✅ 작업 목록
<!-- 체크박스로 완료한 작업을 표시해주세요 -->

- [ ] 기능 구현
- [ ] 코드 리뷰 반영
- [ ] 테스트 코드 작성
- [ ] 문서 업데이트

---

## 📝 기타 참고사항
<!-- 리뷰어가 참고하면 좋을 추가 정보나 질문이 있다면 자유롭게 작성해주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 책의 읽기 상태를 “완료”로 변경할 수 있습니다. 읽기 진행 관리가 더욱 명확해졌습니다.
- 버그 수정
  - 하루에 중복 등록 시 노출되는 오류 코드가 정리되어 일관된 코드(BOOK-007)로 안내됩니다.
  - 잘못된 상태에서 읽기 상태 변경을 시도할 경우, 새로운 오류 코드(BOOKSHELF-008)로 명확한 피드백을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->