### PR TITLE
[FEAT] 알라딘 연동 도서 조회 Redis 캐시 도입

### DIFF
--- a/src/main/java/app/nook/aladin/service/AladinService.java
+++ b/src/main/java/app/nook/aladin/service/AladinService.java
@@ -7,10 +7,12 @@ import app.nook.aladin.utils.AladinUtils;
 import app.nook.book.dto.BookResponseDto;
 import app.nook.book.domain.enums.BookCategory;
 import app.nook.book.exception.BookErrorCode;
+import app.nook.global.config.CacheConfig;
 import app.nook.global.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -92,7 +94,11 @@ public class AladinService {
      * Global Index 기반 (0~49: 1페이지, 50~99: 2페이지 ...)
      * size만큼 채워질 때까지 다음 페이지를 계속 조회함
      */
-    // TODO: redis 도입 예정
+    @Cacheable(
+            cacheNames = CacheConfig.ALADIN_SEARCH_CACHE,
+            key = "#keyword + ':' + (#cursor == null ? 0 : #cursor) + ':' + #size",
+            sync = true
+    )
     public BookResponseDto.SearchResultDto searchItems(String keyword, Integer cursor, int size) {
         List<BookResponseDto.BookSearchDto> results = new ArrayList<>();
         Long totalResults = 0L;

--- a/src/main/java/app/nook/book/service/BookService.java
+++ b/src/main/java/app/nook/book/service/BookService.java
@@ -40,6 +40,7 @@ public class BookService {
     private final LibraryRepository libraryRepository;
     private final UserRepository userRepository;
     private final AladinService aladinService;
+    private final PersonalizedBestsellerCacheService personalizedBestsellerCacheService;
 
     // ISBN 기반 상세조회: ALADIN 소스만 조회/저장 대상으로 사용
     @Transactional
@@ -137,23 +138,18 @@ public class BookService {
     }
 
     // 사용자 맞춤 추천 베스트셀러 조회
-    @Cacheable(
-            cacheNames = CacheConfig.PERSONALIZED_BESTSELLERS_CACHE,
-            key = "'category:' + #root.target.resolveRecommendationCategoryId(#user.id)",
-            sync = true
-    )
     public List<BookResponseDto.BookPreviewDto> getPersonalizedBestsellers(User user) {
-        String categoryId = String.valueOf(resolveRecommendationCategoryId(user.getId()));
+        int categoryId = resolveRecommendationCategoryId(user.getId());
 
         log.info("[FETCH_PERSONAL_BEST] categoryId={}", categoryId);
-        List<BookResponseDto.BookPreviewDto> bookPreviewDtos = aladinService.fetchItemList(
-                "Bestseller", "BOOK", 5, categoryId);
+        List<BookResponseDto.BookPreviewDto> bookPreviewDtos =
+                personalizedBestsellerCacheService.getByCategoryId(categoryId);
 
         log.info("[FETCH_PERSONAL_BEST_SUCCESS] count={}", bookPreviewDtos.size());
         return bookPreviewDtos;
     }
 
-    public int resolveRecommendationCategoryId(Long userId) {
+    private int resolveRecommendationCategoryId(Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 

--- a/src/main/java/app/nook/book/service/BookService.java
+++ b/src/main/java/app/nook/book/service/BookService.java
@@ -12,6 +12,7 @@ import app.nook.book.exception.BookErrorCode;
 import app.nook.book.repository.BookRepository;
 import app.nook.book.repository.CategoryRepository;
 import app.nook.book.utils.BookUtils;
+import app.nook.global.config.CacheConfig;
 import app.nook.global.exception.CustomException;
 import app.nook.global.response.ErrorCode;
 import app.nook.library.domain.Library;
@@ -20,6 +21,7 @@ import app.nook.user.domain.User;
 import app.nook.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -120,7 +122,11 @@ public class BookService {
     }
 
     // 주간 베스트셀러 조회
-    // TODO: redis 도입 예정
+    @Cacheable(
+            cacheNames = CacheConfig.WEEKLY_BESTSELLERS_CACHE,
+            key = "'weekly'",
+            sync = true
+    )
     public List<BookResponseDto.BookPreviewDto> getWeeklyBestsellers() {
         log.info("[FETCH_WEEKLY_BEST]");
         List<BookResponseDto.BookPreviewDto> bookPreviewDtos = aladinService.fetchItemList(
@@ -131,7 +137,11 @@ public class BookService {
     }
 
     // 사용자 맞춤 추천 베스트셀러 조회
-    // TODO: redis 이후 구현 예정
+    @Cacheable(
+            cacheNames = CacheConfig.PERSONALIZED_BESTSELLERS_CACHE,
+            key = "'category:' + #root.target.resolveRecommendationCategoryId(#user.id)",
+            sync = true
+    )
     public List<BookResponseDto.BookPreviewDto> getPersonalizedBestsellers(User user) {
         String categoryId = String.valueOf(resolveRecommendationCategoryId(user.getId()));
 
@@ -143,7 +153,7 @@ public class BookService {
         return bookPreviewDtos;
     }
 
-    private int resolveRecommendationCategoryId(Long userId) {
+    public int resolveRecommendationCategoryId(Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
@@ -219,4 +229,3 @@ public class BookService {
         return (library != null) ? library.getId() : null;
     }
 }
-

--- a/src/main/java/app/nook/book/service/BookService.java
+++ b/src/main/java/app/nook/book/service/BookService.java
@@ -126,6 +126,7 @@ public class BookService {
     @Cacheable(
             cacheNames = CacheConfig.WEEKLY_BESTSELLERS_CACHE,
             key = "'weekly'",
+            unless = "#result == null || #result.isEmpty()",
             sync = true
     )
     public List<BookResponseDto.BookPreviewDto> getWeeklyBestsellers() {

--- a/src/main/java/app/nook/book/service/PersonalizedBestsellerCacheService.java
+++ b/src/main/java/app/nook/book/service/PersonalizedBestsellerCacheService.java
@@ -19,6 +19,7 @@ public class PersonalizedBestsellerCacheService {
     @Cacheable(
             cacheNames = CacheConfig.PERSONALIZED_BESTSELLERS_CACHE,
             key = "'category:' + #categoryId",
+            unless = "#result == null || #result.isEmpty()",
             sync = true
     )
     public List<BookResponseDto.BookPreviewDto> getByCategoryId(int categoryId) {

--- a/src/main/java/app/nook/book/service/PersonalizedBestsellerCacheService.java
+++ b/src/main/java/app/nook/book/service/PersonalizedBestsellerCacheService.java
@@ -1,0 +1,32 @@
+package app.nook.book.service;
+
+import app.nook.aladin.service.AladinService;
+import app.nook.book.dto.BookResponseDto;
+import app.nook.global.config.CacheConfig;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PersonalizedBestsellerCacheService {
+
+    private final AladinService aladinService;
+
+    // categoryId를 직접 key로 사용해 캐시 조회 전에 DB를 다시 조회하지 않도록 분리
+    @Cacheable(
+            cacheNames = CacheConfig.PERSONALIZED_BESTSELLERS_CACHE,
+            key = "'category:' + #categoryId",
+            sync = true
+    )
+    public List<BookResponseDto.BookPreviewDto> getByCategoryId(int categoryId) {
+        return aladinService.fetchItemList(
+                "Bestseller",
+                "BOOK",
+                5,
+                String.valueOf(categoryId)
+        );
+    }
+}

--- a/src/main/java/app/nook/global/config/CacheConfig.java
+++ b/src/main/java/app/nook/global/config/CacheConfig.java
@@ -17,6 +17,9 @@ import java.util.Map;
 @Configuration
 @EnableCaching
 public class CacheConfig {
+    public static final String ALADIN_SEARCH_CACHE = "aladinSearchResults";
+    public static final String WEEKLY_BESTSELLERS_CACHE = "weeklyBestsellers";
+    public static final String PERSONALIZED_BESTSELLERS_CACHE = "personalizedBestsellers";
 
     @Bean
     public RedisCacheManager cacheManager(RedisConnectionFactory connectionFactory) {
@@ -31,6 +34,12 @@ public class CacheConfig {
 
         cacheConfigs.put("libraryStatusFirstPage",
                 defaultConfig.entryTtl(Duration.ofMinutes(2)));
+        cacheConfigs.put(ALADIN_SEARCH_CACHE,
+                defaultConfig.entryTtl(Duration.ofMinutes(10)));
+        cacheConfigs.put(WEEKLY_BESTSELLERS_CACHE,
+                defaultConfig.entryTtl(Duration.ofMinutes(30)));
+        cacheConfigs.put(PERSONALIZED_BESTSELLERS_CACHE,
+                defaultConfig.entryTtl(Duration.ofMinutes(30)));
 
         return RedisCacheManager.builder(connectionFactory)
                 .cacheDefaults(defaultConfig)


### PR DESCRIPTION
## 📄 작업 내용 요약
 - 알라딘 연동 도서 조회 구간에 Redis 캐시 도입
 - 도서 검색, 주간 베스트셀러, 사용자 맞춤 추천 조회에 Spring Cache + RedisCacheManager 기반 캐시 적용
 - 검색: `keyword + cursor + size`
 - 주간 베스트셀러: 고정 key
 - 추천: `categoryId` 기준 key

---

## 📎 Issue 번호
<!-- 관련된 이슈가 있다면 닫히도록 연결해주세요 (ex: closed #1) -->

- closed #229 

---

## ✅ 작업 목록
<!-- 체크박스로 완료한 작업을 표시해주세요 -->

- [x] 기능 구현
- [ ] 코드 리뷰 반영
- [ ] 테스트 코드 작성
- [ ] 문서 업데이트

---

## 📝 기타 참고사항
<!-- 리뷰어가 참고하면 좋을 추가 정보나 질문이 있다면 자유롭게 작성해주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 새로운 기능
* 검색 결과에 대한 캐싱 적용으로 동일 검색 시 응답 속도 및 일관성 개선
* 주간 베스트셀러 조회 결과 캐싱 추가로 빈번한 조회 성능 향상
* 개인 맞춤 베스트셀러를 반환하는 캐시 기반 서비스 도입으로 개인화 추천 응답 속도 및 효율성 개선
* 캐시 적용으로 전반적 응답 지연 감소 및 사용자 경험 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->