### PR TITLE
[FEAT] 도서 추가 API 구현

### DIFF
--- a/src/docs/asciidoc/book.adoc
+++ b/src/docs/asciidoc/book.adoc
@@ -10,6 +10,7 @@ include::{snippets}/book-controller-test/도서_상세조회_성공/response-fie
 === 도서 상세 조회 (bookId)
 
 include::{snippets}/book-controller-test/도서_상세조회_book-id_성공/http-request.adoc[]
+include::{snippets}/book-controller-test/도서_상세조회_book-id_성공/path-parameters.adoc[]
 include::{snippets}/book-controller-test/도서_상세조회_book-id_성공/http-response.adoc[]
 include::{snippets}/book-controller-test/도서_상세조회_book-id_성공/response-fields.adoc[]
 

--- a/src/docs/asciidoc/book.adoc
+++ b/src/docs/asciidoc/book.adoc
@@ -1,11 +1,17 @@
 == 도서 조회
 
-=== 도서 상세 조회
+=== 도서 상세 조회 (ISBN)
 
 include::{snippets}/book-controller-test/도서_상세조회_성공/http-request.adoc[]
 include::{snippets}/book-controller-test/도서_상세조회_성공/path-parameters.adoc[]
 include::{snippets}/book-controller-test/도서_상세조회_성공/http-response.adoc[]
 include::{snippets}/book-controller-test/도서_상세조회_성공/response-fields.adoc[]
+
+=== 도서 상세 조회 (bookId)
+
+include::{snippets}/book-controller-test/도서_상세조회_book-id_성공/http-request.adoc[]
+include::{snippets}/book-controller-test/도서_상세조회_book-id_성공/http-response.adoc[]
+include::{snippets}/book-controller-test/도서_상세조회_book-id_성공/response-fields.adoc[]
 
 === 주간 베스트셀러 조회
 
@@ -18,3 +24,15 @@ include::{snippets}/book-controller-test/주간베스트셀러_조회_성공/res
 include::{snippets}/book-controller-test/추천베스트셀러_조회_성공/http-request.adoc[]
 include::{snippets}/book-controller-test/추천베스트셀러_조회_성공/http-response.adoc[]
 include::{snippets}/book-controller-test/추천베스트셀러_조회_성공/response-fields.adoc[]
+
+=== 사용자 도서 등록
+
+include::{snippets}/book-controller-test/사용자_도서_등록_성공/http-request.adoc[]
+include::{snippets}/book-controller-test/사용자_도서_등록_성공/http-response.adoc[]
+include::{snippets}/book-controller-test/사용자_도서_등록_성공/response-fields.adoc[]
+
+=== 사용자 도서 수정
+
+include::{snippets}/book-controller-test/사용자_도서_수정_성공/http-request.adoc[]
+include::{snippets}/book-controller-test/사용자_도서_수정_성공/http-response.adoc[]
+include::{snippets}/book-controller-test/사용자_도서_수정_성공/response-fields.adoc[]

--- a/src/main/generated/app/nook/book/domain/QBook.java
+++ b/src/main/generated/app/nook/book/domain/QBook.java
@@ -32,6 +32,8 @@ public class QBook extends EntityPathBase<Book> {
 
     public final StringPath coverImageUrl = createString("coverImageUrl");
 
+    public final NumberPath<Long> createdByUserId = createNumber("createdByUserId", Long.class);
+
     //inherited
     public final DateTimePath<java.time.LocalDateTime> createdDate = _super.createdDate;
 

--- a/src/main/java/app/nook/book/controller/BookController.java
+++ b/src/main/java/app/nook/book/controller/BookController.java
@@ -9,6 +9,7 @@ import app.nook.global.response.SuccessCode;
 import app.nook.user.service.CustomUserDetails;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
@@ -52,7 +53,7 @@ public class BookController {
     @GetMapping("/id/{bookId}")
     public ApiResponse<BookResponseDto.BookDetailDto> getBookDetailsById(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @PathVariable Long bookId
+            @PathVariable @Positive(message = "bookId는 1 이상이어야 합니다.") Long bookId
     ) {
         return ApiResponse.onSuccess(
                 bookService.getBookDetailById(userDetails.getUser(), bookId), SuccessCode.OK);
@@ -69,10 +70,11 @@ public class BookController {
     }
 
     // 사용자 도서 수정 (본인 생성 USER 도서만 허용)
-    @PutMapping(value = "/user/{bookId}", consumes = "multipart/form-data")
+    // coverImage 미전송/null이면 기존 표지 유지, 삭제는 별도 API로 처리
+    @PatchMapping(value = "/user/{bookId}", consumes = "multipart/form-data")
     public ApiResponse<BookResponseDto.BookDetailDto> updateUserBook(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @PathVariable Long bookId,
+            @PathVariable @Positive(message = "bookId는 1 이상이어야 합니다.") Long bookId,
             @Valid @ModelAttribute BookRequestDto.UpdateUserBookRequest request
     ) {
         return ApiResponse.onSuccess(

--- a/src/main/java/app/nook/book/controller/BookController.java
+++ b/src/main/java/app/nook/book/controller/BookController.java
@@ -1,19 +1,18 @@
 package app.nook.book.controller;
 
-import app.nook.aladin.dto.AladinResponseDto;
+import app.nook.book.dto.BookRequestDto;
 import app.nook.book.dto.BookResponseDto;
+import app.nook.book.facade.UserBookFacade;
 import app.nook.book.service.BookService;
 import app.nook.global.response.ApiResponse;
 import app.nook.global.response.SuccessCode;
 import app.nook.user.service.CustomUserDetails;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Pattern;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -23,14 +22,15 @@ import java.util.List;
 @Validated
 public class BookController {
     private final BookService bookService;
+    private final UserBookFacade userBookFacade;
 
-    // 도서 상세 조회
+    // ISBN 기반 상세조회: ALADIN 도서 조회 진입점
     @GetMapping("/{isbn13}")
     public ApiResponse<BookResponseDto.BookDetailDto> getBookDetail(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable @Pattern(regexp = "\\d{13}", message = "ISBN13은 13자리 숫자여야 합니다.") String isbn13) {
         return ApiResponse.onSuccess(
-                bookService.getBookDetailByIsbn(userDetails.getUser(),isbn13), SuccessCode.OK);
+                bookService.getBookDetailByIsbn(userDetails.getUser(), isbn13), SuccessCode.OK);
     }
 
     // 주간 베스트셀러 조회
@@ -46,6 +46,38 @@ public class BookController {
     ) {
         return ApiResponse.onSuccess(
                 bookService.getPersonalizedBestsellers(userDetails.getUser().getId()), SuccessCode.OK);
+    }
+
+    // bookId 기반 상세조회: 서재/내부 목록에서 상세 진입 시 사용
+    @GetMapping("/id/{bookId}")
+    public ApiResponse<BookResponseDto.BookDetailDto> getBookDetailsById(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long bookId
+    ) {
+        return ApiResponse.onSuccess(
+                bookService.getBookDetailById(userDetails.getUser(), bookId), SuccessCode.OK);
+    }
+
+    // 사용자 도서 등록 (multipart/form-data)
+    @PostMapping(value = "/user", consumes = "multipart/form-data")
+    public ApiResponse<BookResponseDto.BookDetailDto> createUserBook(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @ModelAttribute BookRequestDto.CreateUserBookRequest request
+    ) {
+        return ApiResponse.onSuccess(
+                userBookFacade.createUserBook(userDetails.getUser(), request), SuccessCode.CREATED);
+    }
+
+    // 사용자 도서 수정 (본인 생성 USER 도서만 허용)
+    @PutMapping(value = "/user/{bookId}", consumes = "multipart/form-data")
+    public ApiResponse<BookResponseDto.BookDetailDto> updateUserBook(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long bookId,
+            @Valid @ModelAttribute BookRequestDto.UpdateUserBookRequest request
+    ) {
+        return ApiResponse.onSuccess(
+                userBookFacade.updateUserBook(userDetails.getUser(), bookId, request), SuccessCode.OK
+        );
     }
 }
 

--- a/src/main/java/app/nook/book/domain/Book.java
+++ b/src/main/java/app/nook/book/domain/Book.java
@@ -107,7 +107,9 @@ public class Book extends BaseEntity {
         this.publicationDate = request.publicationDate();
         this.pages = request.pages();
         this.description = request.description();
-        this.coverImageUrl = coverImageUrl;
         this.category = category;
+        if (coverImageUrl != null && !coverImageUrl.isBlank()) {
+            this.coverImageUrl = coverImageUrl;
+        }
     }
 }

--- a/src/main/java/app/nook/book/domain/Book.java
+++ b/src/main/java/app/nook/book/domain/Book.java
@@ -1,10 +1,11 @@
 package app.nook.book.domain;
 
 import app.nook.book.domain.enums.SourceType;
+import app.nook.book.dto.BookRequestDto;
 import app.nook.book.dto.BookResponseDto;
+import app.nook.book.utils.BookUtils;
 import app.nook.global.common.BaseEntity;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -19,7 +20,7 @@ public class Book extends BaseEntity {
     @Column(name = "book_id")
     private Long id;
 
-    @Column(length = 13, nullable = false, unique = true)
+    @Column(length = 13)
     private String isbn13;
 
     @Column(length = 1000)
@@ -48,6 +49,10 @@ public class Book extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private SourceType sourceType;
 
+    // USER 도서 소유자 추적(ALADIN은 null)
+    @Column(name = "created_by_user_id")
+    private Long createdByUserId;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "category_id")
     private Category category;
@@ -64,6 +69,7 @@ public class Book extends BaseEntity {
             String coverImageUrl,
             String aladinLink,
             SourceType sourceType,
+            Long createdByUserId,
             Category category
     ) {
         this.isbn13 = isbn13;
@@ -76,6 +82,7 @@ public class Book extends BaseEntity {
         this.coverImageUrl = coverImageUrl;
         this.aladinLink = aladinLink;
         this.sourceType = sourceType;
+        this.createdByUserId = createdByUserId;
         this.category = category;
     }
 
@@ -89,5 +96,18 @@ public class Book extends BaseEntity {
         this.description = info.getDescription();
         this.coverImageUrl = info.getCoverImageUrl();
         this.aladinLink = info.getAladinLink();
+    }
+
+    public void updateUserBookInfo(
+            BookRequestDto.UpdateUserBookRequest request, String coverImageUrl, Category category) {
+        this.isbn13 = BookUtils.normalizeIsbn(request.isbn13());
+        this.title = request.title();
+        this.author = request.author();
+        this.publisher = request.publisher();
+        this.publicationDate = request.publicationDate();
+        this.pages = request.pages();
+        this.description = request.description();
+        this.coverImageUrl = coverImageUrl;
+        this.category = category;
     }
 }

--- a/src/main/java/app/nook/book/dto/BookRequestDto.java
+++ b/src/main/java/app/nook/book/dto/BookRequestDto.java
@@ -24,6 +24,7 @@ public class BookRequestDto {
             @Size(max = 500, message = "소개는 500자를 초과할 수 없습니다.")
             String description,
 
+            @Min(value = 1, message = "페이지 수는 1 이상이어야 합니다.")
             Integer pages,
 
             @Size(max = 1500, message = "출판사는 1500자를 초과할 수 없습니다.")
@@ -31,7 +32,7 @@ public class BookRequestDto {
 
             String publicationDate,
 
-            @Pattern(regexp = "^$|\\d{1,13}", message = "ISBN은 숫자만 입력 가능하며 최대 13자리입니다.")
+            @Pattern(regexp = "^(|\\d{1,13})$", message = "ISBN은 숫자만 입력 가능하며 최대 13자리입니다.")
             String isbn13,
 
             MultipartFile coverImage
@@ -53,7 +54,7 @@ public class BookRequestDto {
                 @Size(max = 500, message = "소개는 500자를 초과할 수 없습니다.")
                 String description,
 
-                @Min(1)
+                @Min(value = 1, message = "페이지 수는 1 이상이어야 합니다.")
                 Integer pages,
 
                 @Size(max = 1500, message = "출판사는 1500자를 초과할 수 없습니다.")
@@ -61,7 +62,7 @@ public class BookRequestDto {
 
                 String publicationDate,
 
-                @Pattern(regexp = "^$|\\d{1,13}", message = "ISBN은 숫자만 입력 가능하며 최대 13자리입니다.")
+                @Pattern(regexp = "^(|\\d{1,13})$", message = "ISBN은 숫자만 입력 가능하며 최대 13자리입니다.")
                 String isbn13,
 
                 MultipartFile coverImage

--- a/src/main/java/app/nook/book/dto/BookRequestDto.java
+++ b/src/main/java/app/nook/book/dto/BookRequestDto.java
@@ -1,0 +1,70 @@
+package app.nook.book.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import org.springframework.web.multipart.MultipartFile;
+
+public class BookRequestDto {
+
+    public record CreateUserBookRequest(
+            @NotBlank(message = "제목은 필수입니다.")
+            @Size(max = 1000, message = "제목은 1000자를 초과할 수 없습니다.")
+            String title,
+
+            @NotBlank(message = "저자는 필수입니다.")
+            @Size(max = 1500, message = "저자는 1500자를 초과할 수 없습니다.")
+            String author,
+
+            @NotBlank(message = "카테고리는 필수입니다.")
+            @Size(max = 50, message = "카테고리 이름이 너무 깁니다.")
+            String categoryName,
+
+            @Size(max = 500, message = "소개는 500자를 초과할 수 없습니다.")
+            String description,
+
+            Integer pages,
+
+            @Size(max = 1500, message = "출판사는 1500자를 초과할 수 없습니다.")
+            String publisher,
+
+            String publicationDate,
+
+            @Pattern(regexp = "^$|\\d{1,13}", message = "ISBN은 숫자만 입력 가능하며 최대 13자리입니다.")
+            String isbn13,
+
+            MultipartFile coverImage
+    ) {}
+
+        public record UpdateUserBookRequest(
+                @NotBlank(message = "제목은 필수입니다.")
+                @Size(max = 1000, message = "제목은 1000자를 초과할 수 없습니다.")
+                String title,
+
+                @NotBlank(message = "저자는 필수입니다.")
+                @Size(max = 1500, message = "저자는 1500자를 초과할 수 없습니다.")
+                String author,
+
+                @NotBlank(message = "카테고리는 필수입니다.")
+                @Size(max = 50, message = "카테고리 이름이 너무 깁니다.")
+                String categoryName,
+
+                @Size(max = 500, message = "소개는 500자를 초과할 수 없습니다.")
+                String description,
+
+                @Min(1)
+                Integer pages,
+
+                @Size(max = 1500, message = "출판사는 1500자를 초과할 수 없습니다.")
+                String publisher,
+
+                String publicationDate,
+
+                @Pattern(regexp = "^$|\\d{1,13}", message = "ISBN은 숫자만 입력 가능하며 최대 13자리입니다.")
+                String isbn13,
+
+                MultipartFile coverImage
+        ) {}
+
+}

--- a/src/main/java/app/nook/book/exception/BookErrorCode.java
+++ b/src/main/java/app/nook/book/exception/BookErrorCode.java
@@ -12,7 +12,11 @@ public enum BookErrorCode implements BaseCode {
     ISBN13_NOT_FOUND(HttpStatus.NOT_FOUND, "BOOK-001", "요청한 ISBN-13에 해당하는 도서를 찾을 수 없습니다."),
     INVALID_ISBN13(HttpStatus.BAD_REQUEST, "BOOK-002", "유효하지 않은 ISBN-13 형식입니다."),
     BOOK_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "BOOK-003", "서비스 정책에 의해 조회할 수 없는 도서입니다."),
-    BOOK_NOT_FOUND(HttpStatus.NOT_FOUND, "BOOK-004", "존재하지 않는 책입니다.");
+    BOOK_NOT_FOUND(HttpStatus.NOT_FOUND, "BOOK-004", "존재하지 않는 책입니다."),
+    BOOK_NOT_OWNED(HttpStatus.FORBIDDEN, "BOOK-005", "본인이 생성한 사용자 도서만 수정할 수 있습니다."),
+    INVALID_FILE_TYPE(HttpStatus.BAD_REQUEST, "BOOK-006", "지원하지 않는 이미지 파일 형식입니다."),
+    FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "BOOK-007", "이미지 업로드에 실패했습니다."),
+    CATEGORY_NOT_FOUND(HttpStatus.BAD_REQUEST, "BOOK-008", "유효하지 않은 카테고리입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/app/nook/book/facade/UserBookFacade.java
+++ b/src/main/java/app/nook/book/facade/UserBookFacade.java
@@ -1,0 +1,56 @@
+package app.nook.book.facade;
+
+import app.nook.book.domain.Book;
+import app.nook.book.dto.BookRequestDto;
+import app.nook.book.dto.BookResponseDto;
+import app.nook.book.service.BookService;
+import app.nook.book.service.FileStorageService;
+import app.nook.library.service.LibraryService;
+import app.nook.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+public class UserBookFacade {
+
+    private final BookService bookService;
+    private final LibraryService libraryService;
+    private final FileStorageService fileStorageService;
+
+    // 표지 업로드 + USER 도서 저장 + 서재 자동등록
+    @Transactional
+    public BookResponseDto.BookDetailDto createUserBook(User user, BookRequestDto.CreateUserBookRequest request) {
+        boolean hasCover = request.coverImage() != null && !request.coverImage().isEmpty();
+        log.info("[USER_BOOK_CREATE_START] userId={}, hasCover={}", user.getId(), hasCover);
+
+        String coverImageUrl = fileStorageService.uploadCover(request.coverImage());
+
+        Book book = bookService.createUserBook(user, request, coverImageUrl);
+        log.info("[USER_BOOK_CREATE_SAVED] userId={}, bookId={}", user.getId(), book.getId());
+
+        // 신규 생성 도서는 생성 즉시 내 서재로 등록
+        libraryService.save(user, book.getId());
+
+        return bookService.getBookDetailById(user, book.getId());
+    }
+
+    // USER 도서 수정(업로드/도서 수정/상세 조회)
+    @Transactional
+    public BookResponseDto.BookDetailDto updateUserBook(
+            User user, Long bookId, BookRequestDto.UpdateUserBookRequest request) {
+        boolean hasNewCover = request.coverImage() != null && !request.coverImage().isEmpty();
+        log.info("[USER_BOOK_UPDATE_START] userId={}, bookId={}, hasNewCover={}", user.getId(), bookId, hasNewCover);
+
+        String newCoverUrl = fileStorageService.uploadCover(request.coverImage());
+        bookService.updateUserBook(user, bookId, request, newCoverUrl);
+
+        log.info("[USER_BOOK_UPDATE_DONE] userId={}, bookId={}", user.getId(), bookId);
+        return bookService.getBookDetailById(user, bookId);
+    }
+}
+

--- a/src/main/java/app/nook/book/facade/UserBookFacade.java
+++ b/src/main/java/app/nook/book/facade/UserBookFacade.java
@@ -28,7 +28,7 @@ public class UserBookFacade {
         boolean hasCover = request.coverImage() != null && !request.coverImage().isEmpty();
         log.info("[USER_BOOK_CREATE_START] userId={}, hasCover={}", user.getId(), hasCover);
 
-        String coverImageUrl = fileStorageService.uploadCover(request.coverImage());
+        String coverImageUrl = hasCover ? fileStorageService.uploadCover(request.coverImage()) : null;
 
         Book book = bookService.createUserBook(user, request, coverImageUrl);
         log.info("[USER_BOOK_CREATE_SAVED] userId={}, bookId={}", user.getId(), book.getId());
@@ -46,7 +46,7 @@ public class UserBookFacade {
         boolean hasNewCover = request.coverImage() != null && !request.coverImage().isEmpty();
         log.info("[USER_BOOK_UPDATE_START] userId={}, bookId={}, hasNewCover={}", user.getId(), bookId, hasNewCover);
 
-        String newCoverUrl = fileStorageService.uploadCover(request.coverImage());
+        String newCoverUrl = hasNewCover ? fileStorageService.uploadCover(request.coverImage()) : null;
         bookService.updateUserBook(user, bookId, request, newCoverUrl);
 
         log.info("[USER_BOOK_UPDATE_DONE] userId={}, bookId={}", user.getId(), bookId);

--- a/src/main/java/app/nook/book/repository/BookRepository.java
+++ b/src/main/java/app/nook/book/repository/BookRepository.java
@@ -1,10 +1,13 @@
 package app.nook.book.repository;
 
 import app.nook.book.domain.Book;
+import app.nook.book.domain.enums.SourceType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface BookRepository extends JpaRepository<Book, Long> {
     Optional<Book> findByIsbn13(String isbn13);
+
+    Optional<Book> findByIsbn13AndSourceType(String isbn13, SourceType sourceType);
 }

--- a/src/main/java/app/nook/book/service/BookService.java
+++ b/src/main/java/app/nook/book/service/BookService.java
@@ -2,14 +2,16 @@ package app.nook.book.service;
 
 import app.nook.aladin.service.AladinService;
 import app.nook.book.converter.BookConverter;
-import app.nook.book.dto.BookResponseDto;
 import app.nook.book.domain.Book;
 import app.nook.book.domain.Category;
 import app.nook.book.domain.enums.MallType;
 import app.nook.book.domain.enums.SourceType;
+import app.nook.book.dto.BookRequestDto;
+import app.nook.book.dto.BookResponseDto;
 import app.nook.book.exception.BookErrorCode;
 import app.nook.book.repository.BookRepository;
 import app.nook.book.repository.CategoryRepository;
+import app.nook.book.utils.BookUtils;
 import app.nook.global.exception.CustomException;
 import app.nook.library.domain.Library;
 import app.nook.library.repository.LibraryRepository;
@@ -33,16 +35,17 @@ public class BookService {
     private final LibraryRepository libraryRepository;
     private final AladinService aladinService;
 
-    // 도서 상세 조회
-    // TODO: 사용자가 추가한 서재인 경우 필터링 로직 추가 예정
+    // ISBN 기반 상세조회: ALADIN 소스만 조회/저장 대상으로 사용
     @Transactional
     public BookResponseDto.BookDetailDto getBookDetailByIsbn(User user, String isbn13) {
 
-        Optional<Book> existingBook = bookRepository.findByIsbn13(isbn13);
+        Optional<Book> existingBook = bookRepository.findByIsbn13AndSourceType(isbn13, SourceType.ALADIN);
         if (existingBook.isPresent()) {
             Book book = existingBook.get();
 
-            if (isOutdated(book.getModifiedDate()) && book.getSourceType()== SourceType.ALADIN) {
+            if (book.getSourceType() == SourceType.ALADIN
+                    && book.getIsbn13() != null
+                    && isOutdated(book.getModifiedDate())) {
                 log.info("[BOOK_UPDATE] isbn={}, title={}", isbn13, book.getTitle());
                 updateBookInfo(book, isbn13);
             }
@@ -50,7 +53,7 @@ public class BookService {
             return BookConverter.toBookDetailDto(book, findLibraryId(user, book));
         }
 
-        log.info("[API_FETCH] isbn={}, status='Not found in DB'", isbn13);
+        log.info("[API_FETCH] isbn={}, status='Not found in DB(ALADIN)'", isbn13);
         BookResponseDto.BookDetailDto bookDetailDto = aladinService.lookupItem(isbn13);
         Category category = findCategory(bookDetailDto);
         Book newBook = bookRepository.save(BookConverter.toBook(bookDetailDto, category, SourceType.ALADIN));
@@ -58,7 +61,60 @@ public class BookService {
         return BookConverter.toBookDetailDto(newBook, null);
     }
 
-    // 주간 베스트셀러
+    // bookId 기반 상세조회: USER/ALADIN 공통 상세 진입점
+    public BookResponseDto.BookDetailDto getBookDetailById(User user, Long bookId) {
+        Book book = bookRepository.findById(bookId)
+                .orElseThrow(() -> new CustomException(BookErrorCode.BOOK_NOT_FOUND));
+
+        if (book.getSourceType() == SourceType.ALADIN
+                && book.getIsbn13() != null
+                && isOutdated(book.getModifiedDate())) {
+            updateBookInfo(book, book.getIsbn13());
+        }
+
+        return BookConverter.toBookDetailDto(book, findLibraryId(user, book));
+    }
+
+    @Transactional
+    public Book createUserBook(User user, BookRequestDto.CreateUserBookRequest request, String coverImageUrl) {
+        // 프론트 categoryName을 DB Category(FK)로 매핑
+        Category category = findUserBookCategory(request.categoryName());
+        Book book = Book.builder()
+                .isbn13(BookUtils.normalizeIsbn(request.isbn13()))
+                .title(request.title())
+                .author(request.author())
+                .publisher(request.publisher())
+                .publicationDate(request.publicationDate())
+                .pages(request.pages())
+                .description(request.description())
+                .coverImageUrl(coverImageUrl)
+                .aladinLink(null)
+                .sourceType(SourceType.USER)
+                .createdByUserId(user.getId())
+                .category(category)
+                .build();
+
+        Book saved = bookRepository.save(book);
+        log.info("[USER_BOOK_CREATE_SAVED] userId={}, bookId={}, sourceType={}",
+                user.getId(), saved.getId(), saved.getSourceType());
+        return saved;
+    }
+
+    @Transactional
+    public void updateUserBook(
+            User user, Long bookId, BookRequestDto.UpdateUserBookRequest request, String newCoverImageUrl) {
+        // 소유권 검증 후에만 USER 도서 수정 허용
+        Book book = bookRepository.findById(bookId)
+                .orElseThrow(() -> new CustomException(BookErrorCode.BOOK_NOT_FOUND));
+        validateUserBookOwnership(user, book);
+        String coverImageUrlToUse = (newCoverImageUrl == null || newCoverImageUrl.isBlank())
+                ? book.getCoverImageUrl() : newCoverImageUrl;
+
+        book.updateUserBookInfo(request, coverImageUrlToUse, findUserBookCategory(request.categoryName()));
+        log.info("[USER_BOOK_UPDATE_DONE] userId={}, bookId={}", user.getId(), bookId);
+    }
+
+    // 주간 베스트셀러 조회
     // TODO: redis 도입 예정
     public List<BookResponseDto.BookPreviewDto> getWeeklyBestsellers() {
         log.info("[FETCH_WEEKLY_BEST]");
@@ -69,10 +125,10 @@ public class BookService {
         return bookPreviewDtos;
     }
 
-    // 사용자 맞춤 추천 베스트셀러
-    // TODO: 카테고리 추출 및 redis는 이후 구현 예정
+    // 사용자 맞춤 추천 베스트셀러 조회
+    // TODO: 카테고리 추출 및 redis 이후 구현 예정
     public List<BookResponseDto.BookPreviewDto> getPersonalizedBestsellers(Long userId) {
-        String categoryId = "1"; // 예시 카테고리 ID
+        String categoryId = "1"; // 임시 카테고리 ID
 
         log.info("[FETCH_PERSONAL_BEST] categoryId={}", categoryId);
         List<BookResponseDto.BookPreviewDto> bookPreviewDtos = aladinService.fetchItemList(
@@ -82,13 +138,34 @@ public class BookService {
         return bookPreviewDtos;
     }
 
+    private void validateUserBookOwnership(User user, Book book) {
+        if (book.getSourceType() != SourceType.USER) {
+            log.warn("[USER_BOOK_UPDATE_FORBIDDEN] requestUserId={}, bookId={}, reason=NOT_USER_SOURCE, sourceType={}",
+                    user.getId(), book.getId(), book.getSourceType());
+            throw new CustomException(BookErrorCode.BOOK_NOT_OWNED);
+        }
+        if (book.getCreatedByUserId() == null || !book.getCreatedByUserId().equals(user.getId())) {
+            log.warn("[USER_BOOK_UPDATE_FORBIDDEN] requestUserId={}, bookId={}, reason=NOT_OWNER, createdByUserId={}",
+                    user.getId(), book.getId(), book.getCreatedByUserId());
+            throw new CustomException(BookErrorCode.BOOK_NOT_OWNED);
+        }
+    }
+
+    // USER 도서는 BOOK mallType 기준 카테고리만 허용
+    private Category findUserBookCategory(String categoryName) {
+        return categoryRepository.findByMallTypeAndCategoryName(MallType.BOOK, categoryName)
+                .orElseThrow(() -> {
+                    log.warn("[USER_BOOK_CATEGORY_NOT_FOUND] categoryName={}", categoryName);
+                    return new CustomException(BookErrorCode.CATEGORY_NOT_FOUND);
+                });
+    }
+
     private Category findCategory(BookResponseDto.BookDetailDto bookDetailDto) {
-        MallType mallType = bookDetailDto.getMallTypeCode(); // 예: BOOK
-        String categoryName = bookDetailDto.getCategory(); // 예: 소설/시/희곡
+        MallType mallType = bookDetailDto.getMallTypeCode();
+        String categoryName = bookDetailDto.getCategory();
 
         return categoryRepository.findByMallTypeAndCategoryName(mallType, categoryName)
                 .orElseGet(() -> {
-                    // 예외 처리: 알라딘이 보낸 1 Depth 이름이 우리 DB 초기화 리스트에 없는 경우
                     log.warn("[CATEGORY_MAPPING_FAIL] mallType={}, category='{}'", mallType, categoryName);
                     throw new CustomException(BookErrorCode.BOOK_NOT_ALLOWED);
                 });
@@ -113,3 +190,4 @@ public class BookService {
         return (library != null) ? library.getId() : null;
     }
 }
+

--- a/src/main/java/app/nook/book/service/BookService.java
+++ b/src/main/java/app/nook/book/service/BookService.java
@@ -62,6 +62,7 @@ public class BookService {
     }
 
     // bookId 기반 상세조회: USER/ALADIN 공통 상세 진입점
+    @Transactional
     public BookResponseDto.BookDetailDto getBookDetailById(User user, Long bookId) {
         Book book = bookRepository.findById(bookId)
                 .orElseThrow(() -> new CustomException(BookErrorCode.BOOK_NOT_FOUND));

--- a/src/main/java/app/nook/book/service/FileStorageService.java
+++ b/src/main/java/app/nook/book/service/FileStorageService.java
@@ -1,0 +1,8 @@
+package app.nook.book.service;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface FileStorageService {
+    String uploadCover(MultipartFile file);
+    void deleteByUrl(String fileUrl);
+}

--- a/src/main/java/app/nook/book/service/LocalFileStorageService.java
+++ b/src/main/java/app/nook/book/service/LocalFileStorageService.java
@@ -67,10 +67,28 @@ public class LocalFileStorageService implements FileStorageService {
         }
 
         String fileName = fileUrl.substring(idx + marker.length());
-        Path path = Paths.get(uploadDir).resolve(fileName);
+
+        // 부적절한 경로 차단
+        if (fileName.isBlank() || fileName.contains("/") || fileName.contains("\\") || fileName.contains("..")) {
+            log.warn("[COVER_DELETE_REJECTED] invalid fileName extracted from url. fileUrl={}", fileUrl);
+            return;
+        }
+
+        // 경로 정규화 + 루트 이탈 방지
+        Path basePath = Paths.get(uploadDir).toAbsolutePath().normalize();
+        Path targetPath = basePath.resolve(fileName).normalize();
+        if (!targetPath.startsWith(basePath)) {
+            log.warn("[COVER_DELETE_REJECTED] path traversal detected. fileUrl={}, targetPath={}", fileUrl, targetPath);
+            return;
+        }
+
         try {
-            Files.deleteIfExists(path);
-        } catch (IOException ignored) {
+            boolean deleted = Files.deleteIfExists(targetPath);
+            if (!deleted) {
+                log.info("[COVER_DELETE_SKIPPED] file not found. path={}", targetPath);
+            }
+        } catch (IOException e) {
+            log.warn("[COVER_DELETE_FAILED] path={}", targetPath, e);
         }
     }
 

--- a/src/main/java/app/nook/book/service/LocalFileStorageService.java
+++ b/src/main/java/app/nook/book/service/LocalFileStorageService.java
@@ -1,0 +1,86 @@
+package app.nook.book.service;
+
+import app.nook.book.exception.BookErrorCode;
+import app.nook.global.exception.CustomException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.Set;
+import java.util.UUID;
+
+@Service
+@Slf4j
+public class LocalFileStorageService implements FileStorageService {
+
+    // 로컬 개발 환경에서 허용하는 표지 확장자
+    private static final Set<String> ALLOWED_CONTENT_TYPES = Set.of("jpg", "jpeg", "png", "gif", "webp");
+
+    // TODO: S3 전환 전까지 로컬 디렉터리에 저장
+    @Value("${file.upload-dir:uploads/covers}")
+    private String uploadDir;
+
+    @Override
+    public String uploadCover(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            return null;
+        }
+
+        String ext = extractExtension(file.getOriginalFilename());
+        if (!ALLOWED_CONTENT_TYPES.contains(ext)) {
+            throw new CustomException(BookErrorCode.INVALID_FILE_TYPE);
+        }
+
+        try {
+            Path dirPath = Paths.get(uploadDir);
+            Files.createDirectories(dirPath);
+
+            String fileName = UUID.randomUUID() + "." + ext;
+            Path targetPath = dirPath.resolve(fileName);
+
+            Files.copy(file.getInputStream(), targetPath, StandardCopyOption.REPLACE_EXISTING);
+
+            log.info("[COVER_UPLOAD_SUCCESS] storedFileName={}", fileName);
+            return "/uploads/covers/" + fileName;
+        } catch (IOException e) {
+            log.error("[COVER_UPLOAD_FAILED] originalFilename={}", file.getOriginalFilename(), e);
+            throw new CustomException(BookErrorCode.FILE_UPLOAD_FAILED);
+        }
+    }
+
+    @Override
+    public void deleteByUrl(String fileUrl) {
+        if (fileUrl == null || fileUrl.isBlank()) {
+            return;
+        }
+        String marker = "/uploads/covers/";
+        int idx = fileUrl.indexOf(marker);
+        if (idx < 0) {
+            return;
+        }
+
+        String fileName = fileUrl.substring(idx + marker.length());
+        Path path = Paths.get(uploadDir).resolve(fileName);
+        try {
+            Files.deleteIfExists(path);
+        } catch (IOException ignored) {
+        }
+    }
+
+    private String extractExtension(String originalFilename) {
+        String filename = StringUtils.hasText(originalFilename) ? originalFilename : "";
+        int dotIndex = filename.lastIndexOf('.');
+        if (dotIndex < 0 || dotIndex == filename.length() - 1) {
+            throw new CustomException(BookErrorCode.INVALID_FILE_TYPE);
+        }
+        return filename.substring(dotIndex + 1).toLowerCase();
+    }
+}
+

--- a/src/main/java/app/nook/book/utils/BookUtils.java
+++ b/src/main/java/app/nook/book/utils/BookUtils.java
@@ -1,0 +1,13 @@
+package app.nook.book.utils;
+
+public class BookUtils {
+    private BookUtils() {}
+
+    public static String normalizeIsbn(String rawIsbn) {
+        if (rawIsbn == null) {
+            return null;
+        }
+        String trimmed = rawIsbn.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+}

--- a/src/main/java/app/nook/global/config/WebConfig.java
+++ b/src/main/java/app/nook/global/config/WebConfig.java
@@ -3,15 +3,21 @@ package app.nook.global.config;
 import app.nook.book.domain.enums.SearchType;
 import app.nook.book.exception.SearchErrorCode;
 import app.nook.global.exception.CustomException;
-import app.nook.global.response.ErrorCode;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.format.FormatterRegistry;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.nio.file.Paths;
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
 
-    // 검색 타입 대소문자 변환
+    @Value("${file.upload-dir:uploads/covers}")
+    private String uploadDir;
+
+    // 검색 타입 문자열을 SearchType enum으로 변환
     @Override
     public void addFormatters(FormatterRegistry registry) {
         registry.addConverter(String.class, SearchType.class, source -> {
@@ -25,4 +31,14 @@ public class WebConfig implements WebMvcConfigurer {
             }
         });
     }
+
+    // /uploads/**를 로컬 업로드 디렉터리와 매핑
+    // 보안 설정(WebSecurityConfig)에서 /uploads/** 공개 여부를 함께 관리해야 함
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        String absolutePath = Paths.get(uploadDir).toAbsolutePath().toUri().toString();
+        registry.addResourceHandler("/uploads/**")
+                .addResourceLocations(absolutePath);
+    }
 }
+

--- a/src/main/java/app/nook/global/config/WebConfig.java
+++ b/src/main/java/app/nook/global/config/WebConfig.java
@@ -37,7 +37,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addResourceHandlers(ResourceHandlerRegistry registry) {
         String absolutePath = Paths.get(uploadDir).toAbsolutePath().toUri().toString();
-        registry.addResourceHandler("/uploads/**")
+        registry.addResourceHandler("/uploads/covers/**")
                 .addResourceLocations(absolutePath);
     }
 }

--- a/src/main/java/app/nook/global/config/WebSecurityConfig.java
+++ b/src/main/java/app/nook/global/config/WebSecurityConfig.java
@@ -57,7 +57,8 @@ public class WebSecurityConfig {
                                 "/docs/**",              // REST Docs
                                 "/index.html",
                                 "/api/auth/**",
-                                "/ws/**"
+                                "/ws/**",
+                                "/uploads/**"            // TODO: 임시 로컬 이미지 업로드용, 추후 S3로 변경 예정
                         ).permitAll()
                         .requestMatchers("/api/**").authenticated()
                         .anyRequest().authenticated()

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -27,6 +27,15 @@ spring:
       host: ${REDIS_HOST:localhost}
       port: 6379
 
+  servlet:
+    multipart:
+      max-file-size: 5MB
+      max-request-size: 5MB
+
+file:
+  upload-dir: uploads/covers
+
+
 jwt:
   secret: ${JWT_SECRET}
 

--- a/src/test/java/app/nook/book/facade/UserBookFacadeTest.java
+++ b/src/test/java/app/nook/book/facade/UserBookFacadeTest.java
@@ -1,0 +1,111 @@
+package app.nook.book.facade;
+
+import app.nook.book.domain.Book;
+import app.nook.book.dto.BookRequestDto;
+import app.nook.book.dto.BookResponseDto;
+import app.nook.book.service.BookService;
+import app.nook.book.service.FileStorageService;
+import app.nook.library.service.LibraryService;
+import app.nook.user.domain.User;
+import app.nook.user.domain.enums.UserRole;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.Mockito.verify;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+class UserBookFacadeTest {
+
+    @Mock private BookService bookService;
+    @Mock private LibraryService libraryService;
+    @Mock private FileStorageService fileStorageService;
+
+    @InjectMocks private UserBookFacade userBookFacade;
+
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        user = User.builder()
+                .email("test@example.com")
+                .nickName("tester")
+                .provider("google")
+                .providerId("pid")
+                .role(UserRole.USER)
+                .build();
+        ReflectionTestUtils.setField(user, "id", 1L);
+    }
+
+    @Test
+    void createUserBook_success() {
+        BookRequestDto.CreateUserBookRequest req = new BookRequestDto.CreateUserBookRequest(
+                "혼모노",
+                "성해은",
+                "소설/시/희곡",
+                "소개",
+                348,
+                "민음사",
+                "2023-06-05",
+                "9788936439743",
+                null
+        );
+
+        Book saved = Book.builder().title("혼모노").build();
+        ReflectionTestUtils.setField(saved, "id", 100L);
+
+        BookResponseDto.BookDetailDto detail = BookResponseDto.BookDetailDto.builder()
+                .bookId(100L).title("혼모노").build();
+
+        given(fileStorageService.uploadCover(any())).willReturn("/uploads/covers/a.png");
+        given(bookService.createUserBook(eq(user), any(), anyString())).willReturn(saved);
+        given(bookService.getBookDetailById(user, 100L)).willReturn(detail);
+
+        BookResponseDto.BookDetailDto result = userBookFacade.createUserBook(user, req);
+
+        verify(libraryService).save(user, 100L);
+        assertThat(result.getBookId()).isEqualTo(100L);
+    }
+
+    @Test
+    void updateUserBook_success() {
+        BookRequestDto.UpdateUserBookRequest req = new BookRequestDto.UpdateUserBookRequest(
+                "혼모노 수정",
+                "성해은",
+                "소설/시/희곡",
+                "소개수정",
+                360,
+                "민음사",
+                "2024-01-01",
+                "9788936439743",
+                null
+        );
+
+        Book updated = Book.builder().title("혼모노 수정").build();
+        ReflectionTestUtils.setField(updated, "id", 100L);
+
+        BookResponseDto.BookDetailDto detail = BookResponseDto.BookDetailDto.builder()
+                .bookId(100L).title("혼모노 수정").build();
+
+        given(fileStorageService.uploadCover(any())).willReturn("/uploads/covers/new.png");
+        willDoNothing().given(bookService)
+                .updateUserBook(eq(user), eq(100L), any(BookRequestDto.UpdateUserBookRequest.class), anyString());
+        given(bookService.getBookDetailById(user, 100L)).willReturn(detail);
+
+        BookResponseDto.BookDetailDto result = userBookFacade.updateUserBook(user, 100L, req);
+
+        verify(fileStorageService).uploadCover(any());
+        verify(bookService).updateUserBook(eq(user), eq(100L), any(BookRequestDto.UpdateUserBookRequest.class), anyString());
+        verify(bookService).getBookDetailById(user, 100L);
+        assertThat(result.getBookId()).isEqualTo(100L);
+    }
+
+}

--- a/src/test/java/app/nook/book/facade/UserBookFacadeTest.java
+++ b/src/test/java/app/nook/book/facade/UserBookFacadeTest.java
@@ -19,6 +19,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -65,12 +66,13 @@ class UserBookFacadeTest {
         BookResponseDto.BookDetailDto detail = BookResponseDto.BookDetailDto.builder()
                 .bookId(100L).title("혼모노").build();
 
-        given(fileStorageService.uploadCover(any())).willReturn("/uploads/covers/a.png");
-        given(bookService.createUserBook(eq(user), any(), anyString())).willReturn(saved);
+        given(bookService.createUserBook(eq(user), any(), isNull())).willReturn(saved);
         given(bookService.getBookDetailById(user, 100L)).willReturn(detail);
 
         BookResponseDto.BookDetailDto result = userBookFacade.createUserBook(user, req);
 
+        verify(fileStorageService, never()).uploadCover(any());
+        verify(bookService).createUserBook(eq(user), any(), isNull());
         verify(libraryService).save(user, 100L);
         assertThat(result.getBookId()).isEqualTo(100L);
     }
@@ -95,15 +97,14 @@ class UserBookFacadeTest {
         BookResponseDto.BookDetailDto detail = BookResponseDto.BookDetailDto.builder()
                 .bookId(100L).title("혼모노 수정").build();
 
-        given(fileStorageService.uploadCover(any())).willReturn("/uploads/covers/new.png");
         willDoNothing().given(bookService)
-                .updateUserBook(eq(user), eq(100L), any(BookRequestDto.UpdateUserBookRequest.class), anyString());
+                .updateUserBook(eq(user), eq(100L), any(BookRequestDto.UpdateUserBookRequest.class), isNull());
         given(bookService.getBookDetailById(user, 100L)).willReturn(detail);
 
         BookResponseDto.BookDetailDto result = userBookFacade.updateUserBook(user, 100L, req);
 
-        verify(fileStorageService).uploadCover(any());
-        verify(bookService).updateUserBook(eq(user), eq(100L), any(BookRequestDto.UpdateUserBookRequest.class), anyString());
+        verify(fileStorageService, never()).uploadCover(any());
+        verify(bookService).updateUserBook(eq(user), eq(100L), any(BookRequestDto.UpdateUserBookRequest.class), isNull());
         verify(bookService).getBookDetailById(user, 100L);
         assertThat(result.getBookId()).isEqualTo(100L);
     }

--- a/src/test/java/app/nook/book/service/BookServiceTest.java
+++ b/src/test/java/app/nook/book/service/BookServiceTest.java
@@ -5,6 +5,7 @@ import app.nook.book.domain.Book;
 import app.nook.book.domain.Category;
 import app.nook.book.domain.enums.MallType;
 import app.nook.book.domain.enums.SourceType;
+import app.nook.book.dto.BookRequestDto;
 import app.nook.book.dto.BookResponseDto;
 import app.nook.book.exception.BookErrorCode;
 import app.nook.book.repository.BookRepository;
@@ -93,7 +94,7 @@ class BookServiceTest {
         ReflectionTestUtils.setField(book, "id", 1L);
         ReflectionTestUtils.setField(book, "modifiedDate", LocalDateTime.now());
 
-        given(bookRepository.findByIsbn13(TEST_ISBN_1))
+        given(bookRepository.findByIsbn13AndSourceType(TEST_ISBN_1, SourceType.ALADIN))
                 .willReturn(Optional.of(book));
         given(bookRepository.findById(1L))
                 .willReturn(Optional.of(book));
@@ -111,7 +112,7 @@ class BookServiceTest {
         assertThat(result.getPages()).isEqualTo(184);
 
         // DB에 있었으므로 알라딘 API는 호출되지 않아야 함
-        verify(bookRepository, times(1)).findByIsbn13(TEST_ISBN_1);
+        verify(bookRepository, times(1)).findByIsbn13AndSourceType(TEST_ISBN_1, SourceType.ALADIN);
         verify(aladinService, never()).lookupItem(any());
     }
 
@@ -126,7 +127,7 @@ class BookServiceTest {
         ReflectionTestUtils.setField(savedBookWithId, "id", 100L);
 
         // Mocking 시나리오
-        given(bookRepository.findByIsbn13(TEST_ISBN_1)).willReturn(Optional.empty()); // DB 없음
+        given(bookRepository.findByIsbn13AndSourceType(TEST_ISBN_1, SourceType.ALADIN)).willReturn(Optional.empty()); // DB 없음
         given(aladinService.lookupItem(TEST_ISBN_1)).willReturn(apiResponse); // API 호출
         given(categoryRepository.findByMallTypeAndCategoryName(MallType.BOOK, TEST_CATEGORY_NAME))
                 .willReturn(Optional.of(category)); // 카테고리 조회
@@ -168,7 +169,7 @@ class BookServiceTest {
                 .category("존재하지않는카테고리")
                 .build();
 
-        given(bookRepository.findByIsbn13(TEST_ISBN_1)).willReturn(Optional.empty());
+        given(bookRepository.findByIsbn13AndSourceType(TEST_ISBN_1, SourceType.ALADIN)).willReturn(Optional.empty());
         given(aladinService.lookupItem(TEST_ISBN_1)).willReturn(apiResponse);
         // 카테고리 조회 실패 시뮬레이션
         given(categoryRepository.findByMallTypeAndCategoryName(any(), any()))
@@ -184,6 +185,22 @@ class BookServiceTest {
 
         // 예외 발생 시 저장이 수행되면 안 됨 (데이터 오염 방지)
         verify(bookRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("bookId 기반 상세 조회 성공")
+    void getBookDetailById_success() {
+        Book book = createBook(TEST_ISBN_1, "제목", 184);
+        ReflectionTestUtils.setField(book, "id", 20L);
+        ReflectionTestUtils.setField(book, "sourceType", SourceType.USER);
+
+        given(bookRepository.findById(20L)).willReturn(Optional.of(book));
+        given(libraryRepository.findByUserAndBook(testUser, book)).willReturn(null);
+
+        BookResponseDto.BookDetailDto result = bookService.getBookDetailById(testUser, 20L);
+
+        assertThat(result.getBookId()).isEqualTo(20L);
+        assertThat(result.getTitle()).isEqualTo("제목");
     }
 
     @Test
@@ -229,6 +246,79 @@ class BookServiceTest {
         assertThat(result.get(0).title()).isEqualTo("채식주의자");
 
         verify(aladinService, times(1)).fetchItemList("Bestseller", "BOOK", 5, "1");
+    }
+
+    @Test
+    @DisplayName("사용자 도서 생성 성공")
+    void createUserBook_success() {
+        BookRequestDto.CreateUserBookRequest request = new BookRequestDto.CreateUserBookRequest(
+                "혼모노", "성해은", TEST_CATEGORY_NAME, "소개", 348, TEST_PUBLISHER,
+                "2023-06-05", "9788936439743", null
+        );
+
+        given(categoryRepository.findByMallTypeAndCategoryName(MallType.BOOK, TEST_CATEGORY_NAME))
+                .willReturn(Optional.of(category));
+        given(bookRepository.save(any(Book.class))).willAnswer(invocation -> {
+            Book saved = invocation.getArgument(0);
+            ReflectionTestUtils.setField(saved, "id", 100L);
+            return saved;
+        });
+
+        Book saved = bookService.createUserBook(testUser, request, "/uploads/covers/a.png");
+
+        assertThat(saved.getId()).isEqualTo(100L);
+        assertThat(saved.getSourceType()).isEqualTo(SourceType.USER);
+        assertThat(saved.getCreatedByUserId()).isEqualTo(TEST_USER_ID);
+        assertThat(saved.getCategory()).isEqualTo(category);
+        assertThat(saved.getIsbn13()).isEqualTo("9788936439743");
+    }
+
+    @Test
+    @DisplayName("사용자 도서 수정 - 본인 소유가 아니면 실패")
+    void updateUserBook_notOwned_fail() {
+        BookRequestDto.UpdateUserBookRequest request = new BookRequestDto.UpdateUserBookRequest(
+                "수정제목", "수정저자", TEST_CATEGORY_NAME, "수정소개", 200, TEST_PUBLISHER,
+                "2024-01-01", "1234567890123", null
+        );
+
+        Book book = createBook("1234567890123", "원제목", 120);
+        ReflectionTestUtils.setField(book, "id", 10L);
+        ReflectionTestUtils.setField(book, "sourceType", SourceType.USER);
+        ReflectionTestUtils.setField(book, "createdByUserId", 999L);
+
+        given(bookRepository.findById(10L)).willReturn(Optional.of(book));
+
+        CustomException ex = assertThrows(
+                CustomException.class,
+                () -> bookService.updateUserBook(testUser, 10L, request, null)
+        );
+
+        assertThat(ex.getErrorCode()).isEqualTo(BookErrorCode.BOOK_NOT_OWNED);
+    }
+
+    @Test
+    @DisplayName("사용자 도서 수정 - 카테고리 없음 실패")
+    void updateUserBook_categoryNotFound_fail() {
+        BookRequestDto.UpdateUserBookRequest request = new BookRequestDto.UpdateUserBookRequest(
+                "수정제목", "수정저자", "없는카테고리", "수정소개", 200, TEST_PUBLISHER,
+                "2024-01-01", "1234567890123", null
+        );
+
+        Book book = createBook("1234567890123", "원제목", 120);
+        ReflectionTestUtils.setField(book, "id", 11L);
+        ReflectionTestUtils.setField(book, "sourceType", SourceType.USER);
+        ReflectionTestUtils.setField(book, "createdByUserId", TEST_USER_ID);
+
+        given(bookRepository.findById(11L)).willReturn(Optional.of(book));
+        given(categoryRepository.findByMallTypeAndCategoryName(MallType.BOOK, "없는카테고리"))
+                .willReturn(Optional.empty());
+
+        CustomException ex = assertThrows(
+                CustomException.class,
+                () -> bookService.updateUserBook(testUser, 11L, request, null)
+        );
+
+        assertThat(ex.getErrorCode()).isEqualTo(BookErrorCode.CATEGORY_NOT_FOUND);
     }
 
     // === 헬퍼 메서드 ===

--- a/src/test/java/app/nook/controller/book/BookControllerTest.java
+++ b/src/test/java/app/nook/controller/book/BookControllerTest.java
@@ -395,7 +395,7 @@ public class BookControllerTest extends AbstractRestDocsTests {
                         .param("publicationDate", "2024-01-01")
                         .param("isbn13", "9788936439743")
                         .with(request -> {
-                            request.setMethod("PUT");
+                            request.setMethod("PATCH");
                             return request;
                         })
                         .header("Authorization", "Bearer test-access-token")

--- a/src/test/java/app/nook/controller/book/BookControllerTest.java
+++ b/src/test/java/app/nook/controller/book/BookControllerTest.java
@@ -2,20 +2,21 @@ package app.nook.controller.book;
 
 import app.nook.book.domain.enums.MallType;
 import app.nook.book.domain.enums.SourceType;
+import app.nook.book.dto.BookRequestDto;
 import app.nook.book.dto.BookResponseDto;
 import app.nook.book.exception.BookErrorCode;
+import app.nook.book.facade.UserBookFacade;
 import app.nook.book.service.BookService;
 import app.nook.global.common.AbstractRestDocsTests;
 import app.nook.global.docs.ApiResponseSnippet;
 import app.nook.global.exception.CustomException;
-import app.nook.global.response.ErrorCode;
 import app.nook.user.domain.User;
 import app.nook.user.domain.enums.UserRole;
 import app.nook.user.service.CustomUserDetails;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -23,8 +24,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
@@ -32,6 +32,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.response
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -40,12 +41,14 @@ public class BookControllerTest extends AbstractRestDocsTests {
     @MockitoBean
     private BookService bookService;
 
-    private User user;
+    @MockitoBean
+    private UserBookFacade userBookFacade;
+
     private CustomUserDetails userDetails;
 
     @BeforeEach
     void setUpUser() {
-        user = User.builder()
+        User user = User.builder()
                 .email("test@example.com")
                 .nickName("테스터")
                 .provider("google")
@@ -152,6 +155,61 @@ public class BookControllerTest extends AbstractRestDocsTests {
     }
 
     @Test
+    @DisplayName("bookId로 도서 상세 조회 성공")
+    void 도서_상세조회_bookId_성공() throws Exception {
+        BookResponseDto.BookDetailDto response = BookResponseDto.BookDetailDto.builder()
+                .bookId(1L)
+                .isbn13("9788936434267")
+                .title("테스트책")
+                .author("저자")
+                .publisher("출판사")
+                .publicationDate("2023-03-21")
+                .mallType("국내도서")
+                .mallTypeCode(MallType.BOOK)
+                .category("소설/시/희곡")
+                .pages(312)
+                .description("한강의 소설")
+                .coverImageUrl("http://example.com/cover.jpg")
+                .sourceType(SourceType.USER)
+                .bookShelfId(3L)
+                .build();
+
+        given(bookService.getBookDetailById(any(User.class), eq(1L))).willReturn(response);
+
+        mockMvc.perform(get("/api/books/id/{bookId}", 1L)
+                        .header("Authorization", "Bearer test-access-token")
+                        .with(user(userDetails)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.bookId").value(1L))
+                .andExpect(jsonPath("$.result.title").value("테스트책"))
+                .andDo(documentWithAuth(
+                        "{class-name}/{method-name}",
+                        pathParameters(
+                                parameterWithName("bookId").description("도서 ID")
+                        ),
+                        responseFields(
+                                ApiResponseSnippet.withResult(
+                                        fieldWithPath("result.bookId").description("도서 ID"),
+                                        fieldWithPath("result.isbn13").description("ISBN13").optional(),
+                                        fieldWithPath("result.title").description("도서 제목"),
+                                        fieldWithPath("result.author").description("저자"),
+                                        fieldWithPath("result.publisher").description("출판사").optional(),
+                                        fieldWithPath("result.publicationDate").description("출판일").optional(),
+                                        fieldWithPath("result.mallType").description("상품 유형").optional(),
+                                        fieldWithPath("result.mallTypeCode").description("상품 유형 코드").optional(),
+                                        fieldWithPath("result.category").description("카테고리").optional(),
+                                        fieldWithPath("result.pages").description("페이지 수").optional(),
+                                        fieldWithPath("result.description").description("도서 설명").optional(),
+                                        fieldWithPath("result.coverImageUrl").description("표지 이미지 URL").optional(),
+                                        fieldWithPath("result.aladinLink").description("알라딘 링크").optional(),
+                                        fieldWithPath("result.sourceType").description("데이터 출처"),
+                                        fieldWithPath("result.bookShelfId").description("서재 ID").optional()
+                                )
+                        )
+                ));
+    }
+
+    @Test
     @DisplayName("주간 베스트셀러 목록 조회 성공")
     void 주간베스트셀러_조회_성공() throws Exception {
         // given
@@ -237,6 +295,132 @@ public class BookControllerTest extends AbstractRestDocsTests {
                                         fieldWithPath("result[].coverImageUrl").description("표지 이미지 URL"),
                                         fieldWithPath("result[].publisher").description("출판사"),
                                         fieldWithPath("result[].rank").description("베스트셀러 순위")
+                                )
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("사용자 도서 등록 성공")
+    void 사용자_도서_등록_성공() throws Exception {
+        BookResponseDto.BookDetailDto response = BookResponseDto.BookDetailDto.builder()
+                .bookId(101L)
+                .title("혼모노")
+                .author("성해은")
+                .category("소설/시/희곡")
+                .sourceType(SourceType.USER)
+                .bookShelfId(5L)
+                .build();
+
+        given(userBookFacade.createUserBook(any(User.class), any(BookRequestDto.CreateUserBookRequest.class)))
+                .willReturn(response);
+
+        MockMultipartFile cover = new MockMultipartFile(
+                "coverImage", "cover.png", "image/png", "fake".getBytes()
+        );
+
+        mockMvc.perform(multipart("/api/books/user")
+                        .file(cover)
+                        .param("title", "혼모노")
+                        .param("author", "성해은")
+                        .param("categoryName", "소설/시/희곡")
+                        .param("description", "소개")
+                        .param("pages", "348")
+                        .param("publisher", "민음사")
+                        .param("publicationDate", "2023-06-05")
+                        .param("isbn13", "9788936439743")
+                        .header("Authorization", "Bearer test-access-token")
+                        .with(user(userDetails)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("SUCCESS-201"))
+                .andExpect(jsonPath("$.result.bookId").value(101L))
+                .andExpect(jsonPath("$.result.sourceType").value("USER"))
+                .andDo(documentWithAuth(
+                        "{class-name}/{method-name}",
+                        responseFields(
+                                ApiResponseSnippet.withResult(
+                                        fieldWithPath("result.bookId").description("도서 ID"),
+                                        fieldWithPath("result.isbn13").description("ISBN13").optional(),
+                                        fieldWithPath("result.title").description("도서 제목"),
+                                        fieldWithPath("result.author").description("저자"),
+                                        fieldWithPath("result.publisher").description("출판사").optional(),
+                                        fieldWithPath("result.publicationDate").description("출판일").optional(),
+                                        fieldWithPath("result.mallType").description("상품 유형").optional(),
+                                        fieldWithPath("result.mallTypeCode").description("상품 유형 코드").optional(),
+                                        fieldWithPath("result.category").description("카테고리").optional(),
+                                        fieldWithPath("result.pages").description("페이지 수").optional(),
+                                        fieldWithPath("result.description").description("도서 설명").optional(),
+                                        fieldWithPath("result.coverImageUrl").description("표지 이미지 URL").optional(),
+                                        fieldWithPath("result.aladinLink").description("알라딘 링크").optional(),
+                                        fieldWithPath("result.sourceType").description("데이터 출처"),
+                                        fieldWithPath("result.bookShelfId").description("서재 ID").optional()
+                                )
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("사용자 도서 수정 성공")
+    void 사용자_도서_수정_성공() throws Exception {
+        BookResponseDto.BookDetailDto response = BookResponseDto.BookDetailDto.builder()
+                .isbn13("1721329381232")
+                .bookId(101L)
+                .title("혼모노 수정")
+                .author("성해은")
+                .publisher("창비")
+                .publicationDate("2012-02-03")
+                .category("소설/시/희곡")
+                .pages(212)
+                .description("혼모노 수정")
+                .coverImageUrl("http://example.com/cover.jpg")
+                .sourceType(SourceType.USER)
+                .bookShelfId(5L)
+                .build();
+
+        given(userBookFacade.updateUserBook(any(User.class), anyLong(), any(BookRequestDto.UpdateUserBookRequest.class)))
+                .willReturn(response);
+
+        MockMultipartFile cover = new MockMultipartFile(
+                "coverImage", "cover2.png", "image/png", "fake2".getBytes()
+        );
+
+        mockMvc.perform(multipart("/api/books/user/{bookId}", 101L)
+                        .file(cover)
+                        .param("title", "혼모노 수정")
+                        .param("author", "성해은")
+                        .param("categoryName", "소설/시/희곡")
+                        .param("description", "소개수정")
+                        .param("pages", "360")
+                        .param("publisher", "민음사")
+                        .param("publicationDate", "2024-01-01")
+                        .param("isbn13", "9788936439743")
+                        .with(request -> {
+                            request.setMethod("PUT");
+                            return request;
+                        })
+                        .header("Authorization", "Bearer test-access-token")
+                        .with(user(userDetails)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.bookId").value(101L))
+                .andDo(documentWithAuth(
+                        "{class-name}/{method-name}",
+                        responseFields(
+                                ApiResponseSnippet.withResult(
+                                        fieldWithPath("result.bookId").description("도서 ID"),
+                                        fieldWithPath("result.isbn13").description("ISBN13").optional(),
+                                        fieldWithPath("result.title").description("도서 제목"),
+                                        fieldWithPath("result.author").description("저자"),
+                                        fieldWithPath("result.publisher").description("출판사").optional(),
+                                        fieldWithPath("result.publicationDate").description("출판일").optional(),
+                                        fieldWithPath("result.mallType").description("상품 유형").optional(),
+                                        fieldWithPath("result.mallTypeCode").description("상품 유형 코드").optional(),
+                                        fieldWithPath("result.category").description("카테고리").optional(),
+                                        fieldWithPath("result.pages").description("페이지 수").optional(),
+                                        fieldWithPath("result.description").description("도서 설명").optional(),
+                                        fieldWithPath("result.coverImageUrl").description("표지 이미지 URL").optional(),
+                                        fieldWithPath("result.aladinLink").description("알라딘 링크").optional(),
+                                        fieldWithPath("result.sourceType").description("데이터 출처"),
+                                        fieldWithPath("result.bookShelfId").description("서재 ID").optional()
                                 )
                         )
                 ));


### PR DESCRIPTION
## 📄 작업 내용 요약
<!-- 무엇을 작업했는지 간단하게 요약해주세요 -->

- bookId를 이용한 도서 상세 정보 조회 API 추가
- 도서 추가/수정 API 구현
- 관련 테스트 코드 작성

---

## 📎 Issue 번호
<!-- 관련된 이슈가 있다면 닫히도록 연결해주세요 (ex: closed #1) -->

- closed #217 

---

## ✅ 작업 목록
<!-- 체크박스로 완료한 작업을 표시해주세요 -->

- [x] 기능 구현
- [x] 코드 리뷰 반영
- [x] 테스트 코드 작성
- [x] 문서 업데이트

---

## 📝 기타 참고사항
<!-- 리뷰어가 참고하면 좋을 추가 정보나 질문이 있다면 자유롭게 작성해주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 개인 도서 등록·수정(멀티파트 커버 업로드) 및 도서 ID로 상세 조회 지원
  * 로컬 커버 이미지 저장 경로 제공 및 공개 리소스 매핑

* **개선사항**
  * ISBN 정규화·검증 강화, 카테고리 유효성 검사 및 소유권 검증 도입
  * 업로드 파일 유형·크기 제한 및 관련 오류 응답 추가

* **문서화**
  * API 문서에 도서 상세(ISBN/ID) 및 사용자 도서 등록·수정 항목 추가/갱신

* **테스트**
  * 사용자 도서 흐름 관련 단위/통합 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->