### PR TITLE
[FEAT] 기록 및 사진 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -102,6 +102,12 @@ dependencies {
 
 	// gpt
 	implementation 'io.github.flashvayne:chatgpt-spring-boot-starter:1.0.4'
+
+	// r2
+	implementation 'software.amazon.awssdk:s3:2.25.4'
+	implementation 'software.amazon.awssdk:auth:2.25.4'
+	implementation 'com.amazonaws:aws-java-sdk-s3:1.12.691'
+
 }
 
 asciidoctor {

--- a/src/docs/asciidoc/image.adoc
+++ b/src/docs/asciidoc/image.adoc
@@ -1,0 +1,15 @@
+== 사진
+
+=== 사진 단건 업로드
+include::{snippets}/image-upload-controller-test/단건_업로드_URL_발급_성공/http-request.adoc[]
+include::{snippets}/image-upload-controller-test/단건_업로드_URL_발급_성공/request-headers.adoc[]
+include::{snippets}/image-upload-controller-test/단건_업로드_URL_발급_성공/request-fields.adoc[]
+include::{snippets}/image-upload-controller-test/단건_업로드_URL_발급_성공/http-response.adoc[]
+include::{snippets}/image-upload-controller-test/단건_업로드_URL_발급_성공/response-fields.adoc[]
+
+=== 사진 다건 업로드
+include::{snippets}/image-upload-controller-test/다건_업로드_URL_발급_성공/http-request.adoc[]
+include::{snippets}/image-upload-controller-test/다건_업로드_URL_발급_성공/request-headers.adoc[]
+include::{snippets}/image-upload-controller-test/다건_업로드_URL_발급_성공/request-fields.adoc[]
+include::{snippets}/image-upload-controller-test/다건_업로드_URL_발급_성공/http-response.adoc[]
+include::{snippets}/image-upload-controller-test/다건_업로드_URL_발급_성공/response-fields.adoc[]

--- a/src/docs/asciidoc/image.adoc
+++ b/src/docs/asciidoc/image.adoc
@@ -1,5 +1,16 @@
 == 사진
 
+프론트가 해야 하는 일은 아래 순서입니다.
+
+1. 이미지 업로드 URL 발급 API를 호출해서 `uploadUrl(imageUrl)` 과 `key` 를 받습니다.
+2. 응답으로 받은 `uploadUrl`  로 파일을 `PUT` 업로드합니다.
+```
+PUT https://r2...signed-url
+Content-Type: image/png
+```
+
+업로드가 끝나면 발급받은 `key` 를 기록 생성/수정 같은 서버 API에 전달합니다.
+
 === 사진 단건 업로드
 include::{snippets}/image-upload-controller-test/단건_업로드_URL_발급_성공/http-request.adoc[]
 include::{snippets}/image-upload-controller-test/단건_업로드_URL_발급_성공/request-headers.adoc[]
@@ -7,9 +18,20 @@ include::{snippets}/image-upload-controller-test/단건_업로드_URL_발급_성
 include::{snippets}/image-upload-controller-test/단건_업로드_URL_발급_성공/http-response.adoc[]
 include::{snippets}/image-upload-controller-test/단건_업로드_URL_발급_성공/response-fields.adoc[]
 
+단건 업로드도 프론트 흐름은 동일합니다.
+
+- 먼저 업로드 URL 발급 API 호출
+- 그 다음 반환된 `imageUrl` 로  `PUT` 업로드
+- 마지막으로 반환된 `key` 를 후속 API에 전달
+
 === 사진 다건 업로드
 include::{snippets}/image-upload-controller-test/다건_업로드_URL_발급_성공/http-request.adoc[]
 include::{snippets}/image-upload-controller-test/다건_업로드_URL_발급_성공/request-headers.adoc[]
 include::{snippets}/image-upload-controller-test/다건_업로드_URL_발급_성공/request-fields.adoc[]
 include::{snippets}/image-upload-controller-test/다건_업로드_URL_발급_성공/http-response.adoc[]
 include::{snippets}/image-upload-controller-test/다건_업로드_URL_발급_성공/response-fields.adoc[]
+
+다건 업로드는 각 응답 항목마다 같은 작업을 반복합니다.
+
+- 각 `imageUrl` 로 파일 `PUT` 업로드
+- 각 `key` 를 모아서 후속 API의 `imageKeys` 에 전달

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -23,5 +23,5 @@ include::focus.adoc[]
 == 검색
 include::search.adoc[]
 
-== test
-include::test.adoc[]
+== 사진
+include::image.adoc[]

--- a/src/docs/asciidoc/reading-record.adoc
+++ b/src/docs/asciidoc/reading-record.adoc
@@ -1,0 +1,36 @@
+== 기록
+
+=== 기록 생성
+이미지 파일은 먼저 이미지 업로드 API로 업로드한 뒤, 발급받은 `key` 목록을 `imageKeys`로 전달합니다.
+`presigned URL` 자체를 기록 생성 요청에 넣지 않습니다.
+
+include::{snippets}/record-controller-test/기록_생성_성공/http-request.adoc[]
+include::{snippets}/record-controller-test/기록_생성_성공/request-headers.adoc[]
+include::{snippets}/record-controller-test/기록_생성_성공/path-parameters.adoc[]
+include::{snippets}/record-controller-test/기록_생성_성공/request-fields.adoc[]
+include::{snippets}/record-controller-test/기록_생성_성공/http-response.adoc[]
+include::{snippets}/record-controller-test/기록_생성_성공/response-fields.adoc[]
+
+=== 기록 수정
+기록 수정도 동일하게 업로드 완료된 이미지의 최종 `key` 목록을 `imageKeys`로 전달합니다.
+기존 이미지를 유지하려면 해당 `key`를 그대로 포함하고, 제거할 이미지는 목록에서 제외합니다.
+
+include::{snippets}/record-controller-test/기록_수정_성공/http-request.adoc[]
+include::{snippets}/record-controller-test/기록_수정_성공/request-headers.adoc[]
+include::{snippets}/record-controller-test/기록_수정_성공/path-parameters.adoc[]
+include::{snippets}/record-controller-test/기록_수정_성공/request-fields.adoc[]
+include::{snippets}/record-controller-test/기록_수정_성공/http-response.adoc[]
+include::{snippets}/record-controller-test/기록_수정_성공/response-fields.adoc[]
+
+=== 기록 삭제
+include::{snippets}/record-controller-test/기록_삭제_성공/http-request.adoc[]
+include::{snippets}/record-controller-test/기록_삭제_성공/request-headers.adoc[]
+include::{snippets}/record-controller-test/기록_삭제_성공/path-parameters.adoc[]
+include::{snippets}/record-controller-test/기록_삭제_성공/http-response.adoc[]
+include::{snippets}/record-controller-test/기록_삭제_성공/response-fields.adoc[]
+
+=== 기록 전체 개수 조회
+include::{snippets}/record-controller-test/기록_전체개수_조회_성공/http-request.adoc[]
+include::{snippets}/record-controller-test/기록_전체개수_조회_성공/request-headers.adoc[]
+include::{snippets}/record-controller-test/기록_전체개수_조회_성공/http-response.adoc[]
+include::{snippets}/record-controller-test/기록_전체개수_조회_성공/response-fields.adoc[]

--- a/src/docs/asciidoc/reading-record.adoc
+++ b/src/docs/asciidoc/reading-record.adoc
@@ -3,6 +3,7 @@
 === 기록 생성
 이미지 파일은 먼저 이미지 업로드 API로 업로드한 뒤, 발급받은 `key` 목록을 `imageKeys`로 전달합니다.
 `presigned URL` 자체를 기록 생성 요청에 넣지 않습니다.
+즉 프론트 순서는 `uploadUrl 받기 -> uploadUrl로 PUT 업로드 -> key를 기록 생성 API에 전달` 입니다.
 
 include::{snippets}/record-controller-test/기록_생성_성공/http-request.adoc[]
 include::{snippets}/record-controller-test/기록_생성_성공/request-headers.adoc[]
@@ -14,6 +15,7 @@ include::{snippets}/record-controller-test/기록_생성_성공/response-fields.
 === 기록 수정
 기록 수정도 동일하게 업로드 완료된 이미지의 최종 `key` 목록을 `imageKeys`로 전달합니다.
 기존 이미지를 유지하려면 해당 `key`를 그대로 포함하고, 제거할 이미지는 목록에서 제외합니다.
+즉 프론트는 새 이미지가 필요하면 먼저 `uploadUrl`을 발급받고 `PUT` 업로드를 끝낸 뒤, 최종 `imageKeys` 목록을 만들어 수정 API에 전달해야 합니다.
 
 include::{snippets}/record-controller-test/기록_수정_성공/http-request.adoc[]
 include::{snippets}/record-controller-test/기록_수정_성공/request-headers.adoc[]

--- a/src/main/generated/app/nook/library/domain/QLibrary.java
+++ b/src/main/generated/app/nook/library/domain/QLibrary.java
@@ -50,6 +50,8 @@ public class QLibrary extends EntityPathBase<Library> {
 
     public final app.nook.user.domain.QUser user;
 
+    public final NumberPath<Long> version = createNumber("version", Long.class);
+
     public QLibrary(String variable) {
         this(Library.class, forVariable(variable), INITS);
     }

--- a/src/main/generated/app/nook/record/domain/QRecord.java
+++ b/src/main/generated/app/nook/record/domain/QRecord.java
@@ -1,0 +1,65 @@
+package app.nook.record.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QRecord is a Querydsl query type for Record
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QRecord extends EntityPathBase<Record> {
+
+    private static final long serialVersionUID = -1934363038L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QRecord record = new QRecord("record");
+
+    public final app.nook.global.common.QBaseEntity _super = new app.nook.global.common.QBaseEntity(this);
+
+    public final StringPath content = createString("content");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdDate = _super.createdDate;
+
+    public final EnumPath<app.nook.record.domain.enums.Emotion> emotion = createEnum("emotion", app.nook.record.domain.enums.Emotion.class);
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final ListPath<RecordImage, QRecordImage> images = this.<RecordImage, QRecordImage>createList("images", RecordImage.class, QRecordImage.class, PathInits.DIRECT2);
+
+    public final app.nook.library.domain.QLibrary library;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> modifiedDate = _super.modifiedDate;
+
+    public QRecord(String variable) {
+        this(Record.class, forVariable(variable), INITS);
+    }
+
+    public QRecord(Path<? extends Record> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QRecord(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QRecord(PathMetadata metadata, PathInits inits) {
+        this(Record.class, metadata, inits);
+    }
+
+    public QRecord(Class<? extends Record> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.library = inits.isInitialized("library") ? new app.nook.library.domain.QLibrary(forProperty("library"), inits.get("library")) : null;
+    }
+
+}
+

--- a/src/main/generated/app/nook/record/domain/QRecordImage.java
+++ b/src/main/generated/app/nook/record/domain/QRecordImage.java
@@ -1,0 +1,65 @@
+package app.nook.record.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QRecordImage is a Querydsl query type for RecordImage
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QRecordImage extends EntityPathBase<RecordImage> {
+
+    private static final long serialVersionUID = -557289447L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QRecordImage recordImage = new QRecordImage("recordImage");
+
+    public final app.nook.global.common.QBaseEntity _super = new app.nook.global.common.QBaseEntity(this);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdDate = _super.createdDate;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath imageUrl = createString("imageUrl");
+
+    public final StringPath key = createString("key");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> modifiedDate = _super.modifiedDate;
+
+    public final NumberPath<Integer> orderIndex = createNumber("orderIndex", Integer.class);
+
+    public final QRecord record;
+
+    public QRecordImage(String variable) {
+        this(RecordImage.class, forVariable(variable), INITS);
+    }
+
+    public QRecordImage(Path<? extends RecordImage> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QRecordImage(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QRecordImage(PathMetadata metadata, PathInits inits) {
+        this(RecordImage.class, metadata, inits);
+    }
+
+    public QRecordImage(Class<? extends RecordImage> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.record = inits.isInitialized("record") ? new QRecord(forProperty("record"), inits.get("record")) : null;
+    }
+
+}
+

--- a/src/main/java/app/nook/global/config/S3Config.java
+++ b/src/main/java/app/nook/global/config/S3Config.java
@@ -1,0 +1,53 @@
+package app.nook.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+import java.net.URI;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloudflare.r2.endpoint}")
+    private String endpoint;
+
+    @Value("${cloudflare.r2.access-key}")
+    private String accessKey;
+
+    @Value("${cloudflare.r2.secret-key}")
+    private String secretKey;
+
+    /** S3Presigner
+     *  SDK 기본 주소 강제로 변경, URI 객체로 바꾸는 방법 사용
+     */
+    @Bean
+    public S3Presigner s3Presigner() {
+        return S3Presigner.builder()
+                .endpointOverride(URI.create(endpoint))
+                .region(Region.of("auto"))
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(accessKey,secretKey)
+                ))
+                .build();
+    }
+
+    @Bean
+    public S3Client s3Client() {
+        return S3Client.builder()
+                .endpointOverride(URI.create(endpoint))
+                .region(Region.of("auto"))
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(accessKey,secretKey)
+                ))
+                .build();
+
+    }
+
+
+}

--- a/src/main/java/app/nook/global/config/WebSecurityConfig.java
+++ b/src/main/java/app/nook/global/config/WebSecurityConfig.java
@@ -58,8 +58,7 @@ public class WebSecurityConfig {
                                 "/index.html",
                                 "/api/auth/**",
                                 "/ws/**",
-                                "/uploads/**",            // TODO: 임시 로컬 이미지 업로드용, 추후 S3로 변경 예정
-                                "/api/images/**" // 이미지 업로드
+                                "/uploads/**"         // TODO: 임시 로컬 이미지 업로드용, 추후 S3로 변경 예정
                         ).permitAll()
                         .requestMatchers("/api/**").authenticated()
                         .anyRequest().authenticated()

--- a/src/main/java/app/nook/global/config/WebSecurityConfig.java
+++ b/src/main/java/app/nook/global/config/WebSecurityConfig.java
@@ -58,7 +58,8 @@ public class WebSecurityConfig {
                                 "/index.html",
                                 "/api/auth/**",
                                 "/ws/**",
-                                "/uploads/**"            // TODO: 임시 로컬 이미지 업로드용, 추후 S3로 변경 예정
+                                "/uploads/**",            // TODO: 임시 로컬 이미지 업로드용, 추후 S3로 변경 예정
+                                "/api/images/**" // 이미지 업로드
                         ).permitAll()
                         .requestMatchers("/api/**").authenticated()
                         .anyRequest().authenticated()
@@ -99,4 +100,3 @@ public class WebSecurityConfig {
         return source;
     }
 }
-

--- a/src/main/java/app/nook/global/exception/ExceptionAdvice.java
+++ b/src/main/java/app/nook/global/exception/ExceptionAdvice.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
@@ -19,6 +20,7 @@ import org.springframework.web.context.request.ServletWebRequest;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
+import jakarta.persistence.OptimisticLockException;
 import java.time.LocalDate;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -116,6 +118,19 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
         ApiResponse<Object> body = ApiResponse.onFailure(ErrorCode.INVALID_REQUEST, errors);
         return handleExceptionInternal(
                 e, body, new HttpHeaders(), ErrorCode.INVALID_REQUEST.getHttpStatus(), request
+        );
+    }
+
+    @ExceptionHandler({OptimisticLockException.class, ObjectOptimisticLockingFailureException.class})
+    public ResponseEntity<Object> handleOptimisticLockException(Exception e, HttpServletRequest request) {
+        ApiResponse<Object> body = ApiResponse.onFailure(ErrorCode.CONCURRENT_MODIFICATION, null);
+        WebRequest webRequest = new ServletWebRequest(request);
+        return handleExceptionInternal(
+                e,
+                body,
+                new HttpHeaders(),
+                ErrorCode.CONCURRENT_MODIFICATION.getHttpStatus(),
+                webRequest
         );
     }
 }

--- a/src/main/java/app/nook/global/response/ErrorCode.java
+++ b/src/main/java/app/nook/global/response/ErrorCode.java
@@ -14,10 +14,61 @@ public enum ErrorCode implements BaseCode {
     INVALID_DATE(HttpStatus.BAD_REQUEST, "DATE-001", "유효하지 않은 날짜입니다."),
     INVALID_FORMAT(HttpStatus.BAD_REQUEST, "FORMAT-001", "형식이 올바르지 않습니다."),
     JSON_PARSE_ERROR(HttpStatus.BAD_REQUEST, "COMMON-003", "JSON 파싱에 실패했습니다."),
-    CONCURRENT_MODIFICATION(HttpStatus.CONFLICT, "COMMON-004", "동시 수정 충돌이 발생했습니다. 잠시 후 다시 시도해주세요.");
-    
+    CONCURRENT_MODIFICATION(HttpStatus.CONFLICT, "COMMON-004", "동시 수정 충돌이 발생했습니다. 잠시 후 다시 시도해주세요."),
+
+    // 사용자
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "ACCOUNT-001", "사용자를 찾을 수 없습니다."),
+    DUPLICATE_NAME(HttpStatus.CONFLICT, "ACCOUNT-002", "중복된 닉네임입니다."),
+    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "ACCOUNT-003", "비밀번호가 유효하지 않습니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "ACCOUNT-004", "유효하지 않는 리프레시 토큰입니다."),
+    INVALID_TOKEN(HttpStatus.BAD_REQUEST, "ACCOUNT-005", "유효하지 않는 토큰입니다."),
+    TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "ACCOUNT-006", "토큰이 만료되었습니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "ACCOUNT-007", "인증이 필요합니다."),
+    EMAIL_DUPLICATE(HttpStatus.CONFLICT, "ACCOUNT-008", "중복된 이메일입니다."),
+    PERMISSION_DENIED(HttpStatus.FORBIDDEN, "ACCOUNT-009", "권한이 없습니다."),
+    USER_INACTIVE(HttpStatus.FORBIDDEN, "ACCOUNT-010", "탈퇴한 사용자입니다."),
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "ACCOUNT-011", "리프레시 토큰을 찾을 수 없습니다."),
+    REFRESH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "ACCOUNT-012", "리프레시 토큰이 만료되었습니다."),
+    REFRESH_TOKEN_INVALID(HttpStatus.BAD_REQUEST, "ACCOUNT-013", "리프레시 토큰이 유효하지 않습니다."),
+    INVALID_OAUTH_PROVIDER(HttpStatus.BAD_REQUEST, "ACCOUNT-014", "유효하지 않은 소셜 로그인 방법입니다."),
+
+    // 서재 관련
+    DUPLICATE_BOOK_IN_SHELF(HttpStatus.CONFLICT, "BOOKSHELF-001", "이미 서재에 등록된 책입니다."),
+    ALREADY_READING(HttpStatus.CONFLICT, "BOOKSHELF-002", "이미 독서중 상태입니다."),
+    ALREADY_FINISHED(HttpStatus.CONFLICT, "BOOKSHELF-003", "완독한 책은 다시 읽기로 변경할 수 없습니다."),
+    BOOK_NOT_EXIST(HttpStatus.NOT_FOUND, "BOOKSHELF-004", "서재에 등록되지 않은 책입니다."),
+    INVALID_MONTH(HttpStatus.BAD_REQUEST, "BOOKSHELF-005", "형식이 잘못되었습니다. yyyy-MM 형식으로 입력해주세요."),
+    BOOKSHELF_IS_EMPTY(HttpStatus.NOT_FOUND, "BOOKSHELF-006", "현재 읽고 있는 책이 없습니다."),
+    ALREADY_REGISTERED_TODAY(HttpStatus.CONFLICT, "BOOK-007", "해당 날짜에는 이미 책이 등록되었습니다."),
+    INVALID_STATE(HttpStatus.BAD_REQUEST, "BOOKSHELF-008", "독서 상태를 변경할 수 없습니다."),
+    ALREADY_BOOKMARKED(HttpStatus.CONFLICT, "BOOKSHELF-009", "이미 찜한 책입니다."),
+    RECORDED_AT_REQUIRED(HttpStatus.BAD_REQUEST, "BOOKSHELF-010", "recordedAt값은 필수입니다."),
+
+    // 리딩룸 관련
+    READING_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "ROOM-001", "리딩룸을 찾을 수 없습니다."),
+    ALREADY_JOINED_READING_ROOM(HttpStatus.CONFLICT, "ROOM-002", "이미 가입한 리딩룸입니다."),
+    ROOM_CAPACITY_EXCEEDED(HttpStatus.CONFLICT, "ROOM-003", "리딩룸의 최대 인원 수를 초과했습니다."),
+    HOST_ONLY(HttpStatus.FORBIDDEN, "ROOM-004", "리딩룸의 호스트만 수행할 수 있습니다."),
+    USER_NOT_JOINED_ROOM(HttpStatus.NOT_FOUND, "ROOM-005", "리딩룸에 가입하지 않은 사용자입니다."),
+    TOO_MANY_JOINED_ROOM(HttpStatus.CONFLICT, "ROOM-006", "리딩룸은 최대 4개까지 가입 가능합니다."),
+
+    // 기록
+    RECORD_NOT_FOUND(HttpStatus.NOT_FOUND, "RECORD-001", "기록이 존재하지 않습니다."),
+    INVALID_RECORD_TYPE(HttpStatus.BAD_REQUEST, "RECORD-002", "유효하지 않은 기록 유형입니다."),
+    RECORD_NOT_EXIST(HttpStatus.NOT_FOUND, "RECORD-003", "기록이 없습니다."),
+    CHAT_RECORD_MUST_BE_COMMENT(HttpStatus.BAD_REQUEST, "RECORD-004", "감상의 경우에만 저장 가능합니다."),
+    CHAT_RECORD_NOT_FOUND(HttpStatus.NOT_FOUND, "RECORD-003", "채팅 기록이 존재하지 않습니다."),
+
+    // OAUTH
+    INVALID_OAUTH_TOKEN(HttpStatus.BAD_REQUEST, "OAUTH-001", "유효하지 않은 카카오 토큰입니다."),
+    INVALID_KAKAO_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "OAUTH-002", "유효하지 않은 카카오 리프레시 토큰입니다."),
+    INVALID_USER_ID(HttpStatus.BAD_REQUEST, "OAUTH-003", "유효하지 않은 카카오ID입니다."),
+    KAKAO_UNLINK_FAILED(HttpStatus.BAD_REQUEST, "OAUTH-004", "카카오 계정 연결 해제에 실패하였습니다."),
+
+    // GPT
+    GPT_RESPONSE_FORMAT_ERROR(HttpStatus.BAD_GATEWAY, "GPT-001", "GPT 응답 포맷이 올바르지 않습니다.");
+
     private final HttpStatus httpStatus;
     private final String code;
     private final String message;
 }
-

--- a/src/main/java/app/nook/global/response/ErrorCode.java
+++ b/src/main/java/app/nook/global/response/ErrorCode.java
@@ -14,64 +14,10 @@ public enum ErrorCode implements BaseCode {
     INVALID_DATE(HttpStatus.BAD_REQUEST, "DATE-001", "유효하지 않은 날짜입니다."),
     INVALID_FORMAT(HttpStatus.BAD_REQUEST, "FORMAT-001", "형식이 올바르지 않습니다."),
     JSON_PARSE_ERROR(HttpStatus.BAD_REQUEST, "COMMON-003", "JSON 파싱에 실패했습니다."),
-
-    // 사용자
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "ACCOUNT-001", "사용자를 찾을 수 없습니다."),
-    DUPLICATE_NAME(HttpStatus.CONFLICT, "ACCOUNT-002", "중복된 닉네임입니다."),
-    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "ACCOUNT-003", "비밀번호가 유효하지 않습니다."),
-    INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST,"ACCOUNT-004" ,"유효하지 않는 리프레시 토큰입니다." ),
-    INVALID_TOKEN(HttpStatus.BAD_REQUEST,"ACCOUNT-005" ,"유효하지 않는 토큰입니다." ),
-    TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "ACCOUNT-006", "토큰이 만료되었습니다."),
-    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "ACCOUNT-007", "인증이 필요합니다."),
-    EMAIL_DUPLICATE(HttpStatus.CONFLICT, "ACCOUNT-008", "중복된 이메일입니다."),
-    PERMISSION_DENIED(HttpStatus.FORBIDDEN, "ACCOUNT-009", "권한이 없습니다."),
-    USER_INACTIVE(HttpStatus.FORBIDDEN,"ACCOUNT-010", "탈퇴한 사용자입니다."),
-    REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "ACCOUNT-011","리프레시 토큰을 찾을 수 없습니다."),
-    REFRESH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "ACCOUNT-012","리프레시 토큰이 만료되었습니다."),
-    REFRESH_TOKEN_INVALID(HttpStatus.BAD_REQUEST, "ACCOUNT-013","리프레시 토큰이 유효하지 않습니다."),
-    INVALID_OAUTH_PROVIDER(HttpStatus.BAD_REQUEST, "ACCOUNT-014", "유효하지 않은 소셜 로그인 방법입니다." ),
-    // 서재 관련
-    DUPLICATE_BOOK_IN_SHELF(HttpStatus.CONFLICT, "BOOKSHELF-001", "이미 서재에 등록된 책입니다."),
-    ALREADY_READING(HttpStatus.CONFLICT, "BOOKSHELF-002", "이미 독서중 상태입니다."),
-    ALREADY_FINISHED(HttpStatus.CONFLICT, "BOOKSHELF-003", "완독한 책은 다시 읽기로 변경할 수 없습니다."),
-    BOOK_NOT_EXIST(HttpStatus.NOT_FOUND,"BOOKSHELF-004" ,"서재에 등록되지 않은 책입니다." ),
-    INVALID_MONTH(HttpStatus.BAD_REQUEST,"BOOKSHELF-005", "형식이 잘못되었습니다. yyyy-MM 형식으로 입력해주세요." ),
-    BOOKSHELF_IS_EMPTY(HttpStatus.NOT_FOUND, "BOOKSHELF-006", "현재 읽고 있는 책이 없습니다."),
-    ALREADY_REGISTERED_TODAY(HttpStatus.CONFLICT, "BOOK-007", "해당 날짜에는 이미 책이 등록되었습니다."),
-
-    INVALID_STATE(HttpStatus.BAD_REQUEST,"BOOKSHELF-008" , "독서 상태를 변경할 수 없습니다."),
-
-    ALREADY_BOOKMARKED(HttpStatus.CONFLICT,"BOOKSHELF-009" , "이미 찜한 책입니다."),
-    RECORDED_AT_REQUIRED(HttpStatus.BAD_REQUEST, "BOOKSHELF-010", "recordedAt값은 필수입니다."),
-
-    //리딩룸 관련
-    READING_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "ROOM-001", "리딩룸을 찾을 수 없습니다."),
-    ALREADY_JOINED_READING_ROOM(HttpStatus.CONFLICT, "ROOM-002", "이미 가입한 리딩룸입니다."),
-    ROOM_CAPACITY_EXCEEDED(HttpStatus.CONFLICT, "ROOM-003", "리딩룸의 최대 인원 수를 초과했습니다."),
-    HOST_ONLY(HttpStatus.FORBIDDEN, "ROOM-004" ,"리딩룸의 호스트만 수행할 수 있습니다." ),
-    USER_NOT_JOINED_ROOM(HttpStatus.NOT_FOUND, "ROOM-005" ,"리딩룸에 가입하지 않은 사용자입니다." ),
-    TOO_MANY_JOINED_ROOM(HttpStatus.CONFLICT, "ROOM-006", "리딩룸은 최대 4개까지 가입 가능합니다." ),
-
-
-    // 기록
-    RECORD_NOT_FOUND(HttpStatus.NOT_FOUND, "RECORD-001","기록이 존재하지 않습니다." ),
-    INVALID_RECORD_TYPE(HttpStatus.BAD_REQUEST, "RECORD-002", "유효하지 않은 기록 유형입니다."),
-    RECORD_NOT_EXIST(HttpStatus.NOT_FOUND, "RECORD-003","기록이 없습니다." ),
-    CHAT_RECORD_MUST_BE_COMMENT(HttpStatus.BAD_REQUEST,"RECORD-004","감상의 경우에만 저장 가능합니다." ),
-
-    CHAT_RECORD_NOT_FOUND(HttpStatus.NOT_FOUND,"RECORD-003","채팅 기록이 존재하지 않습니다." ),
-
-
-    // OAUTH
-    INVALID_OAUTH_TOKEN(HttpStatus.BAD_REQUEST, "OAUTH-001", "유효하지 않은 카카오 토큰입니다."),
-    INVALID_KAKAO_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "OAUTH-002", "유효하지 않은 카카오 리프레시 토큰입니다."),
-    INVALID_USER_ID(HttpStatus.BAD_REQUEST,"OAUTH-003","유효하지 않은 카카오ID입니다."),
-    KAKAO_UNLINK_FAILED(HttpStatus.BAD_REQUEST,"OAUTH-004","카카오 계정 연결 해제에 실패하였습니다." ),
-
-    // GPT
-    GPT_RESPONSE_FORMAT_ERROR(HttpStatus.BAD_GATEWAY, "GPT-001", "GPT 응답 포맷이 올바르지 않습니다.");
-
+    CONCURRENT_MODIFICATION(HttpStatus.CONFLICT, "COMMON-004", "동시 수정 충돌이 발생했습니다. 잠시 후 다시 시도해주세요.");
+    
     private final HttpStatus httpStatus;
     private final String code;
     private final String message;
 }
+

--- a/src/main/java/app/nook/global/response/FileErrorCode.java
+++ b/src/main/java/app/nook/global/response/FileErrorCode.java
@@ -14,7 +14,7 @@ public enum  FileErrorCode implements BaseCode {
     FILE_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "FILE-501", "파일 삭제에 실패했습니다."),
     INVALID_FILE_TYPE(HttpStatus.BAD_REQUEST, "FILE-400", "유효하지 않은 파일 형식입니다."),
     FILE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "FILE-401", "파일 크기가 허용된 최대 크기를 초과했습니다."),
-    FILE_NUM_EXCEEDED(HttpStatus.BAD_REQUEST, "FILE-401", "파일 개수가 허용된 최대 개수를 초과했습니다."),
+    FILE_NUM_EXCEEDED(HttpStatus.BAD_REQUEST, "FILE-402", "파일 개수가 허용된 최대 개수를 초과했습니다."),
     FILE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "FILE-403","파일 접근 권한이 없습니다." );
 
 

--- a/src/main/java/app/nook/global/response/FileErrorCode.java
+++ b/src/main/java/app/nook/global/response/FileErrorCode.java
@@ -1,0 +1,24 @@
+package app.nook.global.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+
+@Getter
+@AllArgsConstructor
+public enum  FileErrorCode implements BaseCode {
+
+    FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "FILE-404", "파일을 찾을 수 없습니다."),
+    FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "FILE-500", "파일 업로드에 실패했습니다."),
+    FILE_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "FILE-501", "파일 삭제에 실패했습니다."),
+    INVALID_FILE_TYPE(HttpStatus.BAD_REQUEST, "FILE-400", "유효하지 않은 파일 형식입니다."),
+    FILE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "FILE-401", "파일 크기가 허용된 최대 크기를 초과했습니다."),
+    FILE_NUM_EXCEEDED(HttpStatus.BAD_REQUEST, "FILE-401", "파일 개수가 허용된 최대 개수를 초과했습니다."),
+    FILE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "FILE-403","파일 접근 권한이 없습니다." );
+
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/app/nook/library/controller/LibraryController.java
+++ b/src/main/java/app/nook/library/controller/LibraryController.java
@@ -117,4 +117,5 @@ public class LibraryController {
             return ApiResponse.onSuccess(null, SuccessCode.NO_CONTENT);
         return ApiResponse.onSuccess(response, SuccessCode.OK);
     }
+
 }

--- a/src/main/java/app/nook/library/domain/Library.java
+++ b/src/main/java/app/nook/library/domain/Library.java
@@ -73,6 +73,9 @@ public class Library extends BaseEntity {
     @Column(name = "page")
     private int page = 0;
 
+    @Version
+    private Long version;
+
     @Builder
     public Library(
             User user,

--- a/src/main/java/app/nook/library/repository/LibraryRepository.java
+++ b/src/main/java/app/nook/library/repository/LibraryRepository.java
@@ -5,10 +5,12 @@ import app.nook.book.domain.enums.MallType;
 import app.nook.library.domain.Library;
 import app.nook.library.domain.enums.ReadingStatus;
 import app.nook.user.domain.User;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -18,6 +20,18 @@ import java.util.Set;
 public interface LibraryRepository extends JpaRepository<Library,Long> {
 
     Library findByUserAndBook(User user, Book book);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+        select l
+        from Library l
+        where l.id = :libraryId
+          and l.user.id = :userId
+    """)
+    java.util.Optional<Library> findByIdAndUserIdForUpdate(
+            @Param("libraryId") Long libraryId,
+            @Param("userId") Long userId
+    );
 
 
     @Query("""

--- a/src/main/java/app/nook/r2/controller/ImageUploadController.java
+++ b/src/main/java/app/nook/r2/controller/ImageUploadController.java
@@ -1,0 +1,46 @@
+package app.nook.r2.controller;
+
+import app.nook.r2.dto.ImageUploadRequestDto;
+import app.nook.r2.dto.ImageUrlResponseDto;
+import app.nook.r2.dto.MultipleImageUploadRequestDto;
+import app.nook.global.response.ApiResponse;
+import app.nook.global.response.SuccessCode;
+import app.nook.r2.service.PresignedUrlService;
+import app.nook.user.service.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/images")
+public class ImageUploadController {
+
+    private final PresignedUrlService presignedUrlService;
+
+    // 단건 업로드
+    @PostMapping("/upload-url")
+    public ApiResponse<ImageUrlResponseDto> issueUploadUrl(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody ImageUploadRequestDto requestDto
+    ) {
+        return ApiResponse.onSuccess(
+                presignedUrlService.generateUploadUrl(userDetails.getUser().getId(), requestDto),
+                SuccessCode.OK
+        );
+    }
+
+    // 다건 업로드
+    @PostMapping("/upload-urls")
+    public ApiResponse<List<ImageUrlResponseDto>> issueUploadUrls(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody MultipleImageUploadRequestDto requestDto
+    ) {
+        return ApiResponse.onSuccess(
+                presignedUrlService.generateMultipleUploadUrls(userDetails.getUser().getId(), requestDto.files()),
+                SuccessCode.OK
+        );
+    }
+}

--- a/src/main/java/app/nook/r2/controller/ImageUploadController.java
+++ b/src/main/java/app/nook/r2/controller/ImageUploadController.java
@@ -7,6 +7,7 @@ import app.nook.global.response.ApiResponse;
 import app.nook.global.response.SuccessCode;
 import app.nook.r2.service.PresignedUrlService;
 import app.nook.user.service.CustomUserDetails;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -24,7 +25,7 @@ public class ImageUploadController {
     @PostMapping("/upload-url")
     public ApiResponse<ImageUrlResponseDto> issueUploadUrl(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @RequestBody ImageUploadRequestDto requestDto
+            @Valid @RequestBody ImageUploadRequestDto requestDto
     ) {
         return ApiResponse.onSuccess(
                 presignedUrlService.generateUploadUrl(userDetails.getUser().getId(), requestDto),
@@ -36,7 +37,7 @@ public class ImageUploadController {
     @PostMapping("/upload-urls")
     public ApiResponse<List<ImageUrlResponseDto>> issueUploadUrls(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @RequestBody MultipleImageUploadRequestDto requestDto
+            @Valid @RequestBody MultipleImageUploadRequestDto requestDto
     ) {
         return ApiResponse.onSuccess(
                 presignedUrlService.generateMultipleUploadUrls(userDetails.getUser().getId(), requestDto.files()),

--- a/src/main/java/app/nook/r2/dto/ImageUploadRequestDto.java
+++ b/src/main/java/app/nook/r2/dto/ImageUploadRequestDto.java
@@ -1,7 +1,14 @@
 package app.nook.r2.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 
 public record ImageUploadRequestDto(
+        @NotBlank(message = "contentType은 필수입니다.")
+        @Pattern(
+                regexp = "^(book|record|profile)$",
+                message = "contentType은 book, record, profile 중 하나여야 합니다."
+        )
         String contentType
-){
+) {
 }

--- a/src/main/java/app/nook/r2/dto/ImageUploadRequestDto.java
+++ b/src/main/java/app/nook/r2/dto/ImageUploadRequestDto.java
@@ -1,0 +1,7 @@
+package app.nook.r2.dto;
+
+
+public record ImageUploadRequestDto(
+        String contentType
+){
+}

--- a/src/main/java/app/nook/r2/dto/ImageUrlResponseDto.java
+++ b/src/main/java/app/nook/r2/dto/ImageUrlResponseDto.java
@@ -1,0 +1,6 @@
+package app.nook.r2.dto;
+
+public record ImageUrlResponseDto (
+        String imageUrl,
+        String key
+){}

--- a/src/main/java/app/nook/r2/dto/ImageUrlResponseDto.java
+++ b/src/main/java/app/nook/r2/dto/ImageUrlResponseDto.java
@@ -1,6 +1,10 @@
 package app.nook.r2.dto;
 
+import jakarta.validation.constraints.NotNull;
+
 public record ImageUrlResponseDto (
+        @NotNull(message = "url은 필수입니다.")
         String imageUrl,
+        @NotNull(message = "key는 필수입니다.")
         String key
 ){}

--- a/src/main/java/app/nook/r2/dto/MultipleImageUploadRequestDto.java
+++ b/src/main/java/app/nook/r2/dto/MultipleImageUploadRequestDto.java
@@ -1,8 +1,13 @@
 package app.nook.r2.dto;
 
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+
 import java.util.List;
 
 public record MultipleImageUploadRequestDto(
+        @NotEmpty(message = "files는 최소 1개 이상이어야 합니다.")
+        @Valid
         List<ImageUploadRequestDto> files
 ) {
 }

--- a/src/main/java/app/nook/r2/dto/MultipleImageUploadRequestDto.java
+++ b/src/main/java/app/nook/r2/dto/MultipleImageUploadRequestDto.java
@@ -1,0 +1,8 @@
+package app.nook.r2.dto;
+
+import java.util.List;
+
+public record MultipleImageUploadRequestDto(
+        List<ImageUploadRequestDto> files
+) {
+}

--- a/src/main/java/app/nook/r2/service/PresignedUrlService.java
+++ b/src/main/java/app/nook/r2/service/PresignedUrlService.java
@@ -1,0 +1,273 @@
+package app.nook.r2.service;
+
+import app.nook.r2.dto.ImageUploadRequestDto;
+import app.nook.r2.dto.ImageUrlResponseDto;
+import app.nook.global.exception.CustomException;
+import app.nook.global.response.FileErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.*;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class PresignedUrlService {
+
+
+    // 만료 시간 필수 지정
+    private static final int EXPIRATION_SECONDS = 300;
+    private static final String FIXED_IMAGE_MIME_TYPE = "image/png";
+    private static final long MAX_FILE_SIZE_BYTES = 5 * 1024 * 1024L;
+    private static final int MAX_FILE_COUNT = 5;
+
+    private final S3Presigner s3Presigner;
+
+    private final S3Client s3Client;
+
+    @Value("${cloudflare.r2.bucket-name}")
+    private String bucketName;
+
+    private static final Set<String> ALLOWED = Set.of(
+            "book", "profile", "record"
+    );
+    private static final Map<String, String> MIME_TO_EXTENSION = Map.of(
+            "image/png", ".png",
+            "image/jpeg", ".jpg",
+            "image/jpg", ".jpg",
+            "image/webp", ".webp",
+            "image/gif", ".gif"
+    );
+
+
+    // presigned 다운로드
+    public ImageUrlResponseDto getPresignedUrl(String key) {
+        GetObjectRequest objectRequest = GetObjectRequest.builder()
+                .bucket(bucketName)
+                .key(key)
+                .build();
+        GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
+                .signatureDuration(Duration.ofSeconds(EXPIRATION_SECONDS))
+                .getObjectRequest(objectRequest)
+                .build();
+        return new ImageUrlResponseDto(
+                s3Presigner.presignGetObject(presignRequest).url().toString(),
+                key
+        );
+    }
+
+    // 업로드 - 단건
+    public ImageUrlResponseDto generateUploadUrl(Long userId, ImageUploadRequestDto requestDto){
+        NormalizedUpload normalized = validateAndNormalizeUploadRequest(requestDto);
+        String key = buildObjectKey(userId, normalized.contentType(), normalized.extension());
+        return generateUploadUrl(key, normalized.contentType());
+    }
+
+    // 키, 타입 기반으로 url을 생성
+    private ImageUrlResponseDto generateUploadUrl(String key, String contentType) {
+        normalizeAndValidateContentType(contentType);
+        PutObjectRequest request = PutObjectRequest.builder()
+                .bucket(bucketName)
+                .key(key)
+                .contentType(FIXED_IMAGE_MIME_TYPE)
+                .build();
+        PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()
+                .putObjectRequest(request)
+                .signatureDuration(Duration.ofSeconds(EXPIRATION_SECONDS))
+                .build();
+        return new ImageUrlResponseDto(
+                s3Presigner.presignPutObject(presignRequest).url().toString(),
+                key
+        );
+    }
+
+    // 조회
+    public String getImageUrl(Long userId, String key) {
+        ParsedKey parsedKey = parseKey(key);
+        if (!exists(key)) {
+            throw new CustomException(FileErrorCode.FILE_NOT_FOUND);
+        }
+        validateFileSizeByMetadata(key);
+
+        if ("record".equals(parsedKey.contentType())) {
+            if (!isRecordOwner(userId, parsedKey.ownerUserId())) {
+                throw new CustomException(FileErrorCode.FILE_NOT_FOUND);
+            }
+        }
+        return getPresignedUrl(key).imageUrl();
+    }
+
+
+    // 삭제
+     public void deleteFile(String key) {
+         // 파일 존재 여부 확인
+         if (!exists(key)) {
+             throw new CustomException(FileErrorCode.FILE_NOT_FOUND);
+         }
+
+         // 파일 삭제
+         DeleteObjectRequest request = DeleteObjectRequest.builder()
+                 .bucket(bucketName)
+                 .key(key)
+                 .build();
+         s3Client.deleteObject(request);
+     }
+
+     // 파일 수정 - 업로드된 기존 이미지를 삭제하고 새 이미지 업로드
+     public ImageUrlResponseDto updateFile(Long userId, String key, ImageUploadRequestDto requestDto) {
+         deleteFile(key);
+         return generateUploadUrl(userId, requestDto);
+     }
+
+     // 사진 여러장 업로드
+     public List<ImageUrlResponseDto> generateMultipleUploadUrls(Long userId, List<ImageUploadRequestDto> requestDtos) {
+         validateUserId(userId);
+         if (requestDtos == null || requestDtos.isEmpty()) {
+             return List.of();
+         }
+         validateUploadRequests(requestDtos);
+
+         return requestDtos.stream()
+                 .map(requestDto -> {
+                     NormalizedUpload normalized = validateAndNormalizeUploadRequest(requestDto);
+                     String key = buildObjectKey(userId, normalized.contentType(), normalized.extension());
+                     return generateUploadUrl(key, normalized.contentType());
+                 })
+                 .toList();
+     }
+
+
+    /*  Util, 검증 메서드 */
+
+    // 타입/확장자 정규화 + 검증
+    private NormalizedUpload validateAndNormalizeUploadRequest(ImageUploadRequestDto requestDto) {
+        if (requestDto == null) {
+            throw new CustomException(FileErrorCode.INVALID_FILE_TYPE);
+        }
+        String normalizedContentType = normalizeAndValidateContentType(requestDto.contentType());
+        String extension = resolveExtension(FIXED_IMAGE_MIME_TYPE);
+        return new NormalizedUpload(normalizedContentType, extension);
+    }
+
+    private void validateUploadRequests(List<ImageUploadRequestDto> requestDtos) {
+        if (requestDtos == null || requestDtos.isEmpty()) {
+            return;
+        }
+
+        if (requestDtos.size() > MAX_FILE_COUNT) {
+            throw new CustomException(FileErrorCode.FILE_NUM_EXCEEDED);
+        }
+
+        requestDtos.forEach(this::validateAndNormalizeUploadRequest);
+    }
+
+    private void validateUserId(Long userId) {
+        if (userId == null || userId <= 0) {
+            throw new CustomException(FileErrorCode.INVALID_FILE_TYPE);
+        }
+    }
+
+    // 타입 정규화, 검증
+    private String normalizeAndValidateContentType(String contentType) {
+        if (contentType == null) {
+            throw new CustomException(FileErrorCode.INVALID_FILE_TYPE);
+        }
+        String normalized = contentType.trim().toLowerCase(Locale.ROOT);
+        if (!ALLOWED.contains(normalized)) {
+            throw new CustomException(FileErrorCode.INVALID_FILE_TYPE);
+        }
+        return normalized;
+    }
+
+    private String resolveExtension(String mimeType) {
+        return MIME_TO_EXTENSION.getOrDefault(mimeType, ".png");
+    }
+
+    // 고유 키 생성
+     private String buildObjectKey(Long userId, String contentType, String extension) {
+         String uuid = UUID.randomUUID().toString();
+         if ("record".equals(contentType) && userId != null) {
+             return "record/users/" + userId + "/" + uuid + extension;
+         }
+         return contentType + "/" + uuid + extension;
+     }
+
+    // 파일 존재 여부 확인 - 메타데이터 확인
+    public boolean exists(String key) {
+        try {
+            HeadObjectRequest request = HeadObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(key)
+                    .build();
+
+            s3Client.headObject(request);
+            return true;
+
+        } catch (NoSuchKeyException e) {
+            return false;
+        }
+    }
+
+    // S3 메타데이터 기반 파일 크기 검증
+    private void validateFileSizeByMetadata(String key) {
+        HeadObjectRequest request = HeadObjectRequest.builder()
+                .bucket(bucketName)
+                .key(key)
+                .build();
+        HeadObjectResponse response = s3Client.headObject(request);
+        Long contentLength = response.contentLength();
+        if (contentLength != null && contentLength > MAX_FILE_SIZE_BYTES) {
+            throw new CustomException(FileErrorCode.FILE_SIZE_EXCEEDED);
+        }
+    }
+
+    // key에서 타입 파싱
+    private ParsedKey parseKey(String key) {
+        if (key == null || key.isBlank()) {
+            throw new CustomException(FileErrorCode.INVALID_FILE_TYPE);
+        }
+
+        String[] parts = key.split("/");
+        if (parts.length == 2) {
+            String type = parts[0];
+            if (!ALLOWED.contains(type) || "record".equals(type)) {
+                throw new CustomException(FileErrorCode.INVALID_FILE_TYPE);
+            }
+            return new ParsedKey(type, null);
+        }
+
+        // record/users/{userId}/{uuid}.png
+        if (parts.length == 4 && "record".equals(parts[0]) && "users".equals(parts[1])) {
+            Long ownerUserId;
+            try {
+                ownerUserId = Long.parseLong(parts[2]);
+            } catch (NumberFormatException e) {
+                throw new CustomException(FileErrorCode.INVALID_FILE_TYPE);
+            }
+            return new ParsedKey("record", ownerUserId);
+        }
+
+        throw new CustomException(FileErrorCode.INVALID_FILE_TYPE);
+    }
+
+    private boolean isRecordOwner(Long userId, Long ownerUserId) {
+        if (userId == null || ownerUserId == null) {
+            return false;
+        }
+        return userId.equals(ownerUserId);
+    }
+
+    private record NormalizedUpload(String contentType, String extension) {}
+    private record ParsedKey(String contentType, Long ownerUserId) {}
+
+}

--- a/src/main/java/app/nook/r2/service/PresignedUrlService.java
+++ b/src/main/java/app/nook/r2/service/PresignedUrlService.java
@@ -16,7 +16,6 @@ import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignReques
 import java.time.Duration;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
@@ -27,7 +26,9 @@ public class PresignedUrlService {
 
     // 만료 시간 필수 지정
     private static final int EXPIRATION_SECONDS = 300;
+    // 현재 업로드 정책은 PNG만 지원한다.
     private static final String FIXED_IMAGE_MIME_TYPE = "image/png";
+    private static final String FIXED_IMAGE_EXTENSION = ".png";
     private static final long MAX_FILE_SIZE_BYTES = 5 * 1024 * 1024L;
     private static final int MAX_FILE_COUNT = 5;
 
@@ -40,13 +41,6 @@ public class PresignedUrlService {
 
     private static final Set<String> ALLOWED = Set.of(
             "book", "profile", "record"
-    );
-    private static final Map<String, String> MIME_TO_EXTENSION = Map.of(
-            "image/png", ".png",
-            "image/jpeg", ".jpg",
-            "image/jpg", ".jpg",
-            "image/webp", ".webp",
-            "image/gif", ".gif"
     );
 
 
@@ -70,12 +64,11 @@ public class PresignedUrlService {
     public ImageUrlResponseDto generateUploadUrl(Long userId, ImageUploadRequestDto requestDto){
         NormalizedUpload normalized = validateAndNormalizeUploadRequest(requestDto);
         String key = buildObjectKey(userId, normalized.contentType(), normalized.extension());
-        return generateUploadUrl(key, normalized.contentType());
+        return generateUploadUrl(key);
     }
 
-    // 키, 타입 기반으로 url을 생성
-    private ImageUrlResponseDto generateUploadUrl(String key, String contentType) {
-        normalizeAndValidateContentType(contentType);
+    // 키 기반으로 presigned 업로드 url을 생성
+    private ImageUrlResponseDto generateUploadUrl(String key) {
         PutObjectRequest request = PutObjectRequest.builder()
                 .bucket(bucketName)
                 .key(key)
@@ -141,7 +134,7 @@ public class PresignedUrlService {
                  .map(requestDto -> {
                      NormalizedUpload normalized = validateAndNormalizeUploadRequest(requestDto);
                      String key = buildObjectKey(userId, normalized.contentType(), normalized.extension());
-                     return generateUploadUrl(key, normalized.contentType());
+                     return generateUploadUrl(key);
                  })
                  .toList();
      }
@@ -155,7 +148,7 @@ public class PresignedUrlService {
             throw new CustomException(FileErrorCode.INVALID_FILE_TYPE);
         }
         String normalizedContentType = normalizeAndValidateContentType(requestDto.contentType());
-        String extension = resolveExtension(FIXED_IMAGE_MIME_TYPE);
+        String extension = FIXED_IMAGE_EXTENSION;
         return new NormalizedUpload(normalizedContentType, extension);
     }
 
@@ -187,10 +180,6 @@ public class PresignedUrlService {
             throw new CustomException(FileErrorCode.INVALID_FILE_TYPE);
         }
         return normalized;
-    }
-
-    private String resolveExtension(String mimeType) {
-        return MIME_TO_EXTENSION.getOrDefault(mimeType, ".png");
     }
 
     // 고유 키 생성

--- a/src/main/java/app/nook/record/controller/RecordController.java
+++ b/src/main/java/app/nook/record/controller/RecordController.java
@@ -1,0 +1,62 @@
+package app.nook.record.controller;
+
+
+import app.nook.global.response.ApiResponse;
+import app.nook.global.response.SuccessCode;
+import app.nook.record.dto.RecordRequestDto;
+import app.nook.record.dto.RecordResponseDto;
+import app.nook.record.dto.RecordUpdateRequestDto;
+import app.nook.record.service.RecordService;
+import app.nook.user.service.CustomUserDetails;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/records")
+public class RecordController {
+
+    private final RecordService recordService;
+
+    @PostMapping("/books/{bookId}")
+    public ApiResponse<Void> saveRecord(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long bookId,
+            @Valid @RequestBody RecordRequestDto requestDto
+            ) {
+        recordService.createRecord(userDetails.getUser(), bookId, requestDto);
+        return ApiResponse.onSuccess(null, SuccessCode.CREATED);
+    }
+
+    @PutMapping("/{recordId}")
+    public ApiResponse<Void> updateRecord(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long recordId,
+            @Valid @RequestBody RecordUpdateRequestDto requestDto
+    ) {
+        recordService.updateRecord(userDetails.getUser(), recordId, requestDto);
+        return ApiResponse.onSuccess(null, SuccessCode.OK);
+    }
+
+    @DeleteMapping("/{recordId}")
+    public ApiResponse<Void> deleteRecord(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long recordId
+    ) {
+        recordService.deleteRecord(userDetails.getUser(), recordId);
+        return ApiResponse.onSuccess(null, SuccessCode.OK);
+    }
+
+    @GetMapping("/count")
+    public ApiResponse<RecordResponseDto.RecordCountDto> countRecords(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        return ApiResponse.onSuccess(
+                recordService.countRecords(userDetails.getUser().getId()),
+                SuccessCode.OK
+        );
+    }
+
+}

--- a/src/main/java/app/nook/record/domain/Record.java
+++ b/src/main/java/app/nook/record/domain/Record.java
@@ -1,0 +1,59 @@
+package app.nook.record.domain;
+
+import app.nook.global.common.BaseEntity;
+import app.nook.library.domain.Library;
+import app.nook.record.domain.enums.Emotion;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(
+        name = "records",
+        indexes = {
+                @Index(
+                        name = "idx_records_library_id",
+                        columnList = "emotion, library_id DESC"
+                )
+        }
+)
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Record extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "record_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
+    @JoinColumn(name = "library_id", nullable = false)
+    private Library library;
+
+    @Enumerated(EnumType.STRING)
+    private Emotion emotion;
+
+    private String content;
+
+    @OneToMany(mappedBy = "record", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    @OrderBy("orderIndex ASC, createdDate ASC")
+    private List<RecordImage> images = new ArrayList<>();
+
+    @Builder
+    public Record(Library library, Emotion emotion, String content) {
+        this.library = library;
+        this.emotion = emotion;
+        this.content = content;
+    }
+
+    public void update(String content, Emotion emotion) {
+        this.content = content;
+        this.emotion = emotion;
+
+    }
+}

--- a/src/main/java/app/nook/record/domain/Record.java
+++ b/src/main/java/app/nook/record/domain/Record.java
@@ -40,7 +40,7 @@ public class Record extends BaseEntity {
 
     private String content;
 
-    @OneToMany(mappedBy = "record", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    @OneToMany(mappedBy = "record")
     @OrderBy("orderIndex ASC, createdDate ASC")
     private List<RecordImage> images = new ArrayList<>();
 

--- a/src/main/java/app/nook/record/domain/RecordImage.java
+++ b/src/main/java/app/nook/record/domain/RecordImage.java
@@ -1,0 +1,38 @@
+package app.nook.record.domain;
+
+
+import app.nook.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Table(name = "record_images")
+public class RecordImage extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
+    @JoinColumn(name = "record_id")
+    private Record record;
+
+    @Column(name = "image_url", length = 1000)
+    private String imageUrl;
+
+    private String key;
+
+    private Integer orderIndex;
+
+    @Builder
+    public RecordImage(Record record, String key, Integer orderIndex) {
+        this.record = record;
+        this.key = key;
+        this.orderIndex = orderIndex;
+    }
+}

--- a/src/main/java/app/nook/record/domain/enums/Emotion.java
+++ b/src/main/java/app/nook/record/domain/enums/Emotion.java
@@ -1,0 +1,7 @@
+package app.nook.record.domain.enums;
+
+public enum Emotion {
+
+    FUN, EMPATHIZING, USEFUL, COMPLICATED, SAD, UNCOMFORTABLE
+
+}

--- a/src/main/java/app/nook/record/dto/RecordRequestDto.java
+++ b/src/main/java/app/nook/record/dto/RecordRequestDto.java
@@ -1,0 +1,18 @@
+package app.nook.record.dto;
+
+import app.nook.record.domain.enums.Emotion;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import org.hibernate.validator.constraints.Length;
+
+import java.util.List;
+
+public record RecordRequestDto(
+        @NotBlank(message = "내용은 필수입니다.")
+        @Length(max = 1000, message = "내용은 최대 1000자까지 입력할 수 있습니다.") // TODO : 추후 요구사항 반영해서 수정
+        String content,
+        Emotion emotion,
+        @Size(max = 5, message = "이미지는 최대 5개까지 업로드할 수 있습니다.")
+        List<String> imageKeys
+) {
+}

--- a/src/main/java/app/nook/record/dto/RecordResponseDto.java
+++ b/src/main/java/app/nook/record/dto/RecordResponseDto.java
@@ -11,7 +11,7 @@ public class RecordResponseDto {
     }
 
     public record RecordCountDto(
-            int count
+            long count
     ) {
     }
 

--- a/src/main/java/app/nook/record/dto/RecordResponseDto.java
+++ b/src/main/java/app/nook/record/dto/RecordResponseDto.java
@@ -1,0 +1,19 @@
+package app.nook.record.dto;
+
+public class RecordResponseDto {
+
+    public record RecordDetailDto(
+            Long recordId,
+            String content,
+            String emotion,
+            String imageUrl
+    ) {
+    }
+
+    public record RecordCountDto(
+            int count
+    ) {
+    }
+
+
+}

--- a/src/main/java/app/nook/record/dto/RecordUpdateRequestDto.java
+++ b/src/main/java/app/nook/record/dto/RecordUpdateRequestDto.java
@@ -1,0 +1,18 @@
+package app.nook.record.dto;
+
+import app.nook.record.domain.enums.Emotion;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import org.hibernate.validator.constraints.Length;
+
+import java.util.List;
+
+public record RecordUpdateRequestDto(
+        @NotBlank(message = "내용은 필수입니다.")
+        @Length(max = 1000, message = "내용은 최대 1000자까지 입력할 수 있습니다.") // TODO : 추후 요구사항 반영해서 수정
+        String content,
+        Emotion emotion,
+        @Size(max = 5, message = "이미지는 최대 5개까지 업로드할 수 있습니다.")
+        List<String> imageKeys
+) {
+}

--- a/src/main/java/app/nook/record/event/RecordDeletedEvent.java
+++ b/src/main/java/app/nook/record/event/RecordDeletedEvent.java
@@ -1,0 +1,9 @@
+package app.nook.record.event;
+
+import java.util.List;
+
+public record RecordDeletedEvent(
+        Long recordId,
+        List<String> imageKeys
+) {
+}

--- a/src/main/java/app/nook/record/event/RecordDeletedEventListener.java
+++ b/src/main/java/app/nook/record/event/RecordDeletedEventListener.java
@@ -1,0 +1,30 @@
+package app.nook.record.event;
+
+import app.nook.r2.service.PresignedUrlService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RecordDeletedEventListener {
+
+    private final PresignedUrlService presignedUrlService;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void handle(RecordDeletedEvent event) {
+        for (String imageKey : event.imageKeys()) {
+            try {
+                presignedUrlService.deleteFile(imageKey);
+            } catch (Exception e) {
+                log.warn("[RECORD] R2 스토리지에서 기록 이미지 삭제 실패 recordId={}, key={}", event.recordId(), imageKey, e);
+            }
+        }
+    }
+}

--- a/src/main/java/app/nook/record/exception/RecordErrorCode.java
+++ b/src/main/java/app/nook/record/exception/RecordErrorCode.java
@@ -1,0 +1,19 @@
+package app.nook.record.exception;
+
+import app.nook.global.response.BaseCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum RecordErrorCode implements BaseCode {
+
+    RECORD_NOT_FOUND(HttpStatus.NOT_FOUND, "RECORD-404", "기록을 찾을 수 없습니다."),
+    RECORD_NOT_AUTHORIZED(HttpStatus.BAD_REQUEST,"RECORD-401", "기록 접근 권한이 없습니다." );
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+}

--- a/src/main/java/app/nook/record/exception/RecordErrorCode.java
+++ b/src/main/java/app/nook/record/exception/RecordErrorCode.java
@@ -10,7 +10,7 @@ import org.springframework.http.HttpStatus;
 public enum RecordErrorCode implements BaseCode {
 
     RECORD_NOT_FOUND(HttpStatus.NOT_FOUND, "RECORD-404", "기록을 찾을 수 없습니다."),
-    RECORD_NOT_AUTHORIZED(HttpStatus.BAD_REQUEST,"RECORD-401", "기록 접근 권한이 없습니다." );
+    RECORD_NOT_AUTHORIZED(HttpStatus.FORBIDDEN, "RECORD-403", "기록 접근 권한이 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/app/nook/record/repository/RecordImageRepository.java
+++ b/src/main/java/app/nook/record/repository/RecordImageRepository.java
@@ -1,0 +1,7 @@
+package app.nook.record.repository;
+
+import app.nook.record.domain.RecordImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RecordImageRepository extends JpaRepository<RecordImage,Long> {
+}

--- a/src/main/java/app/nook/record/repository/RecordRepository.java
+++ b/src/main/java/app/nook/record/repository/RecordRepository.java
@@ -20,9 +20,9 @@ public interface RecordRepository extends JpaRepository<Record, Long> {
 
 
     @Query("""
-        select count(r) from Record r join fetch
-        Library l where r.library.id = l.id
-                and l.user.id = :userId
+        select count(r)
+        from Record r
+        where r.library.user.id = :userId
         """)
-    int countByUserId(@Param("userId") Long userId);
+    long countByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/app/nook/record/repository/RecordRepository.java
+++ b/src/main/java/app/nook/record/repository/RecordRepository.java
@@ -1,0 +1,28 @@
+package app.nook.record.repository;
+
+import app.nook.record.domain.Record;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface RecordRepository extends JpaRepository<Record, Long> {
+
+    @Query("""
+        select count(r)
+        from Record r
+        where r.library.id = :libraryId
+          and r.library.user.id = :userId
+    """)
+    long countByLibraryIdAndUserId(
+            @Param("libraryId") Long libraryId,
+            @Param("userId") Long userId
+    );
+
+
+    @Query("""
+        select count(r) from Record r join fetch
+        Library l where r.library.id = l.id
+                and l.user.id = :userId
+        """)
+    int countByUserId(@Param("userId") Long userId);
+}

--- a/src/main/java/app/nook/record/service/RecordService.java
+++ b/src/main/java/app/nook/record/service/RecordService.java
@@ -1,0 +1,194 @@
+package app.nook.record.service;
+
+import app.nook.book.domain.Book;
+import app.nook.book.exception.BookErrorCode;
+import app.nook.book.repository.BookRepository;
+import app.nook.global.exception.CustomException;
+import app.nook.global.response.FileErrorCode;
+import app.nook.library.domain.Library;
+import app.nook.library.exception.LibraryErrorCode;
+import app.nook.library.repository.LibraryRepository;
+import app.nook.r2.service.PresignedUrlService;
+import app.nook.record.domain.Record;
+import app.nook.record.domain.RecordImage;
+import app.nook.record.dto.RecordRequestDto;
+import app.nook.record.dto.RecordResponseDto;
+import app.nook.record.dto.RecordUpdateRequestDto;
+import app.nook.record.exception.RecordErrorCode;
+import app.nook.record.repository.RecordImageRepository;
+import app.nook.record.repository.RecordRepository;
+import app.nook.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RecordService {
+
+    private final RecordRepository recordRepository;
+    private final LibraryRepository libraryRepository;
+    private final BookRepository bookRepository;
+    private final PresignedUrlService presignedUrlService;
+
+    // 기록 최대 개수 - 임의로 설정
+    // TODO : 기록 최대개수 추후 반영
+    private final int MAX_RECORD_COUNT = 1000;
+    private final RecordImageRepository recordImageRepository;
+
+    // 기록 생성
+    @Transactional
+    public void createRecord(
+            User user,
+            Long bookId,
+            RecordRequestDto requestDto
+    ) {
+        List<String> imageKeys = sanitizeImageKeys(requestDto.imageKeys());
+
+        // 책 존재 여부 확인
+        Book book = bookRepository.findById(bookId)
+                .orElseThrow(() -> new CustomException(BookErrorCode.BOOK_NOT_FOUND));
+        // 서재에 등록된 책인지 확인
+        Library library = libraryRepository.findByUserAndBook(user,book);
+        if (library == null )
+            throw new CustomException(LibraryErrorCode.BOOK_NOT_EXIST);
+
+        // 동일 서재 집계 단위 잠금, create를 같은 트랜잭션에서 수행
+        libraryRepository.findByIdAndUserIdForUpdate(library.getId(), user.getId())
+                .orElseThrow(() -> new CustomException(LibraryErrorCode.BOOK_NOT_EXIST));
+
+        // 최대 개수를 넘지 않는지 확인
+        long count = recordRepository.countByLibraryIdAndUserId(library.getId(), user.getId());
+        if (count >= MAX_RECORD_COUNT) {
+            throw new CustomException(FileErrorCode.FILE_NUM_EXCEEDED);
+        }
+
+        // 기록 생성
+        Record newRecord = new Record(
+                library,
+                requestDto.emotion(),
+                requestDto.content()
+        );
+
+        recordRepository.save(newRecord);
+
+        if (!imageKeys.isEmpty()) {
+            saveRecordImages(newRecord, imageKeys);
+        }
+    }
+
+    // 기록 수정
+    @Transactional
+    public void updateRecord(
+            User user,
+            Long recordId,
+            RecordUpdateRequestDto requestDto
+    ) {
+            List<String> requestedImageKeys = sanitizeImageKeys(requestDto.imageKeys());
+
+            // 기록 존재 여부 확인
+            Record record = recordRepository.findById(recordId)
+                    .orElseThrow(() -> new CustomException(RecordErrorCode.RECORD_NOT_FOUND));
+
+            // 기록이 속한 서재가 사용자에게 속한 서재인지 확인
+            if (!record.getLibrary().getUser().getId().equals(user.getId())) {
+                throw new CustomException(LibraryErrorCode.BOOK_NOT_EXIST);
+            }
+
+            // 기록 내용 업데이트
+            record.update(requestDto.content(), requestDto.emotion());
+
+            // 이미지 동기화 - 기존 이미지와 요청된 이미지 키를 비교하여 삭제 및 추가 처리
+            syncRecordImages(record, requestedImageKeys);
+    }
+
+    // 기록 삭제
+    @Transactional
+    public void deleteRecord(
+            User user,
+            Long recordId
+    ) {
+        // 기록 존재 여부 확인
+        Record record = recordRepository.findById(recordId)
+                .orElseThrow(() -> new CustomException(RecordErrorCode.RECORD_NOT_FOUND));
+        // 기록 소유자 확인
+        if (!record.getLibrary().getUser().getId().equals(user.getId())) {
+            throw new CustomException(RecordErrorCode.RECORD_NOT_AUTHORIZED);
+        }
+        record.getImages().stream()
+                .map(RecordImage::getKey)
+                .filter(Objects::nonNull)
+                .forEach(presignedUrlService::deleteFile);
+        record.getImages().clear();
+        recordRepository.delete(record);
+    }
+
+
+    /* 기록 조회 - 전체 */
+
+    // 기록 전체 개수 조회
+    public RecordResponseDto.RecordCountDto countRecords(Long userId) {
+        int recordCount = recordRepository.countByUserId(userId);
+        return new RecordResponseDto.RecordCountDto(recordCount);
+    }
+
+    private List<String> sanitizeImageKeys(List<String> imageKeys) {
+        if (imageKeys == null || imageKeys.isEmpty()) {
+            return List.of();
+        }
+
+        return imageKeys.stream()
+                .filter(Objects::nonNull)
+                .map(String::trim)
+                .filter(key -> !key.isBlank())
+                .toList();
+    }
+
+    // 이미지 저장 - 기록 생성, 수정 공통
+    private void saveRecordImages(Record record, List<String> imageKeys) {
+        for (int index = 0; index < imageKeys.size(); index++) {
+            recordImageRepository.save(new RecordImage(
+                    record,
+                    imageKeys.get(index),
+                    index
+            ));
+        }
+    }
+
+    private void syncRecordImages(Record record, List<String> requestedImageKeys) {
+        List<RecordImage> existingImages = new ArrayList<>(record.getImages());
+
+        // 기존 이미지 중 요청된 이미지 키에 없는 것을 삭제 - 버킷,DB에 모두 반영
+        existingImages.stream()
+                .filter(recordImage -> !requestedImageKeys.contains(recordImage.getKey()))
+                .forEach(recordImage -> {
+                    if (recordImage.getKey() != null) {
+                        presignedUrlService.deleteFile(recordImage.getKey());
+                    }
+                    record.getImages().remove(recordImage);
+                    recordImageRepository.delete(recordImage);
+                });
+
+        // 기록의 이미지 삭제
+        record.getImages().clear();
+
+        // 새로운 이미지 저장 - 순서도 반영해서 저장
+        saveRecordImages(record, requestedImageKeys);
+    }
+
+    // 기록 전체 정렬 조회 - 무한스크롤
+
+    /* 기록 조회 - 상세 */
+
+
+    // 책별 기록 리스트 조회 - 감정 or 전체 필터
+
+    // 기록 상세 조회
+
+
+}

--- a/src/main/java/app/nook/record/service/RecordService.java
+++ b/src/main/java/app/nook/record/service/RecordService.java
@@ -8,7 +8,6 @@ import app.nook.global.response.FileErrorCode;
 import app.nook.library.domain.Library;
 import app.nook.library.exception.LibraryErrorCode;
 import app.nook.library.repository.LibraryRepository;
-import app.nook.r2.service.PresignedUrlService;
 import app.nook.record.domain.Record;
 import app.nook.record.domain.RecordImage;
 import app.nook.record.dto.RecordRequestDto;
@@ -41,7 +40,6 @@ public class RecordService {
     private final BookRepository bookRepository;
     private final RecordImageRepository recordImageRepository;
     private final ApplicationEventPublisher eventPublisher;
-    private final PresignedUrlService presignedUrlService;
 
     // 기록 생성
     @Transactional
@@ -165,19 +163,31 @@ public class RecordService {
     private void syncRecordImages(Record record, List<String> requestedImageKeys) {
         List<RecordImage> existingImages = new ArrayList<>(record.getImages());
 
+        // 삭제될 이미지들을 추출
+        List<String> keysToDelete = existingImages.stream()
+                .map(RecordImage::getKey)
+                .filter(Objects::nonNull)
+                .filter(key -> !requestedImageKeys.contains(key))
+                .toList();
+
         // 기존 이미지 중 요청된 이미지 키에 없는 것들은 삭제
         existingImages.stream()
                 .filter(recordImage -> !requestedImageKeys.contains(recordImage.getKey()))
                 .forEach(recordImage -> {
-                    if (recordImage.getKey() != null) {
-                        presignedUrlService.deleteFile(recordImage.getKey());
-                    }
                     record.getImages().remove(recordImage);
                     recordImageRepository.delete(recordImage);
                 });
 
+        // 이미지 연관관계 정리
         record.getImages().clear();
+
+        // 이미지 저장
         saveRecordImages(record, requestedImageKeys);
+
+        // 삭제할 이미지가 있다면 삭제 이벤트 발행
+        if (!keysToDelete.isEmpty()) {
+            eventPublisher.publishEvent(new RecordDeletedEvent(record.getId(), keysToDelete));
+        }
     }
 
     // TODO: 독서 기록 상세조회

--- a/src/main/java/app/nook/record/service/RecordService.java
+++ b/src/main/java/app/nook/record/service/RecordService.java
@@ -61,7 +61,7 @@ public class RecordService {
             throw new CustomException(LibraryErrorCode.BOOK_NOT_EXIST);
         }
 
-        // 서재 최대 개수를 넘기지 않도록 생성 요청 충돌 방지를 위해 낙관적 락이 걸리도록 설정
+        // 서재 최대 개수 초과를 막기 위해 for update 기반 비관적 락을 건다.
         libraryRepository.findByIdAndUserIdForUpdate(library.getId(), user.getId())
                 .orElseThrow(() -> new CustomException(LibraryErrorCode.BOOK_NOT_EXIST));
 
@@ -99,7 +99,7 @@ public class RecordService {
                 .orElseThrow(() -> new CustomException(RecordErrorCode.RECORD_NOT_FOUND));
 
         if (!record.getLibrary().getUser().getId().equals(user.getId())) {
-            throw new CustomException(LibraryErrorCode.BOOK_NOT_EXIST);
+            throw new CustomException(RecordErrorCode.RECORD_NOT_AUTHORIZED);
         }
 
         record.update(requestDto.content(), requestDto.emotion());

--- a/src/main/java/app/nook/record/service/RecordService.java
+++ b/src/main/java/app/nook/record/service/RecordService.java
@@ -14,11 +14,13 @@ import app.nook.record.domain.RecordImage;
 import app.nook.record.dto.RecordRequestDto;
 import app.nook.record.dto.RecordResponseDto;
 import app.nook.record.dto.RecordUpdateRequestDto;
+import app.nook.record.event.RecordDeletedEvent;
 import app.nook.record.exception.RecordErrorCode;
 import app.nook.record.repository.RecordImageRepository;
 import app.nook.record.repository.RecordRepository;
 import app.nook.user.domain.User;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -31,15 +33,15 @@ import java.util.Objects;
 @Transactional(readOnly = true)
 public class RecordService {
 
+    // TODO: 기록 최대개수 임의설정, 추후 변경
+    private static final int MAX_RECORD_COUNT = 1000;
+
     private final RecordRepository recordRepository;
     private final LibraryRepository libraryRepository;
     private final BookRepository bookRepository;
-    private final PresignedUrlService presignedUrlService;
-
-    // 기록 최대 개수 - 임의로 설정
-    // TODO : 기록 최대개수 추후 반영
-    private final int MAX_RECORD_COUNT = 1000;
     private final RecordImageRepository recordImageRepository;
+    private final ApplicationEventPublisher eventPublisher;
+    private final PresignedUrlService presignedUrlService;
 
     // 기록 생성
     @Transactional
@@ -48,35 +50,39 @@ public class RecordService {
             Long bookId,
             RecordRequestDto requestDto
     ) {
-        List<String> imageKeys = sanitizeImageKeys(requestDto.imageKeys());
+        // 이미지 키 리스트
+        List<String> imageKeys = filterImageKeys(requestDto.imageKeys());
 
         // 책 존재 여부 확인
         Book book = bookRepository.findById(bookId)
                 .orElseThrow(() -> new CustomException(BookErrorCode.BOOK_NOT_FOUND));
-        // 서재에 등록된 책인지 확인
-        Library library = libraryRepository.findByUserAndBook(user,book);
-        if (library == null )
-            throw new CustomException(LibraryErrorCode.BOOK_NOT_EXIST);
 
-        // 동일 서재 집계 단위 잠금, create를 같은 트랜잭션에서 수행
+        // 서재 등록 여부 확인
+        Library library = libraryRepository.findByUserAndBook(user, book);
+        if (library == null) {
+            throw new CustomException(LibraryErrorCode.BOOK_NOT_EXIST);
+        }
+
+        // 서재 최대 개수를 넘기지 않도록 생성 요청 충돌 방지를 위해 낙관적 락이 걸리도록 설정
         libraryRepository.findByIdAndUserIdForUpdate(library.getId(), user.getId())
                 .orElseThrow(() -> new CustomException(LibraryErrorCode.BOOK_NOT_EXIST));
 
-        // 최대 개수를 넘지 않는지 확인
+        // 개수를 초과한다면 에러 반환
         long count = recordRepository.countByLibraryIdAndUserId(library.getId(), user.getId());
         if (count >= MAX_RECORD_COUNT) {
             throw new CustomException(FileErrorCode.FILE_NUM_EXCEEDED);
         }
 
-        // 기록 생성
         Record newRecord = new Record(
                 library,
                 requestDto.emotion(),
                 requestDto.content()
         );
 
+        // 레코드 생성
         recordRepository.save(newRecord);
 
+        // 이미지가 있다면 key와 record로 Record 이미지 생성
         if (!imageKeys.isEmpty()) {
             saveRecordImages(newRecord, imageKeys);
         }
@@ -89,22 +95,19 @@ public class RecordService {
             Long recordId,
             RecordUpdateRequestDto requestDto
     ) {
-            List<String> requestedImageKeys = sanitizeImageKeys(requestDto.imageKeys());
+        List<String> requestedImageKeys = filterImageKeys(requestDto.imageKeys());
 
-            // 기록 존재 여부 확인
-            Record record = recordRepository.findById(recordId)
-                    .orElseThrow(() -> new CustomException(RecordErrorCode.RECORD_NOT_FOUND));
+        Record record = recordRepository.findById(recordId)
+                .orElseThrow(() -> new CustomException(RecordErrorCode.RECORD_NOT_FOUND));
 
-            // 기록이 속한 서재가 사용자에게 속한 서재인지 확인
-            if (!record.getLibrary().getUser().getId().equals(user.getId())) {
-                throw new CustomException(LibraryErrorCode.BOOK_NOT_EXIST);
-            }
+        if (!record.getLibrary().getUser().getId().equals(user.getId())) {
+            throw new CustomException(LibraryErrorCode.BOOK_NOT_EXIST);
+        }
 
-            // 기록 내용 업데이트
-            record.update(requestDto.content(), requestDto.emotion());
+        record.update(requestDto.content(), requestDto.emotion());
 
-            // 이미지 동기화 - 기존 이미지와 요청된 이미지 키를 비교하여 삭제 및 추가 처리
-            syncRecordImages(record, requestedImageKeys);
+        // 이미지 업데이트 시에 동기화 처리
+        syncRecordImages(record, requestedImageKeys);
     }
 
     // 기록 삭제
@@ -113,31 +116,29 @@ public class RecordService {
             User user,
             Long recordId
     ) {
-        // 기록 존재 여부 확인
         Record record = recordRepository.findById(recordId)
                 .orElseThrow(() -> new CustomException(RecordErrorCode.RECORD_NOT_FOUND));
-        // 기록 소유자 확인
+
         if (!record.getLibrary().getUser().getId().equals(user.getId())) {
             throw new CustomException(RecordErrorCode.RECORD_NOT_AUTHORIZED);
         }
-        record.getImages().stream()
+
+        List<String> keysToDelete = record.getImages().stream()
                 .map(RecordImage::getKey)
                 .filter(Objects::nonNull)
-                .forEach(presignedUrlService::deleteFile);
+                .toList();
+
         record.getImages().clear();
         recordRepository.delete(record);
+        eventPublisher.publishEvent(new RecordDeletedEvent(recordId, keysToDelete));
     }
 
-
-    /* 기록 조회 - 전체 */
-
-    // 기록 전체 개수 조회
     public RecordResponseDto.RecordCountDto countRecords(Long userId) {
-        int recordCount = recordRepository.countByUserId(userId);
+        long recordCount = recordRepository.countByUserId(userId);
         return new RecordResponseDto.RecordCountDto(recordCount);
     }
 
-    private List<String> sanitizeImageKeys(List<String> imageKeys) {
+    private List<String> filterImageKeys(List<String> imageKeys) {
         if (imageKeys == null || imageKeys.isEmpty()) {
             return List.of();
         }
@@ -149,7 +150,7 @@ public class RecordService {
                 .toList();
     }
 
-    // 이미지 저장 - 기록 생성, 수정 공통
+    // 기록 이미지 저장
     private void saveRecordImages(Record record, List<String> imageKeys) {
         for (int index = 0; index < imageKeys.size(); index++) {
             recordImageRepository.save(new RecordImage(
@@ -160,10 +161,11 @@ public class RecordService {
         }
     }
 
+    // 수정 요청에 따라 동기화
     private void syncRecordImages(Record record, List<String> requestedImageKeys) {
         List<RecordImage> existingImages = new ArrayList<>(record.getImages());
 
-        // 기존 이미지 중 요청된 이미지 키에 없는 것을 삭제 - 버킷,DB에 모두 반영
+        // 기존 이미지 중 요청된 이미지 키에 없는 것들은 삭제
         existingImages.stream()
                 .filter(recordImage -> !requestedImageKeys.contains(recordImage.getKey()))
                 .forEach(recordImage -> {
@@ -174,21 +176,16 @@ public class RecordService {
                     recordImageRepository.delete(recordImage);
                 });
 
-        // 기록의 이미지 삭제
         record.getImages().clear();
-
-        // 새로운 이미지 저장 - 순서도 반영해서 저장
         saveRecordImages(record, requestedImageKeys);
     }
 
-    // 기록 전체 정렬 조회 - 무한스크롤
+    // TODO: 독서 기록 상세조회
 
-    /* 기록 조회 - 상세 */
+    // TODO: 독서 기록 전체 목록조회 - 정렬 포함
 
+    // TODO: 특정 책 기록 조회 - 감정 필터
 
-    // 책별 기록 리스트 조회 - 감정 or 전체 필터
-
-    // 기록 상세 조회
 
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -39,6 +39,14 @@ file:
   cover-url-prefix: /uploads/covers/
   profile-url-prefix: /uploads/profiles/
 
+# image
+cloudflare:
+  r2:
+    endpoint: ${R2_END_POINT}
+    bucket-name: ${R2_BUCKET_NAME}
+    access-key: ${R2_ACCESS_KEY}
+    secret-key: ${R2_SECRET_KEY}
+
 jwt:
   secret: ${JWT_SECRET}
 
@@ -50,6 +58,7 @@ openai:
   api:
     key: ${OPENAI_API_KEY}
 
+# oauth
 auth:
   kakao:
     client-id: ${KAKAO_CLIENT_ID}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -42,7 +42,7 @@ file:
 # image
 cloudflare:
   r2:
-    endpoint: ${R2_END_POINT}
+    endpoint: ${R2_ENDPOINT}
     bucket-name: ${R2_BUCKET_NAME}
     access-key: ${R2_ACCESS_KEY}
     secret-key: ${R2_SECRET_KEY}
@@ -76,4 +76,3 @@ auth:
     client-secret: ${GOOGLE_CLIENT_SECRET}
     token-request-uri: ${TOKEN_REQUEST_URI}
     user-info-uri: ${MEMBER_INFO_REQUEST_URI}
-

--- a/src/test/java/app/nook/controller/library/LibraryControllerTest.java
+++ b/src/test/java/app/nook/controller/library/LibraryControllerTest.java
@@ -21,6 +21,7 @@ import org.springframework.http.MediaType;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.time.LocalDate;
@@ -31,6 +32,7 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.willThrow;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
@@ -43,6 +45,7 @@ import static org.springframework.restdocs.request.RequestDocumentation.pathPara
 import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.restdocs.payload.JsonFieldType.*;
 
 @WebMvcTest(
@@ -130,6 +133,26 @@ class LibraryControllerTest extends AbstractWebMvcRestDocsTests {
                         ),
                         responseFields(ApiResponseSnippet.commonResponseFieldsWithNullableResult())
                 ));
+    }
+
+    @Test
+    @WithCustomUser
+    void 서재_책_상태변경_실패_낙관적잠금충돌() throws Exception {
+        ReadingStatusRequestDto request = new ReadingStatusRequestDto(1L, ReadingStatus.READING);
+
+        willThrow(new ObjectOptimisticLockingFailureException("Library", 1L))
+                .given(libraryService).changeStatus(any(), any());
+
+        mockMvc.perform(
+                        patch("/api/library/status")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request))
+                                .header(AUTH_HEADER, AUTH_TOKEN)
+                                .with(csrf())
+                )
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.isSuccess").value(false))
+                .andExpect(jsonPath("$.code").value("COMMON-004"));
     }
 
     @Test

--- a/src/test/java/app/nook/controller/r2/ImageUploadControllerTest.java
+++ b/src/test/java/app/nook/controller/r2/ImageUploadControllerTest.java
@@ -1,0 +1,177 @@
+package app.nook.controller.r2;
+
+import app.nook.global.common.AbstractWebMvcRestDocsTests;
+import app.nook.global.common.security.WithCustomUser;
+import app.nook.global.config.WebSecurityConfig;
+import app.nook.global.docs.ApiResponseSnippet;
+import app.nook.global.exception.CustomException;
+import app.nook.global.response.FileErrorCode;
+import app.nook.r2.controller.ImageUploadController;
+import app.nook.r2.dto.ImageUploadRequestDto;
+import app.nook.r2.dto.ImageUrlResponseDto;
+import app.nook.r2.dto.MultipleImageUploadRequestDto;
+import app.nook.r2.service.PresignedUrlService;
+import app.nook.user.filter.JwtExceptionFilter;
+import app.nook.user.filter.JwtFilter;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(
+        controllers = ImageUploadController.class,
+        excludeFilters = @ComponentScan.Filter(
+                type = FilterType.ASSIGNABLE_TYPE,
+                classes = {
+                        WebSecurityConfig.class,
+                        JwtFilter.class,
+                        JwtExceptionFilter.class
+                }
+        )
+)
+class ImageUploadControllerTest extends AbstractWebMvcRestDocsTests {
+
+    @MockitoBean
+    private PresignedUrlService presignedUrlService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @DisplayName("이미지 업로드 URL 발급")
+    @Nested
+    class IssueUploadUrl {
+
+        @DisplayName("성공")
+        @Nested
+        class Success {
+
+            @Test
+            @WithCustomUser
+            void 단건_업로드_URL_발급_성공() throws Exception {
+                // given
+                ImageUrlResponseDto response = new ImageUrlResponseDto(
+                        "https://example.com/upload/book/test.png",
+                        "book/test.png"
+                );
+
+                given(presignedUrlService.generateUploadUrl(anyLong(), any()))
+                        .willReturn(response);
+
+                // when & then
+                mockMvc.perform(post("/api/images/upload-url")
+                                .header(AUTH_HEADER, AUTH_TOKEN)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(
+                                        new ImageUploadRequestDto("book")
+                                )))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.isSuccess").value(true))
+                        .andExpect(jsonPath("$.code").value("SUCCESS-200"))
+                        .andExpect(jsonPath("$.result.imageUrl").value("https://example.com/upload/book/test.png"))
+                        .andExpect(jsonPath("$.result.key").value("book/test.png"))
+                        .andDo(documentWithAuth(
+                                "image-upload-controller-test/단건_업로드_URL_발급_성공",
+                                requestFields(
+                                        fieldWithPath("contentType").type(JsonFieldType.STRING).description("이미지 업로드 타입(record, book, profile)")
+                                ),
+                                responseFields(ApiResponseSnippet.withResult(
+                                        fieldWithPath("result.imageUrl").type(JsonFieldType.STRING).description("Presigned 업로드 URL"),
+                                        fieldWithPath("result.key").type(JsonFieldType.STRING).description("저장된 이미지 key")
+                                ))
+                        ));
+            }
+
+            @Test
+            @WithCustomUser
+            void 다건_업로드_URL_발급_성공() throws Exception {
+                // given
+                List<ImageUrlResponseDto> response = List.of(
+                        new ImageUrlResponseDto(
+                                "https://example.com/upload/record/1.png",
+                                "record/users/1/first.png"
+                        ),
+                        new ImageUrlResponseDto(
+                                "https://example.com/upload/record/2.png",
+                                "record/users/1/second.png"
+                        )
+                );
+
+                given(presignedUrlService.generateMultipleUploadUrls(anyLong(), any()))
+                        .willReturn(response);
+
+                // when & then
+                mockMvc.perform(post("/api/images/upload-urls")
+                                .header(AUTH_HEADER, AUTH_TOKEN)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(
+                                        new MultipleImageUploadRequestDto(List.of(
+                                                new ImageUploadRequestDto("record"),
+                                                new ImageUploadRequestDto("record")
+                                        ))
+                                )))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.isSuccess").value(true))
+                        .andExpect(jsonPath("$.code").value("SUCCESS-200"))
+                        .andExpect(jsonPath("$.result[0].imageUrl").value("https://example.com/upload/record/1.png"))
+                        .andExpect(jsonPath("$.result[0].key").value("record/users/1/first.png"))
+                        .andExpect(jsonPath("$.result[1].imageUrl").value("https://example.com/upload/record/2.png"))
+                        .andExpect(jsonPath("$.result[1].key").value("record/users/1/second.png"))
+                        .andDo(documentWithAuth(
+                                "image-upload-controller-test/다건_업로드_URL_발급_성공",
+                                requestFields(
+                                        fieldWithPath("files").type(JsonFieldType.ARRAY).description("업로드할 이미지 요청 목록"),
+                                        fieldWithPath("files[].contentType").type(JsonFieldType.STRING).description("이미지 업로드 타입(record, book, profile)")
+                                ),
+                                responseFields(ApiResponseSnippet.withResult(
+                                        fieldWithPath("result[].imageUrl").type(JsonFieldType.STRING).description("Presigned 업로드 URL"),
+                                        fieldWithPath("result[].key").type(JsonFieldType.STRING).description("저장된 이미지 key")
+                                ))
+                        ));
+            }
+        }
+
+        @DisplayName("실패")
+        @Nested
+        class Failure {
+
+            @Test
+            @WithCustomUser
+            void 단건_업로드_URL_발급_실패_유효하지않은_파일타입() throws Exception {
+                // given
+                given(presignedUrlService.generateUploadUrl(anyLong(), any()))
+                        .willThrow(new CustomException(FileErrorCode.INVALID_FILE_TYPE));
+
+                // when & then
+                mockMvc.perform(post("/api/images/upload-url")
+                                .header(AUTH_HEADER, AUTH_TOKEN)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(
+                                        new ImageUploadRequestDto("invalid")
+                                )))
+                        .andExpect(status().isBadRequest())
+                        .andExpect(jsonPath("$.isSuccess").value(false))
+                        .andExpect(jsonPath("$.code").value("FILE-400"))
+                        .andExpect(jsonPath("$.message").value("유효하지 않은 파일 형식입니다."));
+            }
+        }
+    }
+}

--- a/src/test/java/app/nook/controller/r2/ImageUploadControllerTest.java
+++ b/src/test/java/app/nook/controller/r2/ImageUploadControllerTest.java
@@ -4,8 +4,6 @@ import app.nook.global.common.AbstractWebMvcRestDocsTests;
 import app.nook.global.common.security.WithCustomUser;
 import app.nook.global.config.WebSecurityConfig;
 import app.nook.global.docs.ApiResponseSnippet;
-import app.nook.global.exception.CustomException;
-import app.nook.global.response.FileErrorCode;
 import app.nook.r2.controller.ImageUploadController;
 import app.nook.r2.dto.ImageUploadRequestDto;
 import app.nook.r2.dto.ImageUrlResponseDto;
@@ -156,10 +154,6 @@ class ImageUploadControllerTest extends AbstractWebMvcRestDocsTests {
             @Test
             @WithCustomUser
             void 단건_업로드_URL_발급_실패_유효하지않은_파일타입() throws Exception {
-                // given
-                given(presignedUrlService.generateUploadUrl(anyLong(), any()))
-                        .willThrow(new CustomException(FileErrorCode.INVALID_FILE_TYPE));
-
                 // when & then
                 mockMvc.perform(post("/api/images/upload-url")
                                 .header(AUTH_HEADER, AUTH_TOKEN)
@@ -169,8 +163,8 @@ class ImageUploadControllerTest extends AbstractWebMvcRestDocsTests {
                                 )))
                         .andExpect(status().isBadRequest())
                         .andExpect(jsonPath("$.isSuccess").value(false))
-                        .andExpect(jsonPath("$.code").value("FILE-400"))
-                        .andExpect(jsonPath("$.message").value("유효하지 않은 파일 형식입니다."));
+                        .andExpect(jsonPath("$.code").value("COMMON-002"))
+                        .andExpect(jsonPath("$.result.contentType").exists());
             }
         }
     }

--- a/src/test/java/app/nook/controller/record/RecordControllerTest.java
+++ b/src/test/java/app/nook/controller/record/RecordControllerTest.java
@@ -1,0 +1,251 @@
+package app.nook.controller.record;
+
+import app.nook.global.common.AbstractWebMvcRestDocsTests;
+import app.nook.global.common.security.WithCustomUser;
+import app.nook.global.config.WebSecurityConfig;
+import app.nook.global.docs.ApiResponseSnippet;
+import app.nook.global.exception.CustomException;
+import app.nook.record.controller.RecordController;
+import app.nook.record.domain.enums.Emotion;
+import app.nook.record.dto.RecordRequestDto;
+import app.nook.record.dto.RecordResponseDto;
+import app.nook.record.dto.RecordUpdateRequestDto;
+import app.nook.record.exception.RecordErrorCode;
+import app.nook.record.service.RecordService;
+import app.nook.user.filter.JwtExceptionFilter;
+import app.nook.user.filter.JwtFilter;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(
+        controllers = RecordController.class,
+        excludeFilters = @ComponentScan.Filter(
+                type = FilterType.ASSIGNABLE_TYPE,
+                classes = {
+                        WebSecurityConfig.class,
+                        JwtFilter.class,
+                        JwtExceptionFilter.class
+                }
+        )
+)
+class RecordControllerTest extends AbstractWebMvcRestDocsTests {
+
+    @MockitoBean
+    private RecordService recordService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @DisplayName("기록 생성")
+    @Nested
+    class CreateRecord {
+
+        @DisplayName("성공")
+        @Nested
+        class Success {
+
+            @Test
+            @WithCustomUser
+            void 기록_생성_성공() throws Exception {
+                // given
+                RecordRequestDto request = new RecordRequestDto(
+                        "기록 내용입니다.",
+                        Emotion.FUN,
+                        List.of("record/users/1/first.png")
+                );
+
+                willDoNothing().given(recordService).createRecord(any(), anyLong(), any());
+
+                // when & then
+                mockMvc.perform(post("/api/records/books/{bookId}", 1L)
+                                .header(AUTH_HEADER, AUTH_TOKEN)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.isSuccess").value(true))
+                        .andExpect(jsonPath("$.code").value("SUCCESS-201"))
+                        .andDo(documentWithAuth(
+                                "record-controller-test/기록_생성_성공",
+                                pathParameters(
+                                        parameterWithName("bookId").description("기록을 생성할 도서 ID")
+                                ),
+                                requestFields(
+                                        fieldWithPath("content").type(JsonFieldType.STRING).description("기록 내용"),
+                                        fieldWithPath("emotion").type(JsonFieldType.STRING).description("기록 감정(FUN, EMPATHIZING, USEFUL, COMPLICATED, SAD, UNCOMFORTABLE)"),
+                                        fieldWithPath("imageKeys").type(JsonFieldType.ARRAY).description("업로드 완료된 이미지 key 목록").optional(),
+                                        fieldWithPath("imageKeys[]").description("업로드 완료된 record 이미지 key")
+                                ),
+                                responseFields(ApiResponseSnippet.commonResponseFieldsWithNullableResult())
+                        ));
+            }
+        }
+
+        @DisplayName("실패")
+        @Nested
+        class Failure {
+
+            @Test
+            @WithCustomUser
+            void 기록_생성_실패_내용_누락() throws Exception {
+                // given
+                RecordRequestDto request = new RecordRequestDto(
+                        "",
+                        Emotion.FUN,
+                        List.of()
+                );
+
+                // when & then
+                mockMvc.perform(post("/api/records/books/{bookId}", 1L)
+                                .header(AUTH_HEADER, AUTH_TOKEN)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
+                        .andExpect(status().isBadRequest());
+            }
+        }
+    }
+
+    @DisplayName("기록 수정")
+    @Nested
+    class UpdateRecord {
+
+        @Test
+        @WithCustomUser
+        void 기록_수정_성공() throws Exception {
+            // given
+            RecordUpdateRequestDto request = new RecordUpdateRequestDto(
+                    "수정된 기록 내용입니다.",
+                    Emotion.EMPATHIZING,
+                    List.of(
+                            "record/users/1/first.png",
+                            "record/users/1/second.png"
+                    )
+            );
+
+            willDoNothing().given(recordService).updateRecord(any(), anyLong(), any());
+
+            // when & then
+            mockMvc.perform(put("/api/records/{recordId}", 10L)
+                            .header(AUTH_HEADER, AUTH_TOKEN)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.isSuccess").value(true))
+                    .andExpect(jsonPath("$.code").value("SUCCESS-200"))
+                    .andDo(documentWithAuth(
+                            "record-controller-test/기록_수정_성공",
+                            pathParameters(
+                                    parameterWithName("recordId").description("수정할 기록 ID")
+                            ),
+                            requestFields(
+                                    fieldWithPath("content").type(JsonFieldType.STRING).description("수정할 기록 내용"),
+                                    fieldWithPath("emotion").type(JsonFieldType.STRING).description("수정할 기록 감정(FUN, EMPATHIZING, USEFUL, COMPLICATED, SAD, UNCOMFORTABLE)"),
+                                    fieldWithPath("imageKeys").type(JsonFieldType.ARRAY).description("수정 후 최종 이미지 key 목록").optional(),
+                                    fieldWithPath("imageKeys[]").description("업로드 완료된 record 이미지 key")
+                            ),
+                            responseFields(ApiResponseSnippet.commonResponseFieldsWithNullableResult())
+                    ));
+        }
+    }
+
+    @DisplayName("기록 삭제")
+    @Nested
+    class DeleteRecord {
+
+        @DisplayName("성공")
+        @Nested
+        class Success {
+
+            @Test
+            @WithCustomUser
+            void 기록_삭제_성공() throws Exception {
+                // given
+                willDoNothing().given(recordService).deleteRecord(any(), anyLong());
+
+                // when & then
+                mockMvc.perform(delete("/api/records/{recordId}", 10L)
+                                .header(AUTH_HEADER, AUTH_TOKEN))
+                        .andExpect(status().isOk())
+                        .andDo(documentWithAuth(
+                                "record-controller-test/기록_삭제_성공",
+                                pathParameters(
+                                        parameterWithName("recordId").description("삭제할 기록 ID")
+                                ),
+                                responseFields(ApiResponseSnippet.commonResponseFieldsWithNullableResult())
+                        ));
+            }
+        }
+
+        @DisplayName("실패")
+        @Nested
+        class Failure {
+
+            @Test
+            @WithCustomUser
+            void 기록_삭제_실패_기록없음() throws Exception {
+                // given
+                willThrow(new CustomException(RecordErrorCode.RECORD_NOT_FOUND))
+                        .given(recordService).deleteRecord(any(), anyLong());
+
+                // when & then
+                mockMvc.perform(delete("/api/records/{recordId}", 999L)
+                                .header(AUTH_HEADER, AUTH_TOKEN))
+                        .andExpect(status().isNotFound())
+                        .andExpect(jsonPath("$.isSuccess").value(false))
+                        .andExpect(jsonPath("$.code").value("RECORD-404"));
+            }
+        }
+    }
+
+    @DisplayName("기록 전체 개수 조회")
+    @Nested
+    class CountRecords {
+
+        @Test
+        @WithCustomUser
+        void 기록_전체개수_조회_성공() throws Exception {
+            // given
+            RecordResponseDto.RecordCountDto response = new RecordResponseDto.RecordCountDto(12);
+            given(recordService.countRecords(anyLong())).willReturn(response);
+
+            // when & then
+            mockMvc.perform(get("/api/records/count")
+                            .header(AUTH_HEADER, AUTH_TOKEN))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.result.count").value(12))
+                    .andDo(documentWithAuth(
+                            "record-controller-test/기록_전체개수_조회_성공",
+                            responseFields(ApiResponseSnippet.withResult(
+                                    fieldWithPath("result.count").type(JsonFieldType.NUMBER).description("사용자의 전체 기록 수")
+                            ))
+                    ));
+        }
+    }
+}


### PR DESCRIPTION
## 📄 작업 내용 요약
<!-- 무엇을 작업했는지 간단하게 요약해주세요 -->

- 예: 회원가입 API 구현
- 예: 예외 처리 공통화

  1. 기록 생성, 수정, 삭제 기능 구현
  2. 사진 업로드 API 구현: presigned URL 방식으로 업로드 URL과 key를 발급하고, 조회 시 key를 기반으로 접근 URL을 반환하도록 구현
  3. 기록 생성 시 동시성으로 인한 최대 개수 초과를 방지하기 위해, 서재 집계 엔티티에 비관적 락을 적용하는 로직 추가
  4. 컨트롤러 테스트 코드 작성
  5. 기록 삭제 시 after_commit, requires_new 기반 후처리를 적용해 R2 파일 삭제가 DB 커밋 이후 수행되도록 구성

---

## 📎 Issue 번호
<!-- 관련된 이슈가 있다면 닫히도록 연결해주세요 (ex: closed #1) -->

- #219 

---

## ✅ 작업 목록
<!-- 체크박스로 완료한 작업을 표시해주세요 -->

- [x] 기능 구현
- [ ] 코드 리뷰 반영
- [x] 테스트 코드 작성
- [x] 문서 업데이트

---

## 📝 기타 참고사항
<!-- 리뷰어가 참고하면 좋을 추가 정보나 질문이 있다면 자유롭게 작성해주세요 -->
application-secret.properties 업데이트 해주세요~! r2 설정 포함되어 있습니다. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 이미지 업로드(단일/다중)용 사전 서명 URL 발급 및 관리 API 추가; 기록(Record) CRUD 및 이미지 첨부(최대 5개) 지원; 기록 삭제 시 연관 이미지 삭제 처리 이벤트 도입
* **Bug Fixes**
  * 낙관적 락 충돌에 대한 409 응답 처리 추가(동시 수정 충돌)
* **Documentation**
  * 이미지 업로드 흐름 및 기록 관리 관련 문서 추가 및 인덱스 반영
* **Tests**
  * 이미지 업로드 및 기록 API 관련 Web 테스트 및 REST Docs 추가
* **Chores**
  * 클라우드 오브젝트 스토리지(R2/S3 호환) 설정 및 관련 의존성/구성 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->