### PR TITLE
[FEAT] 독서 목표 진행률 응답 필드 추가

### DIFF
--- a/src/main/java/app/nook/user/dto/OnboardingDto.java
+++ b/src/main/java/app/nook/user/dto/OnboardingDto.java
@@ -45,6 +45,7 @@ public class OnboardingDto {
 
     public record GoalResponse(
             short goal,
-            int remainingCount
+            int remainingCount,
+            int progressPercent
     ) {}
 }

--- a/src/main/java/app/nook/user/service/OnboardingService.java
+++ b/src/main/java/app/nook/user/service/OnboardingService.java
@@ -124,11 +124,12 @@ public class OnboardingService {
         User user = getUser(userId);
         long finishedCount = libraryRepository.countByUserAndReadingStatus(user, ReadingStatus.FINISHED);
         int remaining = Math.max(0, user.getGoal() - (int) finishedCount);
+        int progressPercent = calculateProgressPercent(user.getGoal(), finishedCount);
 
-        log.info("[GOAL_STATUS] userId={}, goal={}, finishedCount={}, remaining={}",
-                userId, user.getGoal(), finishedCount, remaining);
+        log.info("[GOAL_STATUS] userId={}, goal={}, finishedCount={}, remaining={}, progressPercent={}",
+                userId, user.getGoal(), finishedCount, remaining, progressPercent);
 
-        return new OnboardingDto.GoalResponse(user.getGoal(), remaining);
+        return new OnboardingDto.GoalResponse(user.getGoal(), remaining, progressPercent);
     }
 
     @Transactional
@@ -165,6 +166,13 @@ public class OnboardingService {
             return selected.get(0);
         }
         return selected.get(ThreadLocalRandom.current().nextInt(selected.size()));
+    }
+
+    private int calculateProgressPercent(short goal, long finishedCount) {
+        if (goal <= 0) {
+            return 0;
+        }
+        return (int) Math.min(100, finishedCount * 100 / goal);
     }
 
     private User getUser(Long userId) {

--- a/src/main/java/app/nook/user/service/OnboardingService.java
+++ b/src/main/java/app/nook/user/service/OnboardingService.java
@@ -123,7 +123,7 @@ public class OnboardingService {
     public OnboardingDto.GoalResponse getGoal(Long userId) {
         User user = getUser(userId);
         long finishedCount = libraryRepository.countByUserAndReadingStatus(user, ReadingStatus.FINISHED);
-        int remaining = Math.max(0, user.getGoal() - (int) finishedCount);
+        int remaining = calculateRemainingCount(user.getGoal(), finishedCount);
         int progressPercent = calculateProgressPercent(user.getGoal(), finishedCount);
 
         log.info("[GOAL_STATUS] userId={}, goal={}, finishedCount={}, remaining={}, progressPercent={}",
@@ -168,11 +168,21 @@ public class OnboardingService {
         return selected.get(ThreadLocalRandom.current().nextInt(selected.size()));
     }
 
+    private int calculateRemainingCount(short goal, long finishedCount) {
+        if (finishedCount >= goal) {
+            return 0;
+        }
+        return goal - (int) finishedCount;
+    }
+
     private int calculateProgressPercent(short goal, long finishedCount) {
         if (goal <= 0) {
             return 0;
         }
-        return (int) Math.min(100, finishedCount * 100 / goal);
+        if (finishedCount >= goal) {
+            return 100;
+        }
+        return (int) (finishedCount * 100 / goal);
     }
 
     private User getUser(Long userId) {

--- a/src/test/java/app/nook/controller/user/OnboardingControllerTest.java
+++ b/src/test/java/app/nook/controller/user/OnboardingControllerTest.java
@@ -149,7 +149,7 @@ public class OnboardingControllerTest extends AbstractWebMvcRestDocsTests {
     @WithCustomUser
     @DisplayName("독서 목표 조회 성공")
     void 독서목표_조회_성공() throws Exception {
-        OnboardingDto.GoalResponse response = new OnboardingDto.GoalResponse((short) 100, 73);
+        OnboardingDto.GoalResponse response = new OnboardingDto.GoalResponse((short) 100, 73, 27);
         given(onboardingService.getGoal(anyLong())).willReturn(response);
 
         mockMvc.perform(get("/api/v1/users/me/onboarding/goal")
@@ -157,12 +157,14 @@ public class OnboardingControllerTest extends AbstractWebMvcRestDocsTests {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.result.goal").value(100))
                 .andExpect(jsonPath("$.result.remainingCount").value(73))
+                .andExpect(jsonPath("$.result.progressPercent").value(27))
                 .andDo(documentWithAuth(
                         "{class-name}/{method-name}",
                         responseFields(
                                 ApiResponseSnippet.withResult(
                                         fieldWithPath("result.goal").description("독서 목표 권수"),
-                                        fieldWithPath("result.remainingCount").description("남은 권수")
+                                        fieldWithPath("result.remainingCount").description("남은 권수"),
+                                        fieldWithPath("result.progressPercent").description("독서 목표 진행률(0~100)")
                                 )
                         )
                 ));

--- a/src/test/java/app/nook/user/service/OnboardingServiceTest.java
+++ b/src/test/java/app/nook/user/service/OnboardingServiceTest.java
@@ -278,8 +278,21 @@ class OnboardingServiceTest {
     }
 
     @Test
-    @DisplayName("getGoal: goal이 0이면 progressPercent는 0")
-    void getGoal_zeroGoal_progressPercentZero() {
+    @DisplayName("getGoal: goal이 0 이하이면 progressPercent는 0")
+    void getGoal_goalLessThanOrEqualToZero_progressPercentZero() {
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+        given(libraryRepository.countByUserAndReadingStatus(user, ReadingStatus.FINISHED)).willReturn(3L);
+
+        OnboardingDto.GoalResponse res = onboardingService.getGoal(1L);
+
+        assertThat(res.remainingCount()).isEqualTo(0);
+        assertThat(res.progressPercent()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("getGoal: goal이 음수이면 progressPercent는 0")
+    void getGoal_negativeGoal_progressPercentZero() {
+        user.updateGoal((short) -1);
         given(userRepository.findById(1L)).willReturn(Optional.of(user));
         given(libraryRepository.countByUserAndReadingStatus(user, ReadingStatus.FINISHED)).willReturn(3L);
 

--- a/src/test/java/app/nook/user/service/OnboardingServiceTest.java
+++ b/src/test/java/app/nook/user/service/OnboardingServiceTest.java
@@ -251,7 +251,7 @@ class OnboardingServiceTest {
     }
 
     @Test
-    @DisplayName("getGoal: remainingCount = max(0, goal - finished)")
+    @DisplayName("getGoal: remainingCount = max(0, goal - finished), progressPercent = finished / goal * 100")
     void getGoal_remainingCount() {
         user.updateGoal((short) 10);
         given(userRepository.findById(1L)).willReturn(Optional.of(user));
@@ -261,10 +261,11 @@ class OnboardingServiceTest {
 
         assertThat(res.goal()).isEqualTo((short) 10);
         assertThat(res.remainingCount()).isEqualTo(7);
+        assertThat(res.progressPercent()).isEqualTo(30);
     }
 
     @Test
-    @DisplayName("getGoal: finished가 goal보다 크면 0")
+    @DisplayName("getGoal: finished가 goal보다 크면 remainingCount는 0, progressPercent는 100")
     void getGoal_floorZero() {
         user.updateGoal((short) 5);
         given(userRepository.findById(1L)).willReturn(Optional.of(user));
@@ -273,6 +274,19 @@ class OnboardingServiceTest {
         OnboardingDto.GoalResponse res = onboardingService.getGoal(1L);
 
         assertThat(res.remainingCount()).isEqualTo(0);
+        assertThat(res.progressPercent()).isEqualTo(100);
+    }
+
+    @Test
+    @DisplayName("getGoal: goal이 0이면 progressPercent는 0")
+    void getGoal_zeroGoal_progressPercentZero() {
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+        given(libraryRepository.countByUserAndReadingStatus(user, ReadingStatus.FINISHED)).willReturn(3L);
+
+        OnboardingDto.GoalResponse res = onboardingService.getGoal(1L);
+
+        assertThat(res.remainingCount()).isEqualTo(0);
+        assertThat(res.progressPercent()).isEqualTo(0);
     }
 
     @Test


### PR DESCRIPTION
## 📄 작업 내용 요약
<!-- 무엇을 작업했는지 간단하게 요약해주세요 -->
  - 독서 목표 조회 API 응답에 `progressPercent` 필드 추가
  - 완독 권수 기준 독서 목표 진행률 계산 로직 추가
---

## 📎 Issue 번호
<!-- 관련된 이슈가 있다면 닫히도록 연결해주세요 (ex: closed #1) -->

- closed #246 

---

## ✅ 작업 목록
<!-- 체크박스로 완료한 작업을 표시해주세요 -->

- [x] 기능 구현
- [x] 코드 리뷰 반영
- [x] 테스트 코드 작성
- [x] 문서 업데이트

---

## 📝 기타 참고사항
<!-- 리뷰어가 참고하면 좋을 추가 정보나 질문이 있다면 자유롭게 작성해주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 독서 목표 조회 시 목표 진행률(0~100%)이 추가되어 사용자가 목표 달성 진행 상황을 더 명확하게 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->