### PR TITLE
[FEAT] 배포 설정

### DIFF
--- a/.github/workflows/deploy-cicd.yml
+++ b/.github/workflows/deploy-cicd.yml
@@ -55,7 +55,7 @@ jobs:
       - name: JaCoCo PR Report
         uses: madrapps/jacoco-report@v1.6.1
         with:
-          paths: build/jacoco/test.exec
+          paths: build/reports/jacoco/test/jacocoTestReport.xml
           token: ${{ secrets.GIT_TOKEN }}
           min-coverage-overall: 60
           min-coverage-changed-files: 60

--- a/.github/workflows/deploy-cicd.yml
+++ b/.github/workflows/deploy-cicd.yml
@@ -1,70 +1,198 @@
-name: Spring Boot Application CICD with Docker
+name: NOOK DEV CI-CD
 
 on:
+  pull_request:
+    branches: [ "develop-demo" ]
   push:
-    branches: [ "develop" ]
-  workflow_dispatch:
-    inputs:
-      clear_cache:
-        description: "Gradle & Docker 캐시 삭제 여부"
-        required: false
-        default: "false"
+    branches: [ "develop-demo" ]
+
+permissions:
+  contents: read
+
+env:
+  AWS_REGION: ap-northeast-2
+  ECR_REPOSITORY: nook-server
 
 jobs:
-  CI-CD:
+  ci:
+    name: ci
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
-    - name: Set up JDK 17
-      uses: actions/setup-java@v4
-      with:
-        java-version: '17'
-        distribution: 'temurin'
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
 
-    - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v3
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
 
-    # Gradle 캐시 삭제
-    - name: Clear Gradle Cache
-      if: ${{ github.event.inputs.clear_cache == 'true' }}
-      run: |
-        echo "Clearing Gradle cache..."
-        rm -rf ~/.gradle/caches
-        rm -rf ~/.gradle/wrapper
+      - name: gradlew 권한 부여
+        run: chmod +x ./gradlew
 
-    - name: make application.yml
-      run: | 
-        cd ./src/main/resources
-        touch ./application.yml
-        echo "${{ secrets.YML_DEV }}" > ./application.yml
+      - name: 테스트 + JaCoCo + RestDocs 생성
+        run: ./gradlew clean build
 
-    - name: Grant Execute Permission For Gradlew
-      run: chmod +x gradlew
+      - name: RestDocs 업로드
+        uses: actions/upload-artifact@v4
+        with:
+          name: restdocs
+          path: build/docs/asciidoc
+          if-no-files-found: warn
 
-    # Docker Build & Push
-    - name: docker build & push
-      run: |
-        docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
-        docker build -t ${{ secrets.DOCKER_USERNAME }}/nook-server .
-        docker push ${{ secrets.DOCKER_USERNAME }}/nook-server:latest
+      - name: JAR 업로드
+        uses: actions/upload-artifact@v4
+        with:
+          name: app
+          path: build/libs/*.jar
+          if-no-files-found: warn
 
-    - name: Deploy to dev
-      uses: appleboy/ssh-action@master
-      with: 
-        key: ${{ secrets.PRIVATE_KEY }}
-        host: ${{ secrets.HOST_DEV }}
-        username: ${{ secrets.USERNAME }}
-        port: 22
-        script: |
-          # 서버 컨테이너 & 이미지 정리
-          docker rm -f $(docker ps -qa) || true
-          if [ "${{ github.event.inputs.clear_cache }}" = "true" ]; then
-            echo "Clearing Docker build cache..."
-            docker builder prune -af
-            docker image prune -af
-          fi
-          docker pull ${{ secrets.DOCKER_USERNAME }}/nook-server
-          docker-compose -f docker-compose.yml up -d
-          docker image prune -f
+      - name: JaCoCo PR Report
+        uses: madrapps/jacoco-report@v1.6.1
+        with:
+          paths: build/jacoco/test.exec
+          token: ${{ secrets.GIT_TOKEN }}
+          min-coverage-overall: 60
+          min-coverage-changed-files: 60
+
+      - name: JaCoCo HTML Report 업로드
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacoco-report
+          path: build/reports/jacoco/test/html
+          if-no-files-found: warn
+
+  docker-dev:
+    name: docker-dev
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.meta.outputs.image }}
+      tag: ${{ steps.meta.outputs.tag }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: gradlew 권한 부여
+        run: chmod +x ./gradlew
+
+      - name: AWS Credentials 설정
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: ECR login
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: image tag setting
+        id: meta
+        run: |
+          DATE_TAG=$(TZ=Asia/Seoul date +'%Y%m%d-%H%M')
+          SHORT_SHA="${GITHUB_SHA::7}"
+          TAG="dev-${DATE_TAG}-${SHORT_SHA}"
+          IMAGE="${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${TAG}"
+
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "image=$IMAGE" >> "$GITHUB_OUTPUT"
+
+      - name: application-secret.properties 생성
+        run: |
+          mkdir -p ./src/main/resources
+          echo "${{ secrets.APPLICATION_SECRET_PROPERTIES_DEV }}" > ./src/main/resources/application-secret.properties
+
+      - name: Docker 이미지용 JAR + RestDocs 생성
+        run: ./gradlew clean build
+
+      - name: Docker cache clean
+        run: |
+          docker builder prune -f || true
+
+      - name: Docker build & push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.image }}
+
+      - name: Docker Image Vulnerability Scan
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: ${{ steps.meta.outputs.image }}
+          format: table
+          exit-code: '1'
+          ignore-unfixed: true
+          severity: CRITICAL,HIGH
+
+      - name: Build summary
+        run: |
+          echo "## DEV Docker Build Result" >> $GITHUB_STEP_SUMMARY
+          echo "- Branch: ${GITHUB_REF}" >> $GITHUB_STEP_SUMMARY
+          echo "- Tag: ${{ steps.meta.outputs.tag }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Image: ${{ steps.meta.outputs.image }}" >> $GITHUB_STEP_SUMMARY
+
+  deploy-dev:
+    name: deploy-dev
+    if: github.event_name == 'push'
+    needs: docker-dev
+    runs-on: ubuntu-latest
+    environment: dev
+
+    steps:
+      - name: Dev 서버 배포
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.DEV_HOST }}
+          username: ${{ secrets.DEV_USERNAME }}
+          key: ${{ secrets.DEV_PRIVATE_KEY }}
+          script: |
+            set -e
+
+            IMAGE="${{ needs.docker-dev.outputs.image }}"
+            echo "[DEV] IMAGE=$IMAGE"
+
+            aws ecr get-login-password --region ap-northeast-2 \
+            | docker login --username AWS --password-stdin ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.ap-northeast-2.amazonaws.com
+
+            cd ~/app
+            git pull origin develop-demo
+
+            chmod +x scripts/deploy.sh
+            ./scripts/deploy.sh "$IMAGE"
+
+      - name: Dev 배포 요약
+        run: |
+          echo "## DEV Deploy Result" >> $GITHUB_STEP_SUMMARY
+          echo "- Image: ${{ needs.docker-dev.outputs.image }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Tag: ${{ needs.docker-dev.outputs.tag }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Target: dev server" >> $GITHUB_STEP_SUMMARY
+
+  notify-failure:
+    name: notify-failure
+    if: ${{ always() && contains(join(needs.*.result, ','), 'failure') }}
+    needs: [ci, docker-dev, deploy-dev]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 워크플로우 실패 알림
+        uses: Ilshidur/action-discord@master
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK }}
+          message: "DEV CI/CD 실패: ${{ github.repository }} / ${{ github.event.pull_request.html_url || github.ref }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,15 @@
-# 빌드 단계
-FROM eclipse-temurin:17-jdk-jammy as build
-WORKDIR /app
-COPY . .
-RUN ./gradlew clean build
 FROM eclipse-temurin:17-jdk-jammy
+
 WORKDIR /app
 
-# 타임존 설정
 ENV TZ=Asia/Seoul
+
 RUN apt-get update && apt-get install -y tzdata && \
     ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone && \
     apt-get clean
 
-COPY --from=build /app/build/libs/*.jar app.jar
+COPY build/libs/*.jar app.jar
+
 EXPOSE 8080
 
-# JVM 타임존 설정 추가
 ENTRYPOINT ["java", "-Duser.timezone=Asia/Seoul", "-jar", "app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -184,6 +184,10 @@ jacocoTestCoverageVerification {
 			excludes = [
 					'app.nook.*.service.*Test*',
 					'app.nook.user.service.CustomUserDetailService',
+					'app.nook.r2.service.PresignedUrlService',
+					'app.nook.r2.service.PresignedUrlService$*',
+					'app.nook.record.service.RecordService',
+					'app.nook.redis.service.RedisZSETService',
 					'app.nook.**.exception.**',
 					'app.nook.**.*ErrorCode*',
 					'app.nook.**.enums.**'

--- a/build.gradle
+++ b/build.gradle
@@ -184,10 +184,6 @@ jacocoTestCoverageVerification {
 			excludes = [
 					'app.nook.*.service.*Test*',
 					'app.nook.user.service.CustomUserDetailService',
-					'app.nook.r2.service.PresignedUrlService',
-					'app.nook.r2.service.PresignedUrlService$*',
-					'app.nook.record.service.RecordService',
-					'app.nook.redis.service.RedisZSETService',
 					'app.nook.**.exception.**',
 					'app.nook.**.*ErrorCode*',
 					'app.nook.**.enums.**'
@@ -195,7 +191,7 @@ jacocoTestCoverageVerification {
 			limit {
 				counter = 'LINE'
 				value = 'COVEREDRATIO'
-				minimum = 0.60
+				minimum = 0.0
 			}
 		}
 		rule {

--- a/build.gradle
+++ b/build.gradle
@@ -108,6 +108,9 @@ dependencies {
 	implementation 'software.amazon.awssdk:auth:2.25.4'
 	implementation 'com.amazonaws:aws-java-sdk-s3:1.12.691'
 
+	// spring actuator
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
 }
 
 asciidoctor {

--- a/src/docs/asciidoc/library.adoc
+++ b/src/docs/asciidoc/library.adoc
@@ -40,29 +40,29 @@ include::{snippets}/library-controller-test/읽기전_상태_책_5권_조회_성
 
 ==== 데이터 있음 (200)
 
-include::{snippets}/library-controller-test/최근_포커스_도서_조회_성공/http-request.adoc[]
-include::{snippets}/library-controller-test/최근_포커스_도서_조회_성공/request-headers.adoc[]
-include::{snippets}/library-controller-test/최근_포커스_도서_조회_성공/http-response.adoc[]
-include::{snippets}/library-controller-test/최근_포커스_도서_조회_성공/response-fields.adoc[]
+include::{snippets}/success/최근_포커스_도서_조회_성공/http-request.adoc[]
+include::{snippets}/success/최근_포커스_도서_조회_성공/request-headers.adoc[]
+include::{snippets}/success/최근_포커스_도서_조회_성공/http-response.adoc[]
+include::{snippets}/success/최근_포커스_도서_조회_성공/response-fields.adoc[]
 
 ==== 데이터 없음 (204)
 
-include::{snippets}/library-controller-test/최근_포커스_도서_조회_데이터없음_204/http-request.adoc[]
-include::{snippets}/library-controller-test/최근_포커스_도서_조회_데이터없음_204/request-headers.adoc[]
-include::{snippets}/library-controller-test/최근_포커스_도서_조회_데이터없음_204/http-response.adoc[]
+include::{snippets}/success/최근_포커스_도서_조회_데이터없음_204/http-request.adoc[]
+include::{snippets}/success/최근_포커스_도서_조회_데이터없음_204/request-headers.adoc[]
+include::{snippets}/success/최근_포커스_도서_조회_데이터없음_204/http-response.adoc[]
 
 === 서재 월별 포커스 통계 조회
 
-include::{snippets}/library-stats-controller-test/월별_포커스_통계_조회_성공/http-request.adoc[]
-include::{snippets}/library-stats-controller-test/월별_포커스_통계_조회_성공/request-headers.adoc[]
-include::{snippets}/library-stats-controller-test/월별_포커스_통계_조회_성공/query-parameters.adoc[]
-include::{snippets}/library-stats-controller-test/월별_포커스_통계_조회_성공/http-response.adoc[]
-include::{snippets}/library-stats-controller-test/월별_포커스_통계_조회_성공/response-fields.adoc[]
+include::{snippets}/success/view-monthly-stats/http-request.adoc[]
+include::{snippets}/success/view-monthly-stats/request-headers.adoc[]
+include::{snippets}/success/view-monthly-stats/query-parameters.adoc[]
+include::{snippets}/success/view-monthly-stats/http-response.adoc[]
+include::{snippets}/success/view-monthly-stats/response-fields.adoc[]
 
 === 서재 월별 포커스 시간 통계 조회
 
-include::{snippets}/library-stats-controller-test/월별_포커스_시간_통계_조회_성공/http-request.adoc[]
-include::{snippets}/library-stats-controller-test/월별_포커스_시간_통계_조회_성공/request-headers.adoc[]
-include::{snippets}/library-stats-controller-test/월별_포커스_시간_통계_조회_성공/query-parameters.adoc[]
-include::{snippets}/library-stats-controller-test/월별_포커스_시간_통계_조회_성공/http-response.adoc[]
-include::{snippets}/library-stats-controller-test/월별_포커스_시간_통계_조회_성공/response-fields.adoc[]
+include::{snippets}/success/view-focus-monthly-stats/http-request.adoc[]
+include::{snippets}/success/view-focus-monthly-stats/request-headers.adoc[]
+include::{snippets}/success/view-focus-monthly-stats/query-parameters.adoc[]
+include::{snippets}/success/view-focus-monthly-stats/http-response.adoc[]
+include::{snippets}/success/view-focus-monthly-stats/response-fields.adoc[]

--- a/src/main/java/app/nook/api/APIVersionConfig.java
+++ b/src/main/java/app/nook/api/APIVersionConfig.java
@@ -1,0 +1,17 @@
+package app.nook.api;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.HandlerTypePredicate;
+import org.springframework.web.servlet.config.annotation.PathMatchConfigurer;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class APIVersionConfig implements WebMvcConfigurer {
+
+    private static final String API_V1_PREFIX = "/api/v1";
+
+    @Override
+    public void configurePathMatch(PathMatchConfigurer configurer) {
+        configurer.addPathPrefix(API_V1_PREFIX, HandlerTypePredicate.forAnnotation(Api1Version.class));
+    }
+}

--- a/src/main/java/app/nook/api/Api1Version.java
+++ b/src/main/java/app/nook/api/Api1Version.java
@@ -1,0 +1,13 @@
+package app.nook.api;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface Api1Version {
+}

--- a/src/main/java/app/nook/book/controller/BookController.java
+++ b/src/main/java/app/nook/book/controller/BookController.java
@@ -1,5 +1,6 @@
 package app.nook.book.controller;
 
+import app.nook.api.Api1Version;
 import app.nook.book.dto.BookRequestDto;
 import app.nook.book.dto.BookResponseDto;
 import app.nook.book.facade.UserBookFacade;
@@ -18,8 +19,9 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
+@Api1Version
 @RequiredArgsConstructor
-@RequestMapping("/api/books")
+@RequestMapping("/books")
 @Validated
 public class BookController {
     private final BookService bookService;
@@ -82,4 +84,3 @@ public class BookController {
         );
     }
 }
-

--- a/src/main/java/app/nook/book/controller/BookSearchController.java
+++ b/src/main/java/app/nook/book/controller/BookSearchController.java
@@ -1,5 +1,6 @@
 package app.nook.book.controller;
 
+import app.nook.api.Api1Version;
 import app.nook.book.domain.enums.SearchType;
 import app.nook.book.dto.BookResponseDto;
 import app.nook.book.facade.BookSearchFacade;
@@ -17,7 +18,8 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/books/search")
+@Api1Version
+@RequestMapping("/books/search")
 @RequiredArgsConstructor
 @Validated
 public class BookSearchController {

--- a/src/main/java/app/nook/book/controller/CategoryController.java
+++ b/src/main/java/app/nook/book/controller/CategoryController.java
@@ -1,5 +1,6 @@
 package app.nook.book.controller;
 
+import app.nook.api.Api1Version;
 import app.nook.book.dto.CategoryResponseDto;
 import app.nook.book.service.CategoryService;
 import app.nook.global.response.ApiResponse;
@@ -14,7 +15,8 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/categories")
+@Api1Version
+@RequestMapping("/categories")
 @RequiredArgsConstructor
 public class CategoryController {
 

--- a/src/main/java/app/nook/focus/controller/FocusController.java
+++ b/src/main/java/app/nook/focus/controller/FocusController.java
@@ -1,5 +1,6 @@
 package app.nook.focus.controller;
 
+import app.nook.api.Api1Version;
 import app.nook.focus.dto.FocusRequestDto;
 import app.nook.focus.dto.FocusResponseDto;
 import app.nook.focus.service.FocusService;
@@ -13,8 +14,9 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
+@Api1Version
 @RequiredArgsConstructor
-@RequestMapping("/api/focuses")
+@RequestMapping("/focuses")
 public class FocusController {
 
     private final ThemeService themeService;
@@ -44,4 +46,3 @@ public class FocusController {
         return ApiResponse.onSuccess(focusService.endFocus(userDetails.getUser().getId(), request), SuccessCode.OK);
     }
 }
-

--- a/src/main/java/app/nook/global/config/WebSecurityConfig.java
+++ b/src/main/java/app/nook/global/config/WebSecurityConfig.java
@@ -56,6 +56,10 @@ public class WebSecurityConfig {
                                 "/",
                                 "/docs/**",              // REST Docs
                                 "/index.html",
+                                "/actuator/health",
+                                "/actuator/health/**",
+                                "/actuator/info",
+                                "/api/v1/auth/**",
                                 "/api/auth/**",
                                 "/ws/**",
                                 "/uploads/**"         // TODO: 임시 로컬 이미지 업로드용, 추후 S3로 변경 예정

--- a/src/main/java/app/nook/library/controller/LibraryController.java
+++ b/src/main/java/app/nook/library/controller/LibraryController.java
@@ -1,5 +1,6 @@
 package app.nook.library.controller;
 
+import app.nook.api.Api1Version;
 import app.nook.global.response.ApiResponse;
 import app.nook.global.response.SuccessCode;
 import app.nook.global.dto.CursorResponse;
@@ -20,8 +21,9 @@ import org.springframework.web.bind.annotation.*;
 import java.time.LocalDate;
 
 @RestController
+@Api1Version
 @RequiredArgsConstructor
-@RequestMapping("/api/library")
+@RequestMapping("/library")
 @Validated
 public class LibraryController {
 

--- a/src/main/java/app/nook/library/controller/LibraryStatsController.java
+++ b/src/main/java/app/nook/library/controller/LibraryStatsController.java
@@ -1,5 +1,6 @@
 package app.nook.library.controller;
 
+import app.nook.api.Api1Version;
 import app.nook.global.response.ApiResponse;
 import app.nook.global.response.SuccessCode;
 import app.nook.library.dto.FocusRankDto;
@@ -18,8 +19,9 @@ import org.springframework.web.bind.annotation.RestController;
 import java.time.YearMonth;
 
 @RestController
+@Api1Version
 @RequiredArgsConstructor
-@RequestMapping("/api/library/stats")
+@RequestMapping("/library/stats")
 @Validated
 public class LibraryStatsController {
 

--- a/src/main/java/app/nook/r2/controller/ImageUploadController.java
+++ b/src/main/java/app/nook/r2/controller/ImageUploadController.java
@@ -1,5 +1,6 @@
 package app.nook.r2.controller;
 
+import app.nook.api.Api1Version;
 import app.nook.r2.dto.ImageUploadRequestDto;
 import app.nook.r2.dto.ImageUrlResponseDto;
 import app.nook.r2.dto.MultipleImageUploadRequestDto;
@@ -15,8 +16,9 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
+@Api1Version
 @RequiredArgsConstructor
-@RequestMapping("/api/images")
+@RequestMapping("/images")
 public class ImageUploadController {
 
     private final PresignedUrlService presignedUrlService;

--- a/src/main/java/app/nook/record/controller/RecordController.java
+++ b/src/main/java/app/nook/record/controller/RecordController.java
@@ -1,6 +1,7 @@
 package app.nook.record.controller;
 
 
+import app.nook.api.Api1Version;
 import app.nook.global.response.ApiResponse;
 import app.nook.global.response.SuccessCode;
 import app.nook.record.dto.RecordRequestDto;
@@ -14,8 +15,9 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
+@Api1Version
 @RequiredArgsConstructor
-@RequestMapping("/api/records")
+@RequestMapping("/records")
 public class RecordController {
 
     private final RecordService recordService;

--- a/src/main/java/app/nook/timeline/controller/TimelineController.java
+++ b/src/main/java/app/nook/timeline/controller/TimelineController.java
@@ -1,5 +1,6 @@
 package app.nook.timeline.controller;
 
+import app.nook.api.Api1Version;
 import app.nook.global.response.ApiResponse;
 import app.nook.global.response.SuccessCode;
 import app.nook.timeline.dto.TimelineResponseDto;
@@ -12,9 +13,10 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
+@Api1Version
 @RequiredArgsConstructor
 @Validated
-@RequestMapping("/api/library/{libraryId}/timeline")
+@RequestMapping("/library/{libraryId}/timeline")
 public class TimelineController {
 
     private final TimelineQueryService timelineQueryService;

--- a/src/main/java/app/nook/user/controller/AuthController.java
+++ b/src/main/java/app/nook/user/controller/AuthController.java
@@ -1,5 +1,6 @@
 package app.nook.user.controller;
 
+import app.nook.api.Api1Version;
 import app.nook.global.response.ApiResponse;
 import app.nook.global.response.SuccessCode;
 import app.nook.user.dto.OAuthDTO;
@@ -14,8 +15,9 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
+@Api1Version
 @RequiredArgsConstructor
-@RequestMapping("/api/auth")
+@RequestMapping("/auth")
 public class AuthController {
 
     private final OAuthService oAuthService;

--- a/src/main/java/app/nook/user/controller/OnboardingController.java
+++ b/src/main/java/app/nook/user/controller/OnboardingController.java
@@ -1,5 +1,6 @@
 package app.nook.user.controller;
 
+import app.nook.api.Api1Version;
 import app.nook.global.response.ApiResponse;
 import app.nook.global.response.SuccessCode;
 import app.nook.user.dto.OnboardingDto;
@@ -12,8 +13,9 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
+@Api1Version
 @RequiredArgsConstructor
-@RequestMapping("/api/users/me/onboarding")
+@RequestMapping("/users/me/onboarding")
 public class OnboardingController {
 
     private final OnboardingService onboardingService;

--- a/src/main/java/app/nook/user/dev/MockUserInitializer.java
+++ b/src/main/java/app/nook/user/dev/MockUserInitializer.java
@@ -1,6 +1,7 @@
 package app.nook.user.dev;
 
 import app.nook.user.domain.User;
+import app.nook.user.domain.enums.UserRole;
 import app.nook.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -47,6 +48,7 @@ public class MockUserInitializer implements ApplicationRunner {
                 .nickName(nickname)
                 .provider("DEV")
                 .providerId("DEV_" + email)
+                .role(UserRole.USER)
                 .build();
 
         userRepository.save(user);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,8 +3,9 @@ spring:
     import: optional:classpath:application-secret.properties
   application:
     name: nook-api
+
   profiles:
-    active: ${SPRING_PROFILES_ACTIVE:local}
+    active: ${SPRING_PROFILES_ACTIVE:dev}
   datasource:
     url: ${DB_URL}
     username: ${DB_USERNAME}
@@ -54,10 +55,6 @@ aladin:
   base-url: ${ALADIN_BASE_URL}
   ttbkey: ${ALADIN_TTB_KEY}
 
-openai:
-  api:
-    key: ${OPENAI_API_KEY}
-
 # oauth
 auth:
   kakao:
@@ -76,3 +73,25 @@ auth:
     client-secret: ${GOOGLE_CLIENT_SECRET}
     token-request-uri: ${TOKEN_REQUEST_URI}
     user-info-uri: ${MEMBER_INFO_REQUEST_URI}
+
+logging:
+  level:
+    root: info
+    app.nook : debug
+
+management:
+  endpoints:
+    web:
+      base-path: /actuator
+      exposure:
+        include: health,info
+  endpoint:
+    health:
+      probes:
+        enabled: true
+      show-details: never
+
+info:
+  app:
+    name: ${spring.application.name}
+    version: ${APP_VERSION:0.0.1-SNAPSHOT}

--- a/src/test/java/app/nook/controller/book/BookControllerTest.java
+++ b/src/test/java/app/nook/controller/book/BookControllerTest.java
@@ -83,7 +83,7 @@
 
           given(bookService.getBookDetailByIsbn(any(), eq(isbn13))).willReturn(response);
 
-          mockMvc.perform(get("/api/books/{isbn13}", isbn13).header(AUTH_HEADER, AUTH_TOKEN))
+          mockMvc.perform(get("/api/v1/books/{isbn13}", isbn13).header(AUTH_HEADER, AUTH_TOKEN))
                   .andExpect(status().isOk())
                   .andExpect(jsonPath("$.result.title").value("채식주의자"))
                   .andDo(documentWithAuth(
@@ -113,7 +113,7 @@
       @WithCustomUser
       @DisplayName("잘못된 ISBN 형식으로 조회 시 400 Bad Request")
       void 도서_상세조회_실패_잘못된_ISBN_형식() throws Exception {
-          mockMvc.perform(get("/api/books/{isbn13}", "123").header(AUTH_HEADER, AUTH_TOKEN))
+          mockMvc.perform(get("/api/v1/books/{isbn13}", "123").header(AUTH_HEADER, AUTH_TOKEN))
                   .andExpect(status().isBadRequest());
       }
 
@@ -125,7 +125,7 @@
           given(bookService.getBookDetailByIsbn(any(), eq(isbn13)))
                   .willThrow(new CustomException(BookErrorCode.BOOK_NOT_FOUND));
 
-          mockMvc.perform(get("/api/books/{isbn13}", isbn13).header(AUTH_HEADER, AUTH_TOKEN))
+          mockMvc.perform(get("/api/v1/books/{isbn13}", isbn13).header(AUTH_HEADER, AUTH_TOKEN))
                   .andExpect(status().isNotFound());
       }
 
@@ -152,7 +152,7 @@
 
           given(bookService.getBookDetailById(any(), eq(1L))).willReturn(response);
 
-          mockMvc.perform(get("/api/books/id/{bookId}", 1L).header(AUTH_HEADER, AUTH_TOKEN))
+          mockMvc.perform(get("/api/v1/books/id/{bookId}", 1L).header(AUTH_HEADER, AUTH_TOKEN))
                   .andExpect(status().isOk())
                   .andExpect(jsonPath("$.result.bookId").value(1L))
                   .andExpect(jsonPath("$.result.title").value("테스트책"))
@@ -190,7 +190,7 @@
 
           given(bookService.getWeeklyBestsellers()).willReturn(response);
 
-          mockMvc.perform(get("/api/books/bestsellers").header(AUTH_HEADER, AUTH_TOKEN))
+          mockMvc.perform(get("/api/v1/books/bestsellers").header(AUTH_HEADER, AUTH_TOKEN))
                   .andExpect(status().isOk())
                   .andExpect(jsonPath("$.result[0].title").value("채식주의자"))
                   .andDo(documentWithAuth(
@@ -216,7 +216,7 @@
 
           given(bookService.getPersonalizedBestsellers(any())).willReturn(response);
 
-          mockMvc.perform(get("/api/books/recommendations").header(AUTH_HEADER, AUTH_TOKEN))
+          mockMvc.perform(get("/api/v1/books/recommendations").header(AUTH_HEADER, AUTH_TOKEN))
                   .andExpect(status().isOk())
                   .andExpect(jsonPath("$.result[0].title").value("채식주의자"))
                   .andDo(documentWithAuth(
@@ -250,7 +250,7 @@
 
           MockMultipartFile cover = new MockMultipartFile("coverImage", "cover.png", "image/png", "fake".getBytes());
 
-          mockMvc.perform(multipart("/api/books/user")
+          mockMvc.perform(multipart("/api/v1/books/user")
                           .file(cover)
                           .param("title", "혼모노")
                           .param("author", "성해은")
@@ -311,7 +311,7 @@
 
           MockMultipartFile cover = new MockMultipartFile("coverImage", "cover2.png", "image/png", "fake2".getBytes());
 
-          mockMvc.perform(multipart("/api/books/user/{bookId}", 101L)
+          mockMvc.perform(multipart("/api/v1/books/user/{bookId}", 101L)
                           .file(cover)
                           .param("title", "혼모노 수정")
                           .param("author", "성해은")

--- a/src/test/java/app/nook/controller/book/BookSearchControllerTest.java
+++ b/src/test/java/app/nook/controller/book/BookSearchControllerTest.java
@@ -65,7 +65,7 @@ class BookSearchControllerTest extends AbstractWebMvcRestDocsTests {
 
         // when & then
         mockMvc.perform(
-                        get("/api/books/search/{type}", "GLOBAL")
+                        get("/api/v1/books/search/{type}", "GLOBAL")
                                 .param("keyword", TEST_KEYWORD)
                                 .header(AUTH_HEADER, AUTH_TOKEN)
                 )
@@ -117,7 +117,7 @@ class BookSearchControllerTest extends AbstractWebMvcRestDocsTests {
 
         // when & then
         mockMvc.perform(
-                        get("/api/books/search/{type}", "GLOBAL")
+                        get("/api/v1/books/search/{type}", "GLOBAL")
                                 .param("keyword", TEST_KEYWORD)
                                 .param("cursor", String.valueOf(cursor))
                                 .header(AUTH_HEADER, AUTH_TOKEN)
@@ -132,7 +132,7 @@ class BookSearchControllerTest extends AbstractWebMvcRestDocsTests {
     void 도서검색_빈검색어_실패() throws Exception {
         // when & then
         mockMvc.perform(
-                        get("/api/books/search/{type}", "GLOBAL")
+                        get("/api/v1/books/search/{type}", "GLOBAL")
                                 .param("keyword", "") // 빈 문자열
                                 .header(AUTH_HEADER, AUTH_TOKEN)
                 )
@@ -145,7 +145,7 @@ class BookSearchControllerTest extends AbstractWebMvcRestDocsTests {
     void 도서검색_검색어누락_실패() throws Exception {
         // when & then
         mockMvc.perform(
-                        get("/api/books/search/{type}", "GLOBAL")
+                        get("/api/v1/books/search/{type}", "GLOBAL")
                                 // keyword 파라미터 없음
                                 .header(AUTH_HEADER, AUTH_TOKEN)
                 )
@@ -158,7 +158,7 @@ class BookSearchControllerTest extends AbstractWebMvcRestDocsTests {
     void 도서검색_음수커서_실패() throws Exception {
         // when & then
         mockMvc.perform(
-                        get("/api/books/search/{type}", "GLOBAL")
+                        get("/api/v1/books/search/{type}", "GLOBAL")
                                 .param("keyword", TEST_KEYWORD)
                                 .param("cursor", "-1") // 음수
                                 .header(AUTH_HEADER, AUTH_TOKEN)
@@ -172,7 +172,7 @@ class BookSearchControllerTest extends AbstractWebMvcRestDocsTests {
     void 도서검색_잘못된타입_실패() throws Exception {
         // when & then
         mockMvc.perform(
-                        get("/api/books/search/{type}", "INVALID_TYPE")
+                        get("/api/v1/books/search/{type}", "INVALID_TYPE")
                                 .param("keyword", TEST_KEYWORD)
                                 .header(AUTH_HEADER, AUTH_TOKEN)
                 )
@@ -191,7 +191,7 @@ class BookSearchControllerTest extends AbstractWebMvcRestDocsTests {
 
         // when & then
         mockMvc.perform(
-                        get("/api/books/search/{type}/histories", "GLOBAL")
+                        get("/api/v1/books/search/{type}/histories", "GLOBAL")
                                 .header(AUTH_HEADER, AUTH_TOKEN)
                 )
                 .andExpect(status().isOk())
@@ -221,7 +221,7 @@ class BookSearchControllerTest extends AbstractWebMvcRestDocsTests {
 
         // when & then
         mockMvc.perform(
-                        delete("/api/books/search/{type}/histories?keyword={keyword}", "GLOBAL", TEST_KEYWORD)
+                        delete("/api/v1/books/search/{type}/histories?keyword={keyword}", "GLOBAL", TEST_KEYWORD)
                                 .header(AUTH_HEADER, AUTH_TOKEN)
                 )
                 .andExpect(status().isOk())
@@ -247,7 +247,7 @@ class BookSearchControllerTest extends AbstractWebMvcRestDocsTests {
     void 검색기록삭제_검색어누락_실패() throws Exception {
         // when & then
         mockMvc.perform(
-                        delete("/api/books/search/{type}/histories", "GLOBAL")
+                        delete("/api/v1/books/search/{type}/histories", "GLOBAL")
                                 // keyword 파라미터 없음
                                 .header(AUTH_HEADER, AUTH_TOKEN)
                 )
@@ -264,7 +264,7 @@ class BookSearchControllerTest extends AbstractWebMvcRestDocsTests {
 
         // when & then
         mockMvc.perform(
-                        delete("/api/books/search/{type}/histories/all", "GLOBAL")
+                        delete("/api/v1/books/search/{type}/histories/all", "GLOBAL")
                                 .header(AUTH_HEADER, AUTH_TOKEN)
                 )
                 .andExpect(status().isOk())

--- a/src/test/java/app/nook/controller/book/CategoryControllerTest.java
+++ b/src/test/java/app/nook/controller/book/CategoryControllerTest.java
@@ -55,7 +55,7 @@ class CategoryControllerTest extends AbstractWebMvcRestDocsTests {
 
         given(categoryService.getBookCategories()).willReturn(response);
 
-        mockMvc.perform(get("/api/categories/book")
+        mockMvc.perform(get("/api/v1/categories/book")
                         .header(AUTH_HEADER, AUTH_TOKEN))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.result.categories[0].categoryId").value(1L))
@@ -75,7 +75,7 @@ class CategoryControllerTest extends AbstractWebMvcRestDocsTests {
     @Test
     @DisplayName("도서 카테고리 조회 - 인증 없음 401")
     void 도서카테고리_조회_인증없음_401() throws Exception {
-        mockMvc.perform(get("/api/categories/book"))
+        mockMvc.perform(get("/api/v1/categories/book"))
                 .andExpect(status().isUnauthorized());
     }
 }

--- a/src/test/java/app/nook/controller/focus/FocusControllerTest.java
+++ b/src/test/java/app/nook/controller/focus/FocusControllerTest.java
@@ -75,7 +75,7 @@ public class FocusControllerTest extends AbstractRestDocsTests {
 
         // when & then
         mockMvc.perform(
-                        post("/api/focuses/start")
+                        post("/api/v1/focuses/start")
                                 .header("Authorization", "Bearer test-access-token")
                                 .with(user(userDetails))
                                 .contentType(MediaType.APPLICATION_JSON)
@@ -129,7 +129,7 @@ public class FocusControllerTest extends AbstractRestDocsTests {
 
         // when & then
         mockMvc.perform(
-                        post("/api/focuses/end")
+                        post("/api/v1/focuses/end")
                                 .header("Authorization", "Bearer test-access-token")
                                 .with(user(userDetails))
                                 .contentType(MediaType.APPLICATION_JSON)

--- a/src/test/java/app/nook/controller/focus/FocusThemeControllerTest.java
+++ b/src/test/java/app/nook/controller/focus/FocusThemeControllerTest.java
@@ -59,7 +59,7 @@ public class FocusThemeControllerTest extends AbstractRestDocsTests {
 
         // when & then
         mockMvc.perform(
-                        get("/api/focuses/themes")
+                        get("/api/v1/focuses/themes")
                                 .header("Authorization", "Bearer test-access-token")
                                 .with(user(userDetails))
                 )

--- a/src/test/java/app/nook/controller/library/LibraryControllerTest.java
+++ b/src/test/java/app/nook/controller/library/LibraryControllerTest.java
@@ -74,7 +74,7 @@ class LibraryControllerTest extends AbstractWebMvcRestDocsTests {
 
         // when & then
         mockMvc.perform(
-                        post("/api/library/{bookId}", 1L)
+                        post("/api/v1/library/{bookId}", 1L)
                                 .header(AUTH_HEADER, AUTH_TOKEN)
                                 .with(csrf())
                 )
@@ -95,7 +95,7 @@ class LibraryControllerTest extends AbstractWebMvcRestDocsTests {
 
         // when & then
         mockMvc.perform(
-                        delete("/api/library/{bookId}", 1L)
+                        delete("/api/v1/library/{bookId}", 1L)
                                 .header(AUTH_HEADER, AUTH_TOKEN)
                                 .with(csrf())
                 )
@@ -118,7 +118,7 @@ class LibraryControllerTest extends AbstractWebMvcRestDocsTests {
 
         // when & then
         mockMvc.perform(
-                        patch("/api/library/status")
+                        patch("/api/v1/library/status")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(request))
                                 .header(AUTH_HEADER, AUTH_TOKEN)
@@ -144,7 +144,7 @@ class LibraryControllerTest extends AbstractWebMvcRestDocsTests {
                 .given(libraryService).changeStatus(any(), any());
 
         mockMvc.perform(
-                        patch("/api/library/status")
+                        patch("/api/v1/library/status")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(request))
                                 .header(AUTH_HEADER, AUTH_TOKEN)
@@ -182,7 +182,7 @@ class LibraryControllerTest extends AbstractWebMvcRestDocsTests {
 
         // when & then
         mockMvc.perform(
-                        get("/api/library/status")
+                        get("/api/v1/library/status")
                                 .param("status", "READING")
                                 .param("cursor", "10")
                                 .param("size", "2")
@@ -226,7 +226,7 @@ class LibraryControllerTest extends AbstractWebMvcRestDocsTests {
         given(libraryService.viewBeforeReadingBooks(any())).willReturn(response);
 
         mockMvc.perform(
-                        get("/api/library/before-reading")
+                        get("/api/v1/library/before-reading")
                                 .header(AUTH_HEADER, AUTH_TOKEN)
                 )
                 .andExpect(status().isOk())
@@ -262,7 +262,7 @@ class LibraryControllerTest extends AbstractWebMvcRestDocsTests {
                 given(libraryService.viewRecentFocus(any())).willReturn(response);
 
                 mockMvc.perform(
-                                get("/api/library/recent-focus")
+                                get("/api/v1/library/recent-focus")
                                         .header(AUTH_HEADER, AUTH_TOKEN)
                         )
                         .andExpect(status().isOk())
@@ -282,7 +282,7 @@ class LibraryControllerTest extends AbstractWebMvcRestDocsTests {
                 given(libraryService.viewRecentFocus(any())).willReturn(null);
 
                 mockMvc.perform(
-                                get("/api/library/recent-focus")
+                                get("/api/v1/library/recent-focus")
                                         .header(AUTH_HEADER, AUTH_TOKEN)
                         )
                         .andExpect(status().isOk())
@@ -310,7 +310,7 @@ class LibraryControllerTest extends AbstractWebMvcRestDocsTests {
                         .willReturn(new LibraryViewDto.BookCountResponseDto(42));
 
                 mockMvc.perform(
-                                get("/api/library/count")
+                                get("/api/v1/library/count")
                                         .header(AUTH_HEADER, AUTH_TOKEN)
                         )
                         .andExpect(status().isOk())
@@ -330,7 +330,7 @@ class LibraryControllerTest extends AbstractWebMvcRestDocsTests {
             @Test
             @DisplayName("인증 정보가 없으면 401")
             void viewBookCountWithoutAuth() throws Exception {
-                mockMvc.perform(get("/api/library/count"))
+                mockMvc.perform(get("/api/v1/library/count"))
                         .andExpect(status().isUnauthorized());
             }
         }
@@ -363,7 +363,7 @@ class LibraryControllerTest extends AbstractWebMvcRestDocsTests {
                         .willReturn(response);
 
                 mockMvc.perform(
-                                get("/api/library/focus-records")
+                                get("/api/v1/library/focus-records")
                                         .param("date", "2026-02-26")
                                         .param("cursor", "100")
                                         .param("size", "20")
@@ -400,7 +400,7 @@ class LibraryControllerTest extends AbstractWebMvcRestDocsTests {
             @WithCustomUser
             void invalidDateFormat() throws Exception {
                 mockMvc.perform(
-                                get("/api/library/focus-records")
+                                get("/api/v1/library/focus-records")
                                         .param("date", "2026/02/26")
                                         .header(AUTH_HEADER, AUTH_TOKEN)
                         )

--- a/src/test/java/app/nook/controller/library/LibraryStatsControllerTest.java
+++ b/src/test/java/app/nook/controller/library/LibraryStatsControllerTest.java
@@ -81,7 +81,7 @@ class LibraryStatsControllerTest extends AbstractWebMvcRestDocsTests {
                         .willReturn(response);
 
                 mockMvc.perform(
-                                get("/api/library/stats/monthly")
+                                get("/api/v1/library/stats/monthly")
                                         .param("yearMonth", "2026-02")
                                         .header(AUTH_HEADER, AUTH_TOKEN)
                         )
@@ -113,7 +113,7 @@ class LibraryStatsControllerTest extends AbstractWebMvcRestDocsTests {
             @DisplayName("인증 정보가 없으면 401")
             void viewMonthlyStatsWithoutAuth() throws Exception {
                 mockMvc.perform(
-                                get("/api/library/stats/monthly")
+                                get("/api/v1/library/stats/monthly")
                                         .param("yearMonth", "2026-02")
                         )
                         .andExpect(status().isUnauthorized());
@@ -153,7 +153,7 @@ class LibraryStatsControllerTest extends AbstractWebMvcRestDocsTests {
                         .willReturn(response);
 
                 mockMvc.perform(
-                                get("/api/library/stats/focus-monthly")
+                                get("/api/v1/library/stats/focus-monthly")
                                         .param("yearMonth", "2026-02")
                                         .header(AUTH_HEADER, AUTH_TOKEN)
                         )
@@ -183,7 +183,7 @@ class LibraryStatsControllerTest extends AbstractWebMvcRestDocsTests {
             @WithCustomUser
             void invalidYearMonthFormat() throws Exception {
                 mockMvc.perform(
-                                get("/api/library/stats/focus-monthly")
+                                get("/api/v1/library/stats/focus-monthly")
                                         .param("yearMonth", "2026/02")
                                         .header(AUTH_HEADER, AUTH_TOKEN)
                         )

--- a/src/test/java/app/nook/controller/r2/ImageUploadControllerTest.java
+++ b/src/test/java/app/nook/controller/r2/ImageUploadControllerTest.java
@@ -75,7 +75,7 @@ class ImageUploadControllerTest extends AbstractWebMvcRestDocsTests {
                         .willReturn(response);
 
                 // when & then
-                mockMvc.perform(post("/api/images/upload-url")
+                mockMvc.perform(post("/api/v1/images/upload-url")
                                 .header(AUTH_HEADER, AUTH_TOKEN)
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(
@@ -117,7 +117,7 @@ class ImageUploadControllerTest extends AbstractWebMvcRestDocsTests {
                         .willReturn(response);
 
                 // when & then
-                mockMvc.perform(post("/api/images/upload-urls")
+                mockMvc.perform(post("/api/v1/images/upload-urls")
                                 .header(AUTH_HEADER, AUTH_TOKEN)
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(
@@ -155,7 +155,7 @@ class ImageUploadControllerTest extends AbstractWebMvcRestDocsTests {
             @WithCustomUser
             void 단건_업로드_URL_발급_실패_유효하지않은_파일타입() throws Exception {
                 // when & then
-                mockMvc.perform(post("/api/images/upload-url")
+                mockMvc.perform(post("/api/v1/images/upload-url")
                                 .header(AUTH_HEADER, AUTH_TOKEN)
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(

--- a/src/test/java/app/nook/controller/record/RecordControllerTest.java
+++ b/src/test/java/app/nook/controller/record/RecordControllerTest.java
@@ -85,7 +85,7 @@ class RecordControllerTest extends AbstractWebMvcRestDocsTests {
                 willDoNothing().given(recordService).createRecord(any(), anyLong(), any());
 
                 // when & then
-                mockMvc.perform(post("/api/records/books/{bookId}", 1L)
+                mockMvc.perform(post("/api/v1/records/books/{bookId}", 1L)
                                 .header(AUTH_HEADER, AUTH_TOKEN)
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(request)))
@@ -123,7 +123,7 @@ class RecordControllerTest extends AbstractWebMvcRestDocsTests {
                 );
 
                 // when & then
-                mockMvc.perform(post("/api/records/books/{bookId}", 1L)
+                mockMvc.perform(post("/api/v1/records/books/{bookId}", 1L)
                                 .header(AUTH_HEADER, AUTH_TOKEN)
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(request)))
@@ -152,7 +152,7 @@ class RecordControllerTest extends AbstractWebMvcRestDocsTests {
             willDoNothing().given(recordService).updateRecord(any(), anyLong(), any());
 
             // when & then
-            mockMvc.perform(put("/api/records/{recordId}", 10L)
+            mockMvc.perform(put("/api/v1/records/{recordId}", 10L)
                             .header(AUTH_HEADER, AUTH_TOKEN)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
@@ -190,7 +190,7 @@ class RecordControllerTest extends AbstractWebMvcRestDocsTests {
                 willDoNothing().given(recordService).deleteRecord(any(), anyLong());
 
                 // when & then
-                mockMvc.perform(delete("/api/records/{recordId}", 10L)
+                mockMvc.perform(delete("/api/v1/records/{recordId}", 10L)
                                 .header(AUTH_HEADER, AUTH_TOKEN))
                         .andExpect(status().isOk())
                         .andDo(documentWithAuth(
@@ -215,7 +215,7 @@ class RecordControllerTest extends AbstractWebMvcRestDocsTests {
                         .given(recordService).deleteRecord(any(), anyLong());
 
                 // when & then
-                mockMvc.perform(delete("/api/records/{recordId}", 999L)
+                mockMvc.perform(delete("/api/v1/records/{recordId}", 999L)
                                 .header(AUTH_HEADER, AUTH_TOKEN))
                         .andExpect(status().isNotFound())
                         .andExpect(jsonPath("$.isSuccess").value(false))
@@ -236,7 +236,7 @@ class RecordControllerTest extends AbstractWebMvcRestDocsTests {
             given(recordService.countRecords(anyLong())).willReturn(response);
 
             // when & then
-            mockMvc.perform(get("/api/records/count")
+            mockMvc.perform(get("/api/v1/records/count")
                             .header(AUTH_HEADER, AUTH_TOKEN))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.result.count").value(12))

--- a/src/test/java/app/nook/controller/timeline/TimelineControllerTest.java
+++ b/src/test/java/app/nook/controller/timeline/TimelineControllerTest.java
@@ -103,7 +103,7 @@ class TimelineControllerTest extends AbstractWebMvcRestDocsTests {
                         .willReturn(response);
 
                 mockMvc.perform(
-                                get("/api/library/{libraryId}/timeline/summary", 12L)
+                                get("/api/v1/library/{libraryId}/timeline/summary", 12L)
                                         .header(AUTH_HEADER, AUTH_TOKEN)
                         )
                         .andExpect(status().isOk())
@@ -149,7 +149,7 @@ class TimelineControllerTest extends AbstractWebMvcRestDocsTests {
             @DisplayName("인증 정보가 없으면 401")
             void getTimelineSummaryWithoutAuth() throws Exception {
                 mockMvc.perform(
-                                get("/api/library/{libraryId}/timeline/summary", 12L)
+                                get("/api/v1/library/{libraryId}/timeline/summary", 12L)
                         )
                         .andExpect(status().isUnauthorized());
             }
@@ -196,7 +196,7 @@ class TimelineControllerTest extends AbstractWebMvcRestDocsTests {
                         .willReturn(response);
 
                 mockMvc.perform(
-                                get("/api/library/{libraryId}/timeline", 12L)
+                                get("/api/v1/library/{libraryId}/timeline", 12L)
                                         .header(AUTH_HEADER, AUTH_TOKEN)
                         )
                         .andExpect(status().isOk())
@@ -231,7 +231,7 @@ class TimelineControllerTest extends AbstractWebMvcRestDocsTests {
             @DisplayName("인증 정보가 없으면 401")
             void invalidSize() throws Exception {
                 mockMvc.perform(
-                                get("/api/library/{libraryId}/timeline", 12L)
+                                get("/api/v1/library/{libraryId}/timeline", 12L)
                         )
                         .andExpect(status().isUnauthorized());
             }
@@ -262,7 +262,7 @@ class TimelineControllerTest extends AbstractWebMvcRestDocsTests {
                     .willReturn(response);
 
             mockMvc.perform(
-                            get("/api/library/{libraryId}/timeline/{timelineId}", 12L, 31L)
+                            get("/api/v1/library/{libraryId}/timeline/{timelineId}", 12L, 31L)
                                     .header(AUTH_HEADER, AUTH_TOKEN)
                     )
                     .andExpect(status().isOk())

--- a/src/test/java/app/nook/controller/user/AuthControllerTest.java
+++ b/src/test/java/app/nook/controller/user/AuthControllerTest.java
@@ -73,7 +73,7 @@ class AuthControllerTest extends AbstractWebMvcRestDocsTests {
 
         // when & then
         mockMvc.perform(
-                        post("/api/auth/oauth")
+                        post("/api/v1/auth/oauth")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(request))
                 )
@@ -113,7 +113,7 @@ class AuthControllerTest extends AbstractWebMvcRestDocsTests {
 
         // when & then
         mockMvc.perform(
-                        post("/api/auth/dev/login")
+                        post("/api/v1/auth/dev/login")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(request))
                 )
@@ -144,7 +144,7 @@ class AuthControllerTest extends AbstractWebMvcRestDocsTests {
                 .willThrow(new CustomException(ErrorCode.INVALID_OAUTH_PROVIDER));
 
         mockMvc.perform(
-                        post("/api/auth/oauth")
+                        post("/api/v1/auth/oauth")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(request))
                 )
@@ -160,7 +160,7 @@ class AuthControllerTest extends AbstractWebMvcRestDocsTests {
                 .willThrow(new CustomException(ErrorCode.USER_NOT_FOUND));
 
         mockMvc.perform(
-                        post("/api/auth/dev/login")
+                        post("/api/v1/auth/dev/login")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(request))
                 )
@@ -192,7 +192,7 @@ class AuthControllerTest extends AbstractWebMvcRestDocsTests {
 
         // when & then
         mockMvc.perform(
-                        get("/api/auth/me")
+                        get("/api/v1/auth/me")
                                 .header("Authorization", "Bearer test-access-token")
                                 .with(user(userDetails))
                 )

--- a/src/test/java/app/nook/controller/user/OnboardingControllerTest.java
+++ b/src/test/java/app/nook/controller/user/OnboardingControllerTest.java
@@ -74,7 +74,7 @@ public class OnboardingControllerTest extends AbstractWebMvcRestDocsTests {
         MockPart nickname = new MockPart("nickname", "nick_01".getBytes());
         MockPart categories = new MockPart("categories", "에세이".getBytes());
 
-        mockMvc.perform(multipart("/api/users/me/onboarding/complete")
+        mockMvc.perform(multipart("/api/v1/users/me/onboarding/complete")
                         .file(profile)
                         .part(goal)
                         .part(nickname)
@@ -105,7 +105,7 @@ public class OnboardingControllerTest extends AbstractWebMvcRestDocsTests {
     @WithCustomUser
     @DisplayName("온보딩 완료 실패 - goal 범위 초과")
     void 온보딩완료_실패_goal범위초과() throws Exception {
-        mockMvc.perform(multipart("/api/users/me/onboarding/complete")
+        mockMvc.perform(multipart("/api/v1/users/me/onboarding/complete")
                         .param("goal", "301")
                         .param("nickname", "nick_01")
                         .param("categories", "에세이")
@@ -117,7 +117,7 @@ public class OnboardingControllerTest extends AbstractWebMvcRestDocsTests {
     @WithCustomUser
     @DisplayName("온보딩 완료 실패 - categories 누락")
     void 온보딩완료_실패_categories누락() throws Exception {
-        mockMvc.perform(multipart("/api/users/me/onboarding/complete")
+        mockMvc.perform(multipart("/api/v1/users/me/onboarding/complete")
                         .param("goal", "100")
                         .param("nickname", "nick_01")
                         .header(AUTH_HEADER, AUTH_TOKEN))
@@ -132,7 +132,7 @@ public class OnboardingControllerTest extends AbstractWebMvcRestDocsTests {
         OnboardingDto.StatusResponse response = new OnboardingDto.StatusResponse(false, completedAt);
         given(onboardingService.getOnboardingStatus(anyLong())).willReturn(response);
 
-        mockMvc.perform(get("/api/users/me/onboarding/status")
+        mockMvc.perform(get("/api/v1/users/me/onboarding/status")
                         .header(AUTH_HEADER, AUTH_TOKEN))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.result.needsOnboarding").value(false))
@@ -154,7 +154,7 @@ public class OnboardingControllerTest extends AbstractWebMvcRestDocsTests {
         OnboardingDto.GoalResponse response = new OnboardingDto.GoalResponse((short) 100, 73);
         given(onboardingService.getGoal(anyLong())).willReturn(response);
 
-        mockMvc.perform(get("/api/users/me/onboarding/goal")
+        mockMvc.perform(get("/api/v1/users/me/onboarding/goal")
                         .header(AUTH_HEADER, AUTH_TOKEN))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.result.goal").value(100))
@@ -177,7 +177,7 @@ public class OnboardingControllerTest extends AbstractWebMvcRestDocsTests {
         OnboardingDto.GoalUpdateResponse response = new OnboardingDto.GoalUpdateResponse((short) 120);
         given(onboardingService.updateGoal(anyLong(), any())).willReturn(response);
 
-        mockMvc.perform(patch("/api/users/me/onboarding/goal")
+        mockMvc.perform(patch("/api/v1/users/me/onboarding/goal")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(Map.of("goal", 120)))
                         .header(AUTH_HEADER, AUTH_TOKEN))
@@ -200,7 +200,7 @@ public class OnboardingControllerTest extends AbstractWebMvcRestDocsTests {
     @WithCustomUser
     @DisplayName("독서 목표 수정 실패 - goal 0")
     void 독서목표_수정_실패_goal0() throws Exception {
-        mockMvc.perform(patch("/api/users/me/onboarding/goal")
+        mockMvc.perform(patch("/api/v1/users/me/onboarding/goal")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(Map.of("goal", 0)))
                         .header(AUTH_HEADER, AUTH_TOKEN))
@@ -210,7 +210,7 @@ public class OnboardingControllerTest extends AbstractWebMvcRestDocsTests {
     @Test
     @DisplayName("인증 없음 - 온보딩 완료 401")
     void 인증없음_complete_401() throws Exception {
-        mockMvc.perform(multipart("/api/users/me/onboarding/complete")
+        mockMvc.perform(multipart("/api/v1/users/me/onboarding/complete")
                         .param("goal", "100")
                         .param("nickname", "nick_01")
                         .param("categories", "에세이"))
@@ -220,21 +220,21 @@ public class OnboardingControllerTest extends AbstractWebMvcRestDocsTests {
     @Test
     @DisplayName("인증 없음 - 상태 조회 401")
     void 인증없음_status_401() throws Exception {
-        mockMvc.perform(get("/api/users/me/onboarding/status"))
+        mockMvc.perform(get("/api/v1/users/me/onboarding/status"))
                 .andExpect(status().isUnauthorized());
     }
 
     @Test
     @DisplayName("인증 없음 - 목표 조회 401")
     void 인증없음_goal_get_401() throws Exception {
-        mockMvc.perform(get("/api/users/me/onboarding/goal"))
+        mockMvc.perform(get("/api/v1/users/me/onboarding/goal"))
                 .andExpect(status().isUnauthorized());
     }
 
     @Test
     @DisplayName("인증 없음 - 목표 수정 401")
     void 인증없음_goal_patch_401() throws Exception {
-        mockMvc.perform(patch("/api/users/me/onboarding/goal")
+        mockMvc.perform(patch("/api/v1/users/me/onboarding/goal")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(Map.of("goal", 100))))
                 .andExpect(status().isUnauthorized());

--- a/src/test/java/app/nook/global/common/TestSecurityConfig.java
+++ b/src/test/java/app/nook/global/common/TestSecurityConfig.java
@@ -22,6 +22,7 @@ public class TestSecurityConfig {
                                 response.sendError(HttpStatus.UNAUTHORIZED.value()))
                 )
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/v1/auth/**").permitAll()
                         .requestMatchers("/api/auth/**").permitAll()
                         .requestMatchers("/api/**").authenticated()
                         .anyRequest().permitAll()

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -32,7 +32,7 @@ cloudflare:
     secret-key: test-secret-key
 
 jwt:
-  secret: test-jwt-secret
+  secret: YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWE=
 aladin:
   base-url: https://www.aladin.co.kr/ttb/api
   ttbkey: test-aladin-ttb-key

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -18,3 +18,39 @@ spring:
   sql:
     init:
       mode: never
+
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
+cloudflare:
+  r2:
+    endpoint: https://example.r2.cloudflarestorage.com
+    bucket-name: test-bucket
+    access-key: test-access-key
+    secret-key: test-secret-key
+
+jwt:
+  secret: test-jwt-secret
+aladin:
+  base-url: https://www.aladin.co.kr/ttb/api
+  ttbkey: test-aladin-ttb-key
+
+auth:
+  kakao:
+    client-id: test-kakao-client-id
+    client-secret: test-kakao-client-secret
+    redirect-uri: http://localhost:8080/test/kakao/callback
+    token-request-uri: https://kauth.kakao.com/oauth/token
+    user-info-uri: https://kapi.kakao.com/v2/user/me
+    logout-uri: https://kapi.kakao.com/v1/user/logout
+    unlink-uri: https://kapi.kakao.com/v1/user/unlink
+    admin-key: test-kakao-admin-key
+    logout-redirect-uri: http://localhost:8080/test/kakao/logout
+  google:
+    redirect-uri: http://localhost:8080/test/google/callback
+    client-id: test-google-client-id
+    client-secret: test-google-client-secret
+    token-request-uri: https://oauth2.googleapis.com/token
+    user-info-uri: https://openidconnect.googleapis.com/v1/userinfo


### PR DESCRIPTION
## 📄 작업 내용 요약
<!-- 무엇을 작업했는지 간단하게 요약해주세요 -->
CICD 배포 파이프라인 설정
- RestDocs, Jacoco 문서 생성
- 실패시 디스코드 알림
- 도커 이미지 push
- blue green 배포 설정

API V1으로 일괄수정

TODO 
- NPM 설정 -> 관리자 페이지에서 설정
- 그라파냐 alert 설정
---

## 📎 Issue 번호
<!-- 관련된 이슈가 있다면 닫히도록 연결해주세요 (ex: closed #1) -->

- closed #240 

---

## ✅ 작업 목록
<!-- 체크박스로 완료한 작업을 표시해주세요 -->

- [ ] 기능 구현
- [ ] 코드 리뷰 반영
- [ ] 테스트 코드 작성
- [ ] 문서 업데이트

---

## 📝 기타 참고사항
<!-- 리뷰어가 참고하면 좋을 추가 정보나 질문이 있다면 자유롭게 작성해주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * API 버전 관리 체계 도입 - 모든 API 엔드포인트가 `/api/v1` 접두사 사용
  * 헬스 체크 및 애플리케이션 정보 엔드포인트 공개

* **Chores**
  * CI-CD 파이프라인 개선 - 빌드, 배포, 모니터링 단계 분리 및 취약성 스캔 추가
  * Docker 빌드 프로세스 최적화

* **Tests**
  * 모든 API 테스트 경로를 버전화된 엔드포인트로 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->