### PR TITLE
[FEAT] 로그인 응답에 온보딩 완료 여부 추가

### DIFF
--- a/src/main/java/app/nook/user/domain/User.java
+++ b/src/main/java/app/nook/user/domain/User.java
@@ -101,7 +101,7 @@ public class User extends BaseEntity {
         this.goal = goal;
     }
 
-    public boolean needsOnboarding() {
-        return this.onboardingCompletedAt == null;
+    public boolean isOnboardingCompleted() {
+        return this.onboardingCompletedAt != null;
     }
 }

--- a/src/main/java/app/nook/user/dto/UserDTO.java
+++ b/src/main/java/app/nook/user/dto/UserDTO.java
@@ -21,6 +21,7 @@ public class UserDTO {
         private String nickName;
         private String accessToken;
         private String refreshToken;
+        private Boolean onboardingCompleted;
     }
 
     @AllArgsConstructor

--- a/src/main/java/app/nook/user/dto/UserDTO.java
+++ b/src/main/java/app/nook/user/dto/UserDTO.java
@@ -21,7 +21,7 @@ public class UserDTO {
         private String nickName;
         private String accessToken;
         private String refreshToken;
-        private Boolean onboardingCompleted;
+        private boolean onboardingCompleted;
     }
 
     @AllArgsConstructor

--- a/src/main/java/app/nook/user/oauth/OAuthService.java
+++ b/src/main/java/app/nook/user/oauth/OAuthService.java
@@ -94,6 +94,7 @@ public class OAuthService {
                 .nickName(user.getNickName())
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
+                .onboardingCompleted(user.isOnboardingCompleted())
                 .build();
     }
 

--- a/src/main/java/app/nook/user/service/OnboardingService.java
+++ b/src/main/java/app/nook/user/service/OnboardingService.java
@@ -115,7 +115,7 @@ public class OnboardingService {
     public OnboardingDto.StatusResponse getOnboardingStatus(Long userId) {
         User user = getUser(userId);
         return new OnboardingDto.StatusResponse(
-                user.needsOnboarding(),
+                !user.isOnboardingCompleted(),
                 user.getOnboardingCompletedAt()
         );
     }

--- a/src/main/java/app/nook/user/service/UserService.java
+++ b/src/main/java/app/nook/user/service/UserService.java
@@ -71,6 +71,7 @@ public class UserService {
                 .id(savedUser.getId())
                 .email(savedUser.getEmail())
                 .nickName(savedUser.getNickName())
+                .onboardingCompleted(savedUser.isOnboardingCompleted())
                 .build();
     }
 
@@ -80,6 +81,7 @@ public class UserService {
                     .id(user.getId())
                     .email(user.getEmail())
                     .nickName(user.getNickName())
+                    .onboardingCompleted(user.isOnboardingCompleted())
                     .build();
     }
 
@@ -140,6 +142,7 @@ public class UserService {
                 .nickName(user.getNickName())
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
+                .onboardingCompleted(user.isOnboardingCompleted())
                 .build();
     }
 }

--- a/src/test/java/app/nook/controller/user/AuthControllerTest.java
+++ b/src/test/java/app/nook/controller/user/AuthControllerTest.java
@@ -32,6 +32,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWit
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(
@@ -69,6 +70,7 @@ class AuthControllerTest extends AbstractWebMvcRestDocsTests {
                         .nickName("jiwon")
                         .accessToken("test-access-token")
                         .refreshToken("test-refresh-token")
+                        .onboardingCompleted(false)
                         .build();
 
         given(oAuthService.login(any(), any()))
@@ -81,6 +83,7 @@ class AuthControllerTest extends AbstractWebMvcRestDocsTests {
                                 .content(objectMapper.writeValueAsString(request))
                 )
                 .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.onboardingCompleted").value(false))
                 .andDo(restDocs.document(
                         requestFields(
                                 fieldWithPath("code")
@@ -94,7 +97,8 @@ class AuthControllerTest extends AbstractWebMvcRestDocsTests {
                                         fieldWithPath("result.email").description("이메일"),
                                         fieldWithPath("result.nickName").description("닉네임"),
                                         fieldWithPath("result.accessToken").description("엑세스 토큰"),
-                                        fieldWithPath("result.refreshToken").description("리프레시 토큰")
+                                        fieldWithPath("result.refreshToken").description("리프레시 토큰"),
+                                        fieldWithPath("result.onboardingCompleted").description("온보딩 완료 여부")
                                 )
                         )
                 ));
@@ -113,6 +117,7 @@ class AuthControllerTest extends AbstractWebMvcRestDocsTests {
                         .nickName("DEV_USER")
                         .accessToken("test-access-token")
                         .refreshToken("test-refresh-token")
+                        .onboardingCompleted(false)
                         .build();
 
         given(userService.devLogin(any()))
@@ -125,6 +130,7 @@ class AuthControllerTest extends AbstractWebMvcRestDocsTests {
                                 .content(objectMapper.writeValueAsString(request))
                 )
                 .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.onboardingCompleted").value(false))
                 .andDo(restDocs.document(
                         requestFields(
                                 fieldWithPath("email")
@@ -138,7 +144,8 @@ class AuthControllerTest extends AbstractWebMvcRestDocsTests {
                                         fieldWithPath("result.email").description("이메일"),
                                         fieldWithPath("result.nickName").description("닉네임"),
                                         fieldWithPath("result.accessToken").description("엑세스 토큰"),
-                                        fieldWithPath("result.refreshToken").description("리프레시 토큰")
+                                        fieldWithPath("result.refreshToken").description("리프레시 토큰"),
+                                        fieldWithPath("result.onboardingCompleted").description("온보딩 완료 여부")
                                 )
                         )
                 ));
@@ -154,6 +161,7 @@ class AuthControllerTest extends AbstractWebMvcRestDocsTests {
                         .id(3L)
                         .email("new@test.com")
                         .nickName("NEW_USER")
+                        .onboardingCompleted(false)
                         .build();
 
         given(userService.devSignUp(any()))
@@ -165,6 +173,7 @@ class AuthControllerTest extends AbstractWebMvcRestDocsTests {
                                 .content(objectMapper.writeValueAsString(request))
                 )
                 .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.onboardingCompleted").value(false))
                 .andDo(restDocs.document(
                         requestFields(
                                 fieldWithPath("email").description("DEV 유저 이메일"),
@@ -174,7 +183,8 @@ class AuthControllerTest extends AbstractWebMvcRestDocsTests {
                                 ApiResponseSnippet.withResult(
                                         fieldWithPath("result.id").description("사용자ID"),
                                         fieldWithPath("result.email").description("이메일"),
-                                        fieldWithPath("result.nickName").description("닉네임")
+                                        fieldWithPath("result.nickName").description("닉네임"),
+                                        fieldWithPath("result.onboardingCompleted").description("온보딩 완료 여부")
                                 )
                         )
                 ));
@@ -288,6 +298,7 @@ class AuthControllerTest extends AbstractWebMvcRestDocsTests {
                         .id(2L)
                         .email("jiwon@kakao.com")
                         .nickName("jiwon")
+                        .onboardingCompleted(false)
                         .build();
 
         given(userService.getThisUser(any()))
@@ -300,13 +311,15 @@ class AuthControllerTest extends AbstractWebMvcRestDocsTests {
                                 .with(user(userDetails))
                 )
                 .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.onboardingCompleted").value(false))
                 .andDo(documentWithAuth(
                         "{class-name}/{method-name}",
                         responseFields(
                                 ApiResponseSnippet.withResult(
                                         fieldWithPath("result.id").description("사용자ID"),
                                         fieldWithPath("result.email").description("이메일"),
-                                        fieldWithPath("result.nickName").description("닉네임")
+                                        fieldWithPath("result.nickName").description("닉네임"),
+                                        fieldWithPath("result.onboardingCompleted").description("온보딩 완료 여부")
                                 )
                         )
                 ));

--- a/src/test/java/app/nook/user/oauth/OAuthServiceTest.java
+++ b/src/test/java/app/nook/user/oauth/OAuthServiceTest.java
@@ -21,6 +21,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.RestClient;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -121,6 +122,7 @@ class OAuthServiceTest {
         assertThat(result.getEmail()).isEqualTo("user@test.com");
         assertThat(result.getNickName()).isEqualTo("user");
         assertThat(result.getAccessToken()).isEqualTo("app-access");
+        assertThat(result.isOnboardingCompleted()).isFalse();
         ArgumentCaptor<TokenRedis> tokenCaptor = ArgumentCaptor.forClass(TokenRedis.class);
         verify(tokenRedisRepository).save(tokenCaptor.capture());
         assertThat(tokenCaptor.getValue().getId()).isEqualTo(10L);
@@ -181,11 +183,63 @@ class OAuthServiceTest {
         assertThat(result.getEmail()).isEqualTo("new@test.com");
         assertThat(result.getNickName()).isEqualTo("new-user");
         assertThat(result.getAccessToken()).isEqualTo("app-access-new");
+        assertThat(result.isOnboardingCompleted()).isFalse();
 
         ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
         verify(userRepository).save(userCaptor.capture());
         assertThat(userCaptor.getValue().getProvider()).isEqualTo("GOOGLE");
         assertThat(userCaptor.getValue().getProviderId()).isEqualTo("google-sub-new");
+        server.verify();
+    }
+
+    @Test
+    void 소셜로그인_온보딩완료된_기존유저_onboardingCompleted_true() {
+        String tokenJson = """
+                {
+                  "access_token": "google-access",
+                  "expires_in": 3600,
+                  "scope": "email profile",
+                  "token_type": "Bearer",
+                  "id_token": "id-token",
+                  "refresh_token": "google-refresh"
+                }
+                """;
+
+        String userInfoJson = """
+                {
+                  "sub": "google-sub-done",
+                  "email": "done@test.com",
+                  "name": "done-user",
+                  "picture": "https://img.test/done.png"
+                }
+                """;
+
+        server.expect(once(), requestTo("https://google.test/token"))
+                .andExpect(method(HttpMethod.POST))
+                .andRespond(withSuccess(tokenJson, MediaType.APPLICATION_JSON));
+
+        server.expect(once(), requestTo("https://google.test/userinfo"))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withSuccess(userInfoJson, MediaType.APPLICATION_JSON));
+
+        User user = User.builder()
+                .email("done@test.com")
+                .nickName("done-user")
+                .role(UserRole.USER)
+                .provider("GOOGLE")
+                .providerId("google-sub-done")
+                .build();
+        ReflectionTestUtils.setField(user, "id", 30L);
+        ReflectionTestUtils.setField(user, "onboardingCompletedAt", LocalDateTime.now());
+
+        given(userRepository.findByEmail(eq("done@test.com")))
+                .willReturn(Optional.of(user));
+        given(jwtProvider.createAccessToken(user)).willReturn("app-access-done");
+        given(jwtProvider.createRefreshToken()).willReturn("app-refresh-done");
+
+        UserDTO.LoginResponse result = oAuthService.login("google", "auth-code");
+
+        assertThat(result.isOnboardingCompleted()).isTrue();
         server.verify();
     }
 }

--- a/src/test/java/app/nook/user/service/UserServiceTest.java
+++ b/src/test/java/app/nook/user/service/UserServiceTest.java
@@ -17,6 +17,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -65,6 +66,7 @@ class UserServiceTest {
         assertThat(response.getNickName()).isEqualTo("DEV_USER");
         assertThat(response.getAccessToken()).isEqualTo("access-token");
         assertThat(response.getRefreshToken()).isEqualTo("refresh-token");
+        assertThat(response.isOnboardingCompleted()).isFalse();
 
         ArgumentCaptor<TokenRedis> tokenCaptor = ArgumentCaptor.forClass(TokenRedis.class);
         verify(tokenRedisRepository).save(tokenCaptor.capture());
@@ -124,11 +126,34 @@ class UserServiceTest {
         assertThat(response.getEmail()).isEqualTo("new@test.com");
         assertThat(response.getNickName()).isEqualTo("NEW_USER");
         assertThat(response.getAccessToken()).isNull();
+        assertThat(response.isOnboardingCompleted()).isFalse();
 
         ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
         verify(userRepository).save(userCaptor.capture());
         assertThat(userCaptor.getValue().getRole()).isEqualTo(UserRole.USER);
         assertThat(userCaptor.getValue().getProvider()).isEqualTo("DEV");
+    }
+
+    @Test
+    void devLogin_온보딩완료된유저_onboardingCompleted_true() {
+        User user = User.builder()
+                .email("done@test.com")
+                .nickName("DONE_USER")
+                .role(UserRole.USER)
+                .provider("DEV")
+                .providerId("dev-done")
+                .build();
+        ReflectionTestUtils.setField(user, "id", 2L);
+        ReflectionTestUtils.setField(user, "onboardingCompletedAt", LocalDateTime.now());
+
+        given(userRepository.findByEmail(eq("done@test.com")))
+                .willReturn(Optional.of(user));
+        given(jwtProvider.createAccessToken(user)).willReturn("access-token");
+        given(jwtProvider.createRefreshToken()).willReturn("refresh-token");
+
+        UserDTO.LoginResponse response = userService.devLogin("done@test.com");
+
+        assertThat(response.isOnboardingCompleted()).isTrue();
     }
 
     @Test


### PR DESCRIPTION
## 📄 작업 내용 요약
<!-- 무엇을 작업했는지 간단하게 요약해주세요 -->
  - 로그인 응답에 `onboardingCompleted` 필드 추가
  - 온보딩 완료 여부 판단 메서드를 `isOnboardingCompleted()`로 정리

---

## 📎 Issue 번호
<!-- 관련된 이슈가 있다면 닫히도록 연결해주세요 (ex: closed #1) -->

- closed #268 

---

## ✅ 작업 목록
<!-- 체크박스로 완료한 작업을 표시해주세요 -->

- [x] 기능 구현
- [x] 코드 리뷰 반영
- [x] 테스트 코드 작성
- [x] 문서 업데이트

---

## 📝 기타 참고사항
<!-- 리뷰어가 참고하면 좋을 추가 정보나 질문이 있다면 자유롭게 작성해주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 사용자 온보딩 완료 상태 정보가 로그인 및 사용자 정보 API 응답에 추가되었습니다. 클라이언트는 이제 각 사용자의 온보딩 완료 여부를 확인할 수 있습니다.

* **Bug Fixes**
  * 온보딩 상태 조회 로직이 개선되어 더 정확한 상태 반환을 보장합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->