### PR TITLE
[REFACTOR] 검색 API RestDocs 문서 섹션 분리

### DIFF
--- a/src/docs/asciidoc/book.adoc
+++ b/src/docs/asciidoc/book.adoc
@@ -26,29 +26,6 @@ include::{snippets}/book-controller-test/추천베스트셀러_조회_성공/htt
 include::{snippets}/book-controller-test/추천베스트셀러_조회_성공/http-response.adoc[]
 include::{snippets}/book-controller-test/추천베스트셀러_조회_성공/response-fields.adoc[]
 
-=== 내 서재 검색 홈 조회
-
-==== 최근 포커스와 읽기 전이 모두 있는 경우
-
-include::{snippets}/book-search-controller-test/내서재검색홈_조회_성공/http-request.adoc[]
-include::{snippets}/book-search-controller-test/내서재검색홈_조회_성공/http-response.adoc[]
-include::{snippets}/book-search-controller-test/내서재검색홈_조회_성공/response-fields.adoc[]
-
-==== 최근 포커스만 있는 경우
-
-include::{snippets}/book-search-controller-test/내서재검색홈_조회_최근포커스만_성공/http-request.adoc[]
-include::{snippets}/book-search-controller-test/내서재검색홈_조회_최근포커스만_성공/http-response.adoc[]
-
-==== 읽기 전만 있는 경우
-
-include::{snippets}/book-search-controller-test/내서재검색홈_조회_읽기전만_성공/http-request.adoc[]
-include::{snippets}/book-search-controller-test/내서재검색홈_조회_읽기전만_성공/http-response.adoc[]
-
-==== 추천만 있는 경우
-
-include::{snippets}/book-search-controller-test/내서재검색홈_조회_추천만_성공/http-request.adoc[]
-include::{snippets}/book-search-controller-test/내서재검색홈_조회_추천만_성공/http-response.adoc[]
-
 === 도서 카테고리 조회
 
 include::{snippets}/category-controller-test/도서카테고리_조회_성공/http-request.adoc[]

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -8,6 +8,9 @@
 == 사용자
 include::user.adoc[]
 
+== 검색
+include::search.adoc[]
+
 == 도서
 include::book.adoc[]
 

--- a/src/docs/asciidoc/search.adoc
+++ b/src/docs/asciidoc/search.adoc
@@ -1,0 +1,63 @@
+== 도서 검색
+
+include::{snippets}/book-search-controller-test/도서검색_첫검색_성공/http-request.adoc[]
+include::{snippets}/book-search-controller-test/도서검색_첫검색_성공/request-headers.adoc[]
+include::{snippets}/book-search-controller-test/도서검색_첫검색_성공/path-parameters.adoc[]
+include::{snippets}/book-search-controller-test/도서검색_첫검색_성공/query-parameters.adoc[]
+include::{snippets}/book-search-controller-test/도서검색_첫검색_성공/http-response.adoc[]
+include::{snippets}/book-search-controller-test/도서검색_첫검색_성공/response-fields.adoc[]
+
+== 검색 기록 조회
+
+include::{snippets}/book-search-controller-test/검색기록조회_성공/http-request.adoc[]
+include::{snippets}/book-search-controller-test/검색기록조회_성공/request-headers.adoc[]
+include::{snippets}/book-search-controller-test/검색기록조회_성공/path-parameters.adoc[]
+include::{snippets}/book-search-controller-test/검색기록조회_성공/http-response.adoc[]
+include::{snippets}/book-search-controller-test/검색기록조회_성공/response-fields.adoc[]
+
+== 검색 기록 삭제
+
+include::{snippets}/book-search-controller-test/검색기록삭제_성공/http-request.adoc[]
+include::{snippets}/book-search-controller-test/검색기록삭제_성공/request-headers.adoc[]
+include::{snippets}/book-search-controller-test/검색기록삭제_성공/path-parameters.adoc[]
+include::{snippets}/book-search-controller-test/검색기록삭제_성공/query-parameters.adoc[]
+include::{snippets}/book-search-controller-test/검색기록삭제_성공/http-response.adoc[]
+include::{snippets}/book-search-controller-test/검색기록삭제_성공/response-fields.adoc[]
+
+== 검색 기록 전체 삭제
+
+include::{snippets}/book-search-controller-test/검색기록전체삭제_성공/http-request.adoc[]
+include::{snippets}/book-search-controller-test/검색기록전체삭제_성공/request-headers.adoc[]
+include::{snippets}/book-search-controller-test/검색기록전체삭제_성공/path-parameters.adoc[]
+include::{snippets}/book-search-controller-test/검색기록전체삭제_성공/http-response.adoc[]
+include::{snippets}/book-search-controller-test/검색기록전체삭제_성공/response-fields.adoc[]
+
+== 내 서재 검색 홈 조회
+
+=== 최근 포커스와 읽기 전이 모두 있는 경우
+
+include::{snippets}/book-search-controller-test/내서재검색홈_조회_성공/http-request.adoc[]
+include::{snippets}/book-search-controller-test/내서재검색홈_조회_성공/request-headers.adoc[]
+include::{snippets}/book-search-controller-test/내서재검색홈_조회_성공/http-response.adoc[]
+include::{snippets}/book-search-controller-test/내서재검색홈_조회_성공/response-fields.adoc[]
+
+=== 최근 포커스만 있는 경우
+
+include::{snippets}/book-search-controller-test/내서재검색홈_조회_최근포커스만_성공/http-request.adoc[]
+include::{snippets}/book-search-controller-test/내서재검색홈_조회_최근포커스만_성공/request-headers.adoc[]
+include::{snippets}/book-search-controller-test/내서재검색홈_조회_최근포커스만_성공/http-response.adoc[]
+include::{snippets}/book-search-controller-test/내서재검색홈_조회_최근포커스만_성공/response-fields.adoc[]
+
+=== 읽기 전만 있는 경우
+
+include::{snippets}/book-search-controller-test/내서재검색홈_조회_읽기전만_성공/http-request.adoc[]
+include::{snippets}/book-search-controller-test/내서재검색홈_조회_읽기전만_성공/request-headers.adoc[]
+include::{snippets}/book-search-controller-test/내서재검색홈_조회_읽기전만_성공/http-response.adoc[]
+include::{snippets}/book-search-controller-test/내서재검색홈_조회_읽기전만_성공/response-fields.adoc[]
+
+=== 추천만 있는 경우
+
+include::{snippets}/book-search-controller-test/내서재검색홈_조회_추천만_성공/http-request.adoc[]
+include::{snippets}/book-search-controller-test/내서재검색홈_조회_추천만_성공/request-headers.adoc[]
+include::{snippets}/book-search-controller-test/내서재검색홈_조회_추천만_성공/http-response.adoc[]
+include::{snippets}/book-search-controller-test/내서재검색홈_조회_추천만_성공/response-fields.adoc[]


### PR DESCRIPTION
## 📄 작업 내용 요약
<!-- 무엇을 작업했는지 간단하게 요약해주세요 -->
  - 검색 관련 RestDocs 문서를 `도서` 섹션에서 별도 `검색` 섹션으로 분리
  - `search.adoc` 신규 추가 및 검색 API 스니펫 정리
  - `book.adoc`에서 내 서재 검색 홈 문서 블록 제거
---

## 📎 Issue 번호
<!-- 관련된 이슈가 있다면 닫히도록 연결해주세요 (ex: closed #1) -->

- closed #255 

---

## ✅ 작업 목록
<!-- 체크박스로 완료한 작업을 표시해주세요 -->

- [ ] 기능 구현
- [ ] 코드 리뷰 반영
- [ ] 테스트 코드 작성
- [x] 문서 업데이트

---

## 📝 기타 참고사항
<!-- 리뷰어가 참고하면 좋을 추가 정보나 질문이 있다면 자유롭게 작성해주세요 -->