### PR TITLE
[FEAT] 도서 상세 및 서재 액션에 독서 상태 응답 추가

### DIFF
--- a/src/main/java/app/nook/book/converter/BookConverter.java
+++ b/src/main/java/app/nook/book/converter/BookConverter.java
@@ -7,7 +7,7 @@ import app.nook.book.domain.enums.SourceType;
 import app.nook.library.domain.Library;
 
 public class BookConverter {
-    public static BookResponseDto.BookDetailDto toBookDetailDto(Book book, Long bookShelfId) {
+    public static BookResponseDto.BookDetailDto toBookDetailDto(Book book, Library library) {
         Category category = book.getCategory();
 
         return BookResponseDto.BookDetailDto.builder()
@@ -25,7 +25,8 @@ public class BookConverter {
                 .coverImageUrl(book.getCoverImageKey())
                 .aladinLink(book.getAladinLink())
                 .sourceType(book.getSourceType())
-                .bookShelfId(bookShelfId)
+                .bookShelfId(library == null ? null : library.getId())
+                .readingStatus(library == null ? null : library.getReadingStatus())
                 .build();
     }
 

--- a/src/main/java/app/nook/book/dto/BookResponseDto.java
+++ b/src/main/java/app/nook/book/dto/BookResponseDto.java
@@ -30,6 +30,7 @@ public class BookResponseDto {
         private String aladinLink;
         private SourceType sourceType;
         private Long bookShelfId;
+        private ReadingStatus readingStatus;
     }
 
     public record BookPreviewDto( // 검색 베스트셀러 프리뷰 DTO

--- a/src/main/java/app/nook/book/service/BookService.java
+++ b/src/main/java/app/nook/book/service/BookService.java
@@ -62,7 +62,7 @@ public class BookService {
                 updateBookInfo(book, isbn13);
             }
             log.info("[DB_HIT] isbn={}, title='{}'", isbn13, book.getTitle());
-            return withResolvedCoverImage(resolveUserId(user), BookConverter.toBookDetailDto(book, findLibraryId(user, book)));
+            return withResolvedCoverImage(resolveUserId(user), BookConverter.toBookDetailDto(book, findLibrary(user, book)));
         }
 
         log.info("[API_FETCH] isbn={}, status='Not found in DB(ALADIN)'", isbn13);
@@ -85,7 +85,7 @@ public class BookService {
             updateBookInfo(book, book.getIsbn13());
         }
 
-        return withResolvedCoverImage(resolveUserId(user), BookConverter.toBookDetailDto(book, findLibraryId(user, book)));
+        return withResolvedCoverImage(resolveUserId(user), BookConverter.toBookDetailDto(book, findLibrary(user, book)));
     }
 
     @Transactional
@@ -244,12 +244,11 @@ public class BookService {
         log.info("[BookService] Book info updated - ISBN: {}, title: {}", isbn13, book.getTitle());
     }
 
-    private Long findLibraryId(User user, Book book) {
+    private Library findLibrary(User user, Book book) {
         if (user == null) {
             return null;
         }
         return libraryRepository.findByUserAndBook(user, book)
-                .map(Library::getId)
                 .orElse(null);
     }
 }

--- a/src/main/java/app/nook/library/controller/LibraryController.java
+++ b/src/main/java/app/nook/library/controller/LibraryController.java
@@ -11,6 +11,7 @@ import app.nook.library.service.LibraryCommandService;
 import app.nook.library.service.LibraryQueryService;
 import app.nook.user.annotation.CurrentUser;
 import app.nook.user.domain.User;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
@@ -57,7 +58,7 @@ public class LibraryController {
     @PatchMapping("/status")
     public ApiResponse<LibraryViewDto.BookStatusResponseDto> changeStatus(
             @CurrentUser User user,
-            @RequestBody ReadingStatusRequestDto requestDto
+            @Valid @RequestBody ReadingStatusRequestDto requestDto
     ) {
         LibraryViewDto.BookStatusResponseDto response =
                 libraryCommandService.changeReadingStatus(user.getId(), requestDto);

--- a/src/main/java/app/nook/library/controller/LibraryController.java
+++ b/src/main/java/app/nook/library/controller/LibraryController.java
@@ -33,32 +33,35 @@ public class LibraryController {
 
     // 서재 책 등록
     @PostMapping("/{bookId}")
-    public ApiResponse<Void> registerBook(
+    public ApiResponse<LibraryViewDto.BookStatusResponseDto> registerBook(
             @CurrentUser User user,
             @PathVariable Long bookId
     ) {
-        libraryCommandService.registerBook(user.getId(), bookId);
-        return ApiResponse.onSuccess(null, SuccessCode.OK);
+        LibraryViewDto.BookStatusResponseDto response =
+                libraryCommandService.registerBook(user.getId(), bookId);
+        return ApiResponse.onSuccess(response, SuccessCode.OK);
     }
 
     // 서재 책 삭제
     @DeleteMapping("/{bookId}")
-    public ApiResponse<Void> deleteBook(
+    public ApiResponse<LibraryViewDto.BookStatusResponseDto> deleteBook(
             @CurrentUser User user,
             @PathVariable Long bookId
     ) {
-        libraryCommandService.deleteByBookId(user.getId(), bookId);
-        return ApiResponse.onSuccess(null, SuccessCode.NO_CONTENT);
+        LibraryViewDto.BookStatusResponseDto response =
+                libraryCommandService.deleteByBookId(user.getId(), bookId);
+        return ApiResponse.onSuccess(response, SuccessCode.OK);
     }
 
     // 서재 책 상태 변경
     @PatchMapping("/status")
-    public ApiResponse<Void> changeStatus(
+    public ApiResponse<LibraryViewDto.BookStatusResponseDto> changeStatus(
             @CurrentUser User user,
             @RequestBody ReadingStatusRequestDto requestDto
     ) {
-        libraryCommandService.changeReadingStatus(user.getId(), requestDto);
-        return ApiResponse.onSuccess(null, SuccessCode.OK);
+        LibraryViewDto.BookStatusResponseDto response =
+                libraryCommandService.changeReadingStatus(user.getId(), requestDto);
+        return ApiResponse.onSuccess(response, SuccessCode.OK);
     }
 
     // 서재 상태별 책 조회

--- a/src/main/java/app/nook/library/dto/LibraryViewDto.java
+++ b/src/main/java/app/nook/library/dto/LibraryViewDto.java
@@ -15,6 +15,12 @@ public class LibraryViewDto {
             String coverUrl
     ){}
 
+    public record BookStatusResponseDto(
+            Long bookId,
+            Long bookShelfId,
+            ReadingStatus readingStatus
+    ){}
+
     public record MonthlyBookResponseDto(
             LocalDate date,
             int bookNum,

--- a/src/main/java/app/nook/library/dto/ReadingStatusRequestDto.java
+++ b/src/main/java/app/nook/library/dto/ReadingStatusRequestDto.java
@@ -1,8 +1,13 @@
 package app.nook.library.dto;
 
 import app.nook.library.domain.enums.ReadingStatus;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 
 public record ReadingStatusRequestDto(
+        @NotNull
+        @Positive
         Long bookId,
+        @NotNull
         ReadingStatus readingStatus
 ){}

--- a/src/main/java/app/nook/library/service/LibraryCommandService.java
+++ b/src/main/java/app/nook/library/service/LibraryCommandService.java
@@ -7,6 +7,7 @@ import app.nook.focus.repository.FocusRepository;
 import app.nook.global.exception.CustomException;
 import app.nook.global.response.AuthErrorCode;
 import app.nook.library.domain.Library;
+import app.nook.library.dto.LibraryViewDto;
 import app.nook.library.dto.ReadingStatusRequestDto;
 import app.nook.library.event.LibraryCacheInvalidateEvent;
 import app.nook.library.exception.LibraryErrorCode;
@@ -38,7 +39,7 @@ public class LibraryCommandService {
     private final UserRepository userRepository;
 
     @Transactional
-    public void registerBook(Long userId, Long bookId) {
+    public LibraryViewDto.BookStatusResponseDto registerBook(Long userId, Long bookId) {
         // 등록 대상 도서와 사용자 조회
         Book book = bookRepository.findById(bookId)
                 .orElseThrow(() -> new CustomException(BookErrorCode.BOOK_NOT_FOUND));
@@ -60,10 +61,11 @@ public class LibraryCommandService {
 
         timelineCommandService.appendRegister(savedLibrary);
         eventPublisher.publishEvent(LibraryCacheInvalidateEvent.statusOnly(userId));
+        return toBookStatusResponse(savedLibrary);
     }
 
     @Transactional
-    public void deleteByBookId(Long userId, Long bookId) {
+    public LibraryViewDto.BookStatusResponseDto deleteByBookId(Long userId, Long bookId) {
         // 삭제 대상 도서와 서재 등록 여부 확인
         Book book = bookRepository.findById(bookId)
                 .orElseThrow(() -> new CustomException(BookErrorCode.BOOK_NOT_FOUND));
@@ -85,10 +87,11 @@ public class LibraryCommandService {
         eventPublisher.publishEvent(
                 LibraryCacheInvalidateEvent.statusAndMonthly(userId, affectedYearMonths)
         );
+        return new LibraryViewDto.BookStatusResponseDto(bookId, null, null);
     }
 
     @Transactional
-    public void changeReadingStatus(Long userId, ReadingStatusRequestDto requestDto) {
+    public LibraryViewDto.BookStatusResponseDto changeReadingStatus(Long userId, ReadingStatusRequestDto requestDto) {
         // 상태 변경 대상 도서와 서재 엔티티 조회
         Book book = bookRepository.findById(requestDto.bookId())
                 .orElseThrow(() -> new CustomException(BookErrorCode.BOOK_NOT_FOUND));
@@ -105,10 +108,19 @@ public class LibraryCommandService {
         library.updateStatus(requestDto.readingStatus());
         timelineCommandService.appendStatusChanged(library, occurredAt);
         eventPublisher.publishEvent(LibraryCacheInvalidateEvent.statusOnly(userId));
+        return toBookStatusResponse(library);
     }
 
     private User getUser(Long userId) {
         return userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(AuthErrorCode.USER_NOT_FOUND));
+    }
+
+    private LibraryViewDto.BookStatusResponseDto toBookStatusResponse(Library library) {
+        return new LibraryViewDto.BookStatusResponseDto(
+                library.getBook().getId(),
+                library.getId(),
+                library.getReadingStatus()
+        );
     }
 }

--- a/src/test/java/app/nook/book/service/BookServiceTest.java
+++ b/src/test/java/app/nook/book/service/BookServiceTest.java
@@ -11,6 +11,8 @@ import app.nook.book.exception.BookErrorCode;
 import app.nook.book.repository.BookRepository;
 import app.nook.book.repository.CategoryRepository;
 import app.nook.global.exception.CustomException;
+import app.nook.library.domain.Library;
+import app.nook.library.domain.enums.ReadingStatus;
 import app.nook.library.repository.LibraryRepository;
 import app.nook.r2.service.PresignedUrlService;
 import app.nook.user.domain.User;
@@ -129,10 +131,40 @@ class BookServiceTest {
         assertThat(result.getAuthor()).isEqualTo(TEST_AUTHOR);
         assertThat(result.getPublisher()).isEqualTo(TEST_PUBLISHER);
         assertThat(result.getPages()).isEqualTo(184);
+        assertThat(result.getBookShelfId()).isNull();
+        assertThat(result.getReadingStatus()).isNull();
 
         // DB에 있었으므로 알라딘 API는 호출되지 않아야 함
         verify(bookRepository, times(1)).findByIsbn13AndSourceType(TEST_ISBN_1, SourceType.ALADIN);
         verify(aladinService, never()).lookupItem(any());
+    }
+
+    @Test
+    @DisplayName("DB에 존재하고 서재에 등록된 도서 조회 - 서재 ID와 독서 상태 반환")
+    void getBookDetailByIsbn_서재등록_상태반환() {
+        // given
+        Book book = createBook(TEST_ISBN_1, "채식주의자", 184);
+        ReflectionTestUtils.setField(book, "id", 1L);
+        ReflectionTestUtils.setField(book, "modifiedDate", LocalDateTime.now());
+
+        Library library = Library.builder()
+                .user(testUser)
+                .book(book)
+                .build();
+        ReflectionTestUtils.setField(library, "id", 10L);
+        library.updateStatus(ReadingStatus.READING);
+
+        given(bookRepository.findByIsbn13AndSourceType(TEST_ISBN_1, SourceType.ALADIN))
+                .willReturn(Optional.of(book));
+        given(libraryRepository.findByUserAndBook(testUser, book))
+                .willReturn(Optional.of(library));
+
+        // when
+        BookResponseDto.BookDetailDto result = bookService.getBookDetailByIsbn(testUser, TEST_ISBN_1);
+
+        // then
+        assertThat(result.getBookShelfId()).isEqualTo(10L);
+        assertThat(result.getReadingStatus()).isEqualTo(ReadingStatus.READING);
     }
 
     @Test
@@ -158,6 +190,8 @@ class BookServiceTest {
         // then 1. 반환값 검증 (Controller로 나가는 데이터)
         assertThat(result.getIsbn13()).isEqualTo(TEST_ISBN_1);
         assertThat(result.getTitle()).isEqualTo("채식주의자");
+        assertThat(result.getBookShelfId()).isNull();
+        assertThat(result.getReadingStatus()).isNull();
 
         // then 2. 저장 메서드에 넘겨진 실제 엔티티 '나포'
         verify(bookRepository).save(bookCaptor.capture());
@@ -220,6 +254,32 @@ class BookServiceTest {
 
         assertThat(result.getBookId()).isEqualTo(20L);
         assertThat(result.getTitle()).isEqualTo("제목");
+        assertThat(result.getBookShelfId()).isNull();
+        assertThat(result.getReadingStatus()).isNull();
+    }
+
+    @Test
+    @DisplayName("bookId 기반 상세 조회 - 서재 ID와 독서 상태 반환")
+    void getBookDetailById_서재등록_상태반환() {
+        Book book = createBook(TEST_ISBN_1, "제목", 184);
+        ReflectionTestUtils.setField(book, "id", 20L);
+        ReflectionTestUtils.setField(book, "sourceType", SourceType.USER);
+
+        Library library = Library.builder()
+                .user(testUser)
+                .book(book)
+                .build();
+        ReflectionTestUtils.setField(library, "id", 10L);
+        library.updateStatus(ReadingStatus.READING);
+
+        given(bookRepository.findById(20L)).willReturn(Optional.of(book));
+        given(libraryRepository.findByUserAndBook(testUser, book)).willReturn(Optional.of(library));
+
+        BookResponseDto.BookDetailDto result = bookService.getBookDetailById(testUser, 20L);
+
+        assertThat(result.getBookId()).isEqualTo(20L);
+        assertThat(result.getBookShelfId()).isEqualTo(10L);
+        assertThat(result.getReadingStatus()).isEqualTo(ReadingStatus.READING);
     }
 
     @Test

--- a/src/test/java/app/nook/controller/book/BookControllerTest.java
+++ b/src/test/java/app/nook/controller/book/BookControllerTest.java
@@ -13,6 +13,7 @@
   import app.nook.global.config.WebSecurityConfig;
   import app.nook.global.docs.ApiResponseSnippet;
   import app.nook.global.exception.CustomException;
+  import app.nook.library.domain.enums.ReadingStatus;
   import app.nook.user.filter.JwtExceptionFilter;
   import app.nook.user.filter.JwtFilter;
   import org.junit.jupiter.api.DisplayName;
@@ -81,6 +82,7 @@
                   .aladinLink("http://aladin.com/book")
                   .sourceType(SourceType.ALADIN)
                   .bookShelfId(null)
+                  .readingStatus(null)
                   .build();
 
           given(bookService.getBookDetailByIsbn(any(), eq(isbn13))).willReturn(response);
@@ -88,6 +90,7 @@
           mockMvc.perform(get("/api/v1/books/{isbn13}", isbn13).header(AUTH_HEADER, AUTH_TOKEN))
                   .andExpect(status().isOk())
                   .andExpect(jsonPath("$.result.title").value("채식주의자"))
+                  .andExpect(jsonPath("$.result.readingStatus").doesNotExist())
                   .andDo(documentWithAuth(
                           "{class-name}/{method-name}",
                           pathParameters(parameterWithName("isbn13").description("도서 ISBN13 (13자리 숫자)")),
@@ -106,7 +109,8 @@
                                   fieldWithPath("result.coverImageUrl").description("표지 이미지 URL"),
                                   fieldWithPath("result.aladinLink").description("알라딘 링크"),
                                   fieldWithPath("result.sourceType").description("데이터 출처"),
-                                  fieldWithPath("result.bookShelfId").description("서재 ID (없으면 null)").optional()
+                                  fieldWithPath("result.bookShelfId").description("서재 ID (없으면 null)").optional(),
+                                  fieldWithPath("result.readingStatus").description("독서 상태 (서재에 없으면 null)").optional()
                           ))
                   ));
       }
@@ -150,6 +154,7 @@
                   .coverImageUrl("http://example.com/cover.jpg")
                   .sourceType(SourceType.USER)
                   .bookShelfId(3L)
+                  .readingStatus(ReadingStatus.READING)
                   .build();
 
           given(bookService.getBookDetailById(any(), eq(1L))).willReturn(response);
@@ -158,6 +163,7 @@
                   .andExpect(status().isOk())
                   .andExpect(jsonPath("$.result.bookId").value(1L))
                   .andExpect(jsonPath("$.result.title").value("테스트책"))
+                  .andExpect(jsonPath("$.result.readingStatus").value("READING"))
                   .andDo(documentWithAuth(
                           "{class-name}/{method-name}",
                           pathParameters(parameterWithName("bookId").description("도서 ID")),
@@ -176,7 +182,8 @@
                                   fieldWithPath("result.coverImageUrl").description("표지 이미지 URL").optional(),
                                   fieldWithPath("result.aladinLink").description("알라딘 링크").optional(),
                                   fieldWithPath("result.sourceType").description("데이터 출처"),
-                                  fieldWithPath("result.bookShelfId").description("서재 ID").optional()
+                                  fieldWithPath("result.bookShelfId").description("서재 ID").optional(),
+                                  fieldWithPath("result.readingStatus").description("독서 상태").optional()
                           ))
                   ));
       }
@@ -245,6 +252,7 @@
                   .category("소설/시/희곡")
                   .sourceType(SourceType.USER)
                   .bookShelfId(5L)
+                  .readingStatus(ReadingStatus.BEFORE)
                   .build();
 
           given(userBookFacade.createUserBook(any(), any(BookRequestDto.CreateUserBookRequest.class)))
@@ -270,6 +278,7 @@
                   .andExpect(jsonPath("$.code").value("SUCCESS-201"))
                   .andExpect(jsonPath("$.result.bookId").value(101L))
                   .andExpect(jsonPath("$.result.sourceType").value("USER"))
+                  .andExpect(jsonPath("$.result.readingStatus").value("BEFORE"))
                   .andDo(documentWithAuth(
                           "{class-name}/{method-name}",
                           requestFields(
@@ -298,7 +307,8 @@
                                   fieldWithPath("result.coverImageUrl").description("표지 이미지 URL").optional(),
                                   fieldWithPath("result.aladinLink").description("알라딘 링크").optional(),
                                   fieldWithPath("result.sourceType").description("데이터 출처"),
-                                  fieldWithPath("result.bookShelfId").description("서재 ID").optional()
+                                  fieldWithPath("result.bookShelfId").description("서재 ID").optional(),
+                                  fieldWithPath("result.readingStatus").description("독서 상태").optional()
                           ))
                   ));
       }
@@ -320,6 +330,7 @@
                   .coverImageUrl("http://example.com/cover.jpg")
                   .sourceType(SourceType.USER)
                   .bookShelfId(5L)
+                  .readingStatus(ReadingStatus.READING)
                   .build();
 
           given(userBookFacade.updateUserBook(any(), anyLong(), any(BookRequestDto.UpdateUserBookRequest.class)))
@@ -343,6 +354,7 @@
                           .header(AUTH_HEADER, AUTH_TOKEN))
                   .andExpect(status().isOk())
                   .andExpect(jsonPath("$.result.bookId").value(101L))
+                  .andExpect(jsonPath("$.result.readingStatus").value("READING"))
                   .andDo(documentWithAuth(
                           "{class-name}/{method-name}",
                           pathParameters(
@@ -374,7 +386,8 @@
                                   fieldWithPath("result.coverImageUrl").description("표지 이미지 URL").optional(),
                                   fieldWithPath("result.aladinLink").description("알라딘 링크").optional(),
                                   fieldWithPath("result.sourceType").description("데이터 출처"),
-                                  fieldWithPath("result.bookShelfId").description("서재 ID").optional()
+                                  fieldWithPath("result.bookShelfId").description("서재 ID").optional(),
+                                  fieldWithPath("result.readingStatus").description("독서 상태").optional()
                           ))
                   ));
       }

--- a/src/test/java/app/nook/controller/book/BookControllerTest.java
+++ b/src/test/java/app/nook/controller/book/BookControllerTest.java
@@ -28,6 +28,7 @@
   import java.util.Collections;
   import java.util.List;
 
+  import static org.hamcrest.Matchers.nullValue;
   import static org.mockito.ArgumentMatchers.*;
   import static org.mockito.BDDMockito.given;
   import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
@@ -90,7 +91,8 @@
           mockMvc.perform(get("/api/v1/books/{isbn13}", isbn13).header(AUTH_HEADER, AUTH_TOKEN))
                   .andExpect(status().isOk())
                   .andExpect(jsonPath("$.result.title").value("채식주의자"))
-                  .andExpect(jsonPath("$.result.readingStatus").doesNotExist())
+                  .andExpect(jsonPath("$.result.bookShelfId").value(nullValue()))
+                  .andExpect(jsonPath("$.result.readingStatus").value(nullValue()))
                   .andDo(documentWithAuth(
                           "{class-name}/{method-name}",
                           pathParameters(parameterWithName("isbn13").description("도서 ISBN13 (13자리 숫자)")),

--- a/src/test/java/app/nook/controller/library/LibraryControllerTest.java
+++ b/src/test/java/app/nook/controller/library/LibraryControllerTest.java
@@ -28,11 +28,11 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import java.time.LocalDate;
 import java.util.List;
 
+import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.BDDMockito.willThrow;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
@@ -76,7 +76,10 @@ class LibraryControllerTest extends AbstractWebMvcRestDocsTests {
     @DisplayName("서재에 책 등록 성공")
     @WithCustomUser
     void 서재_책_등록_성공() throws Exception {
-        willDoNothing().given(libraryCommandService).registerBook(anyLong(), anyLong());
+        LibraryViewDto.BookStatusResponseDto response =
+                new LibraryViewDto.BookStatusResponseDto(1L, 10L, ReadingStatus.BEFORE);
+
+        given(libraryCommandService.registerBook(anyLong(), anyLong())).willReturn(response);
 
         // when & then
         mockMvc.perform(
@@ -85,12 +88,19 @@ class LibraryControllerTest extends AbstractWebMvcRestDocsTests {
                                 .with(csrf())
                 )
                 .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.bookId").value(1L))
+                .andExpect(jsonPath("$.result.bookShelfId").value(10L))
+                .andExpect(jsonPath("$.result.readingStatus").value("BEFORE"))
                 .andDo(documentWithAuth(
                         "{class-name}/{method-name}",
                         pathParameters(
                                 parameterWithName("bookId").description("서재에 추가할 도서 ID")
                         ),
-                        responseFields(ApiResponseSnippet.commonResponseFieldsWithNullableResult())
+                        responseFields(ApiResponseSnippet.withResult(
+                                fieldWithPath("result.bookId").type(NUMBER).description("도서 ID"),
+                                fieldWithPath("result.bookShelfId").type(NUMBER).description("서재 ID"),
+                                fieldWithPath("result.readingStatus").type(STRING).description("독서 상태")
+                        ))
                 ));
     }
 
@@ -98,7 +108,10 @@ class LibraryControllerTest extends AbstractWebMvcRestDocsTests {
     @DisplayName("서재에서 책 삭제 성공")
     @WithCustomUser
     void 서재_책_삭제_성공() throws Exception {
-        willDoNothing().given(libraryCommandService).deleteByBookId(anyLong(), anyLong());
+        LibraryViewDto.BookStatusResponseDto response =
+                new LibraryViewDto.BookStatusResponseDto(1L, null, null);
+
+        given(libraryCommandService.deleteByBookId(anyLong(), anyLong())).willReturn(response);
 
         // when & then
         mockMvc.perform(
@@ -107,12 +120,19 @@ class LibraryControllerTest extends AbstractWebMvcRestDocsTests {
                                 .with(csrf())
                 )
                 .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.bookId").value(1L))
+                .andExpect(jsonPath("$.result.bookShelfId").value(nullValue()))
+                .andExpect(jsonPath("$.result.readingStatus").value(nullValue()))
                 .andDo(documentWithAuth(
                         "{class-name}/{method-name}",
                         pathParameters(
                                 parameterWithName("bookId").description("서재에서 삭제할 도서 ID")
                         ),
-                        responseFields(ApiResponseSnippet.commonResponseFieldsWithNullableResult())
+                        responseFields(ApiResponseSnippet.withResult(
+                                fieldWithPath("result.bookId").type(NUMBER).description("도서 ID"),
+                                fieldWithPath("result.bookShelfId").type(NULL).description("서재 ID (삭제 후 null)"),
+                                fieldWithPath("result.readingStatus").type(NULL).description("독서 상태 (삭제 후 null)")
+                        ))
                 ));
     }
 
@@ -121,8 +141,10 @@ class LibraryControllerTest extends AbstractWebMvcRestDocsTests {
     @WithCustomUser
     void 서재_책_상태변경_성공() throws Exception {
         ReadingStatusRequestDto request = new ReadingStatusRequestDto(1L, ReadingStatus.READING);
+        LibraryViewDto.BookStatusResponseDto response =
+                new LibraryViewDto.BookStatusResponseDto(1L, 10L, ReadingStatus.READING);
 
-        willDoNothing().given(libraryCommandService).changeReadingStatus(anyLong(), any());
+        given(libraryCommandService.changeReadingStatus(anyLong(), any())).willReturn(response);
 
         // when & then
         mockMvc.perform(
@@ -133,13 +155,20 @@ class LibraryControllerTest extends AbstractWebMvcRestDocsTests {
                                 .with(csrf())
                 )
                 .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.bookId").value(1L))
+                .andExpect(jsonPath("$.result.bookShelfId").value(10L))
+                .andExpect(jsonPath("$.result.readingStatus").value("READING"))
                 .andDo(documentWithAuth(
                         "{class-name}/{method-name}",
                         requestFields(
                                 fieldWithPath("bookId").description("상태 변경할 도서 ID"),
                                 fieldWithPath("readingStatus").description("독서 상태 (READING, FINISHED, BEFORE)")
                         ),
-                        responseFields(ApiResponseSnippet.commonResponseFieldsWithNullableResult())
+                        responseFields(ApiResponseSnippet.withResult(
+                                fieldWithPath("result.bookId").type(NUMBER).description("도서 ID"),
+                                fieldWithPath("result.bookShelfId").type(NUMBER).description("서재 ID"),
+                                fieldWithPath("result.readingStatus").type(STRING).description("변경된 독서 상태")
+                        ))
                 ));
     }
 

--- a/src/test/java/app/nook/controller/library/LibraryControllerTest.java
+++ b/src/test/java/app/nook/controller/library/LibraryControllerTest.java
@@ -193,6 +193,44 @@ class LibraryControllerTest extends AbstractWebMvcRestDocsTests {
     }
 
     @Test
+    @WithCustomUser
+    void 서재_책_상태변경_실패_bookId_누락() throws Exception {
+        mockMvc.perform(
+                        patch("/api/v1/library/status")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("""
+                                        {
+                                          "readingStatus": "READING"
+                                        }
+                                        """)
+                                .header(AUTH_HEADER, AUTH_TOKEN)
+                                .with(csrf())
+                )
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.isSuccess").value(false))
+                .andExpect(jsonPath("$.code").value("COMMON-002"));
+    }
+
+    @Test
+    @WithCustomUser
+    void 서재_책_상태변경_실패_readingStatus_누락() throws Exception {
+        mockMvc.perform(
+                        patch("/api/v1/library/status")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("""
+                                        {
+                                          "bookId": 1
+                                        }
+                                        """)
+                                .header(AUTH_HEADER, AUTH_TOKEN)
+                                .with(csrf())
+                )
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.isSuccess").value(false))
+                .andExpect(jsonPath("$.code").value("COMMON-002"));
+    }
+
+    @Test
     @DisplayName("서재 상태별 책 조회 성공")
     @WithCustomUser
     void 서재_상태별_책_조회_성공() throws Exception {

--- a/src/test/java/app/nook/library/service/LibraryServiceTest.java
+++ b/src/test/java/app/nook/library/service/LibraryServiceTest.java
@@ -113,8 +113,12 @@ class LibraryServiceTest {
                 return saved;
             });
 
-            libraryCommandService.registerBook(1L, 1L);
+            LibraryViewDto.BookStatusResponseDto response =
+                    libraryCommandService.registerBook(1L, 1L);
 
+            assertThat(response.bookId()).isEqualTo(1L);
+            assertThat(response.bookShelfId()).isEqualTo(1L);
+            assertThat(response.readingStatus()).isEqualTo(ReadingStatus.BEFORE);
             verify(timelineCommandService).appendRegister(any());
         }
 
@@ -161,8 +165,12 @@ class LibraryServiceTest {
             given(libraryRepository.findByUserIdAndBook(1L, book)).willReturn(Optional.of(library));
             given(focusRepository.findDistinctFocusDatesByLibraryAndUser(any(), any())).willReturn(List.of());
 
-            libraryCommandService.deleteByBookId(1L, 1L);
+            LibraryViewDto.BookStatusResponseDto response =
+                    libraryCommandService.deleteByBookId(1L, 1L);
 
+            assertThat(response.bookId()).isEqualTo(1L);
+            assertThat(response.bookShelfId()).isNull();
+            assertThat(response.readingStatus()).isNull();
             verify(libraryRepository).delete(library);
         }
 
@@ -234,15 +242,21 @@ class LibraryServiceTest {
         void changeStatus_성공() {
             User user = UserFixture.user();
             Book book = BookFixture.book();
+            ReflectionTestUtils.setField(book, "id", 1L);
             Library library = LibraryFixture.library(user, book);
+            ReflectionTestUtils.setField(library, "id", 10L);
 
             ReadingStatusRequestDto request = new ReadingStatusRequestDto(1L, ReadingStatus.READING);
 
             given(bookRepository.findById(1L)).willReturn(Optional.of(book));
             given(libraryRepository.findByUserIdAndBook(1L, book)).willReturn(Optional.of(library));
 
-            libraryCommandService.changeReadingStatus(1L, request);
+            LibraryViewDto.BookStatusResponseDto response =
+                    libraryCommandService.changeReadingStatus(1L, request);
 
+            assertThat(response.bookId()).isEqualTo(1L);
+            assertThat(response.bookShelfId()).isEqualTo(library.getId());
+            assertThat(response.readingStatus()).isEqualTo(ReadingStatus.READING);
             assertThat(library.getReadingStatus()).isEqualTo(ReadingStatus.READING);
             verify(timelineCommandService).appendStatusChanged(any(), any());
         }


### PR DESCRIPTION
## 📄 작업 내용 요약
<!-- 무엇을 작업했는지 간단하게 요약해주세요 -->

  - 도서 상세 조회 응답에 `readingStatus` 추가
  - 서재 등록/삭제/상태 변경 API 응답에 `bookId`, `bookShelfId`, `readingStatus` 추가

---

## 📎 Issue 번호
<!-- 관련된 이슈가 있다면 닫히도록 연결해주세요 (ex: closed #1) -->

- closed #265 

---

## ✅ 작업 목록
<!-- 체크박스로 완료한 작업을 표시해주세요 -->

- [x] 기능 구현
- [x] 코드 리뷰 반영
- [x] 테스트 코드 작성
- [x] 문서 업데이트

---

## 📝 기타 참고사항
<!-- 리뷰어가 참고하면 좋을 추가 정보나 질문이 있다면 자유롭게 작성해주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * 서재 도서 관리 작업(등록, 삭제, 독서상태 변경) 시 도서 ID, 책장 ID, 독서상태를 포함한 구조화된 응답 데이터 반환
  * 도서 상세 조회 API에서 사용자의 독서상태 정보 포함
  * 라이브러리 명령 엔드포인트에서 void 응답 대신 실질적인 응답 데이터 제공으로 클라이언트 사용성 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->