### PR TITLE
[FEAT] 사용자 도서 접근 권한 정책 추가

### DIFF
--- a/src/main/java/app/nook/book/exception/BookErrorCode.java
+++ b/src/main/java/app/nook/book/exception/BookErrorCode.java
@@ -15,6 +15,7 @@ public enum BookErrorCode implements BaseCode {
     BOOK_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "BOOK-003", "서비스 정책에 의해 조회할 수 없는 도서입니다."),
     BOOK_NOT_FOUND(HttpStatus.NOT_FOUND, "BOOK-004", "존재하지 않는 책입니다."),
     BOOK_NOT_OWNED(HttpStatus.FORBIDDEN, "BOOK-005", "본인이 생성한 사용자 도서만 수정할 수 있습니다."),
+    BOOK_ACCESS_DENIED(HttpStatus.FORBIDDEN, "BOOK-006", "해당 도서에 접근할 권한이 없습니다."),
     CATEGORY_NOT_FOUND(HttpStatus.BAD_REQUEST, "BOOK-008", "유효하지 않은 카테고리입니다.");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/app/nook/book/service/BookAccessService.java
+++ b/src/main/java/app/nook/book/service/BookAccessService.java
@@ -1,0 +1,48 @@
+package app.nook.book.service;
+
+import app.nook.book.domain.Book;
+import app.nook.book.domain.enums.SourceType;
+import app.nook.book.exception.BookErrorCode;
+import app.nook.global.exception.CustomException;
+import app.nook.user.domain.User;
+import org.springframework.stereotype.Service;
+
+@Service
+public class BookAccessService {
+
+    public void assertCanView(User user, Book book) {
+        if (isPublicBook(book) || isCreatedBy(user, book)) {
+            return;
+        }
+
+        throw new CustomException(BookErrorCode.BOOK_ACCESS_DENIED);
+    }
+
+    public void assertCanAddToLibrary(User user, Book book) {
+        if (isPublicBook(book) || isCreatedBy(user, book)) {
+            return;
+        }
+
+        throw new CustomException(BookErrorCode.BOOK_ACCESS_DENIED);
+    }
+
+    public void assertCanUpdate(User user, Book book) {
+        if (book != null && book.getSourceType() == SourceType.USER && isCreatedBy(user, book)) {
+            return;
+        }
+
+        throw new CustomException(BookErrorCode.BOOK_NOT_OWNED);
+    }
+
+    private boolean isPublicBook(Book book) {
+        return book != null && book.getSourceType() == SourceType.ALADIN;
+    }
+
+    private boolean isCreatedBy(User user, Book book) {
+        return user != null
+                && user.getId() != null
+                && book != null
+                && book.getCreatedByUserId() != null
+                && book.getCreatedByUserId().equals(user.getId());
+    }
+}

--- a/src/main/java/app/nook/book/service/BookService.java
+++ b/src/main/java/app/nook/book/service/BookService.java
@@ -46,6 +46,7 @@ public class BookService {
     private final PersonalizedBestsellerCacheService personalizedBestsellerCacheService;
     private final PresignedUrlService presignedUrlService;
     private final ApplicationEventPublisher eventPublisher;
+    private final BookAccessService bookAccessService;
 
     // ISBN 기반 상세조회: ALADIN 소스만 조회/저장 대상으로 사용
     @Transactional
@@ -78,6 +79,7 @@ public class BookService {
     public BookResponseDto.BookDetailDto getBookDetailById(User user, Long bookId) {
         Book book = bookRepository.findById(bookId)
                 .orElseThrow(() -> new CustomException(BookErrorCode.BOOK_NOT_FOUND));
+        bookAccessService.assertCanView(user, book);
 
         if (book.getSourceType() == SourceType.ALADIN
                 && book.getIsbn13() != null
@@ -119,7 +121,7 @@ public class BookService {
         // 소유권 검증 후에만 USER 도서 수정 허용
         Book book = bookRepository.findById(bookId)
                 .orElseThrow(() -> new CustomException(BookErrorCode.BOOK_NOT_FOUND));
-        validateUserBookOwnership(user, book);
+        bookAccessService.assertCanUpdate(user, book);
         String oldCoverImageKey = book.getCoverImageKey();
         String coverImageKeyToUse = (newCoverImageUrl == null || newCoverImageUrl.isBlank())
                 ? book.getCoverImageKey() : newCoverImageUrl;
@@ -198,19 +200,6 @@ public class BookService {
 
         log.info("[RECOMMEND_CATEGORY_SOURCE] userId={}, source=DEFAULT, categoryId=1", userId);
         return 1;
-    }
-
-    private void validateUserBookOwnership(User user, Book book) {
-        if (book.getSourceType() != SourceType.USER) {
-            log.warn("[USER_BOOK_UPDATE_FORBIDDEN] requestUserId={}, bookId={}, reason=NOT_USER_SOURCE, sourceType={}",
-                    user.getId(), book.getId(), book.getSourceType());
-            throw new CustomException(BookErrorCode.BOOK_NOT_OWNED);
-        }
-        if (book.getCreatedByUserId() == null || !book.getCreatedByUserId().equals(user.getId())) {
-            log.warn("[USER_BOOK_UPDATE_FORBIDDEN] requestUserId={}, bookId={}, reason=NOT_OWNER, createdByUserId={}",
-                    user.getId(), book.getId(), book.getCreatedByUserId());
-            throw new CustomException(BookErrorCode.BOOK_NOT_OWNED);
-        }
     }
 
     // USER 도서는 BOOK mallType 기준 카테고리만 허용

--- a/src/main/java/app/nook/library/service/LibraryCommandService.java
+++ b/src/main/java/app/nook/library/service/LibraryCommandService.java
@@ -3,6 +3,7 @@ package app.nook.library.service;
 import app.nook.book.domain.Book;
 import app.nook.book.exception.BookErrorCode;
 import app.nook.book.repository.BookRepository;
+import app.nook.book.service.BookAccessService;
 import app.nook.focus.repository.FocusRepository;
 import app.nook.global.exception.CustomException;
 import app.nook.global.response.AuthErrorCode;
@@ -37,6 +38,7 @@ public class LibraryCommandService {
     private final TimelineCommandService timelineCommandService;
     private final ApplicationEventPublisher eventPublisher;
     private final UserRepository userRepository;
+    private final BookAccessService bookAccessService;
 
     @Transactional
     public LibraryViewDto.BookStatusResponseDto registerBook(Long userId, Long bookId) {
@@ -44,6 +46,7 @@ public class LibraryCommandService {
         Book book = bookRepository.findById(bookId)
                 .orElseThrow(() -> new CustomException(BookErrorCode.BOOK_NOT_FOUND));
         User user = getUser(userId);
+        bookAccessService.assertCanAddToLibrary(user, book);
 
         // 이미 서재에 있는 도서는 중복 등록 차단
         if (libraryRepository.findByUserIdAndBook(userId, book).isPresent()) {

--- a/src/test/java/app/nook/book/service/BookAccessServiceTest.java
+++ b/src/test/java/app/nook/book/service/BookAccessServiceTest.java
@@ -61,6 +61,16 @@ class BookAccessServiceTest {
     }
 
     @Test
+    @DisplayName("ALADIN 도서는 서재 등록 권한을 허용한다")
+    void assertCanAddToLibrary_aladinBook_success() {
+        User user = createUser(1L);
+        Book book = createBook(SourceType.ALADIN, null);
+
+        assertThatCode(() -> bookAccessService.assertCanAddToLibrary(user, book))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
     @DisplayName("본인이 생성한 USER 도서는 서재 등록 권한을 허용한다")
     void assertCanAddToLibrary_ownedUserBook_success() {
         User user = createUser(1L);
@@ -83,6 +93,17 @@ class BookAccessServiceTest {
     }
 
     @Test
+    @DisplayName("로그인 사용자가 없으면 USER 도서 서재 등록 권한을 차단한다")
+    void assertCanAddToLibrary_anonymousUserBook_fail() {
+        Book book = createBook(SourceType.USER, 1L);
+
+        assertThatThrownBy(() -> bookAccessService.assertCanAddToLibrary(null, book))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(BookErrorCode.BOOK_ACCESS_DENIED);
+    }
+
+    @Test
     @DisplayName("본인이 생성한 USER 도서는 수정 권한을 허용한다")
     void assertCanUpdate_ownedUserBook_success() {
         User user = createUser(1L);
@@ -99,6 +120,17 @@ class BookAccessServiceTest {
         Book book = createBook(SourceType.ALADIN, null);
 
         assertThatThrownBy(() -> bookAccessService.assertCanUpdate(user, book))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(BookErrorCode.BOOK_NOT_OWNED);
+    }
+
+    @Test
+    @DisplayName("로그인 사용자가 없으면 USER 도서 수정 권한을 차단한다")
+    void assertCanUpdate_anonymousUserBook_fail() {
+        Book book = createBook(SourceType.USER, 1L);
+
+        assertThatThrownBy(() -> bookAccessService.assertCanUpdate(null, book))
                 .isInstanceOf(CustomException.class)
                 .extracting(exception -> ((CustomException) exception).getErrorCode())
                 .isEqualTo(BookErrorCode.BOOK_NOT_OWNED);

--- a/src/test/java/app/nook/book/service/BookAccessServiceTest.java
+++ b/src/test/java/app/nook/book/service/BookAccessServiceTest.java
@@ -1,0 +1,139 @@
+package app.nook.book.service;
+
+import app.nook.book.domain.Book;
+import app.nook.book.domain.enums.SourceType;
+import app.nook.book.exception.BookErrorCode;
+import app.nook.global.exception.CustomException;
+import app.nook.user.domain.User;
+import app.nook.user.domain.enums.UserRole;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class BookAccessServiceTest {
+
+    private final BookAccessService bookAccessService = new BookAccessService();
+
+    @Test
+    @DisplayName("ALADIN 도서는 조회 권한을 허용한다")
+    void assertCanView_aladinBook_success() {
+        User user = createUser(1L);
+        Book book = createBook(SourceType.ALADIN, null);
+
+        assertThatCode(() -> bookAccessService.assertCanView(user, book))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("본인이 생성한 USER 도서는 조회 권한을 허용한다")
+    void assertCanView_ownedUserBook_success() {
+        User user = createUser(1L);
+        Book book = createBook(SourceType.USER, 1L);
+
+        assertThatCode(() -> bookAccessService.assertCanView(user, book))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("다른 사용자가 생성한 USER 도서는 조회 권한을 차단한다")
+    void assertCanView_otherUserBook_fail() {
+        User user = createUser(1L);
+        Book book = createBook(SourceType.USER, 2L);
+
+        assertThatThrownBy(() -> bookAccessService.assertCanView(user, book))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(BookErrorCode.BOOK_ACCESS_DENIED);
+    }
+
+    @Test
+    @DisplayName("로그인 사용자가 없으면 USER 도서 조회 권한을 차단한다")
+    void assertCanView_anonymousUserBook_fail() {
+        Book book = createBook(SourceType.USER, 1L);
+
+        assertThatThrownBy(() -> bookAccessService.assertCanView(null, book))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(BookErrorCode.BOOK_ACCESS_DENIED);
+    }
+
+    @Test
+    @DisplayName("본인이 생성한 USER 도서는 서재 등록 권한을 허용한다")
+    void assertCanAddToLibrary_ownedUserBook_success() {
+        User user = createUser(1L);
+        Book book = createBook(SourceType.USER, 1L);
+
+        assertThatCode(() -> bookAccessService.assertCanAddToLibrary(user, book))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("다른 사용자가 생성한 USER 도서는 서재 등록 권한을 차단한다")
+    void assertCanAddToLibrary_otherUserBook_fail() {
+        User user = createUser(1L);
+        Book book = createBook(SourceType.USER, 2L);
+
+        assertThatThrownBy(() -> bookAccessService.assertCanAddToLibrary(user, book))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(BookErrorCode.BOOK_ACCESS_DENIED);
+    }
+
+    @Test
+    @DisplayName("본인이 생성한 USER 도서는 수정 권한을 허용한다")
+    void assertCanUpdate_ownedUserBook_success() {
+        User user = createUser(1L);
+        Book book = createBook(SourceType.USER, 1L);
+
+        assertThatCode(() -> bookAccessService.assertCanUpdate(user, book))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("ALADIN 도서는 수정 권한을 차단한다")
+    void assertCanUpdate_aladinBook_fail() {
+        User user = createUser(1L);
+        Book book = createBook(SourceType.ALADIN, null);
+
+        assertThatThrownBy(() -> bookAccessService.assertCanUpdate(user, book))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(BookErrorCode.BOOK_NOT_OWNED);
+    }
+
+    @Test
+    @DisplayName("다른 사용자가 생성한 USER 도서는 수정 권한을 차단한다")
+    void assertCanUpdate_otherUserBook_fail() {
+        User user = createUser(1L);
+        Book book = createBook(SourceType.USER, 2L);
+
+        assertThatThrownBy(() -> bookAccessService.assertCanUpdate(user, book))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(BookErrorCode.BOOK_NOT_OWNED);
+    }
+
+    private User createUser(Long id) {
+        User user = User.builder()
+                .email("test@example.com")
+                .nickName("tester")
+                .provider("google")
+                .providerId("provider-id")
+                .role(UserRole.USER)
+                .build();
+        ReflectionTestUtils.setField(user, "id", id);
+        return user;
+    }
+
+    private Book createBook(SourceType sourceType, Long createdByUserId) {
+        return Book.builder()
+                .title("테스트 도서")
+                .author("테스트 저자")
+                .sourceType(sourceType)
+                .createdByUserId(createdByUserId)
+                .build();
+    }
+}

--- a/src/test/java/app/nook/book/service/BookServiceTest.java
+++ b/src/test/java/app/nook/book/service/BookServiceTest.java
@@ -26,6 +26,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
@@ -78,6 +79,9 @@ class BookServiceTest {
 
     @Mock
     private ApplicationEventPublisher eventPublisher;
+
+    @Spy
+    private BookAccessService bookAccessService = new BookAccessService();
 
     @InjectMocks
     private BookService bookService;
@@ -246,6 +250,7 @@ class BookServiceTest {
         Book book = createBook(TEST_ISBN_1, "제목", 184);
         ReflectionTestUtils.setField(book, "id", 20L);
         ReflectionTestUtils.setField(book, "sourceType", SourceType.USER);
+        ReflectionTestUtils.setField(book, "createdByUserId", TEST_USER_ID);
 
         given(bookRepository.findById(20L)).willReturn(Optional.of(book));
         given(libraryRepository.findByUserAndBook(testUser, book)).willReturn(Optional.empty());
@@ -264,6 +269,7 @@ class BookServiceTest {
         Book book = createBook(TEST_ISBN_1, "제목", 184);
         ReflectionTestUtils.setField(book, "id", 20L);
         ReflectionTestUtils.setField(book, "sourceType", SourceType.USER);
+        ReflectionTestUtils.setField(book, "createdByUserId", TEST_USER_ID);
 
         Library library = Library.builder()
                 .user(testUser)
@@ -280,6 +286,26 @@ class BookServiceTest {
         assertThat(result.getBookId()).isEqualTo(20L);
         assertThat(result.getBookShelfId()).isEqualTo(10L);
         assertThat(result.getReadingStatus()).isEqualTo(ReadingStatus.READING);
+    }
+
+    @Test
+    @DisplayName("bookId 기반 상세 조회 - 다른 사용자가 생성한 USER 도서면 실패")
+    void getBookDetailById_otherUserBook_fail() {
+        Book book = createBook(TEST_ISBN_1, "제목", 184);
+        ReflectionTestUtils.setField(book, "id", 20L);
+        ReflectionTestUtils.setField(book, "sourceType", SourceType.USER);
+        ReflectionTestUtils.setField(book, "createdByUserId", 999L);
+        ReflectionTestUtils.setField(book, "coverImageKey", "book/users/999/cover.png");
+
+        given(bookRepository.findById(20L)).willReturn(Optional.of(book));
+
+        CustomException ex = assertThrows(
+                CustomException.class,
+                () -> bookService.getBookDetailById(testUser, 20L)
+        );
+
+        assertThat(ex.getErrorCode()).isEqualTo(BookErrorCode.BOOK_ACCESS_DENIED);
+        verify(presignedUrlService, never()).resolveImageUrl(anyLong(), any());
     }
 
     @Test

--- a/src/test/java/app/nook/library/service/LibraryServiceTest.java
+++ b/src/test/java/app/nook/library/service/LibraryServiceTest.java
@@ -3,6 +3,7 @@ package app.nook.library.service;
 import app.nook.book.domain.Book;
 import app.nook.book.exception.BookErrorCode;
 import app.nook.book.repository.BookRepository;
+import app.nook.book.service.BookAccessService;
 import app.nook.focus.domain.Focus;
 import app.nook.focus.repository.FocusRepository;
 import app.nook.global.exception.CustomException;
@@ -51,6 +52,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willReturn;
+import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -79,6 +81,9 @@ class LibraryServiceTest {
 
     @Mock
     private UserRepository userRepository;
+
+    @Mock
+    private BookAccessService bookAccessService;
 
     @InjectMocks
     private LibraryCommandService libraryCommandService;
@@ -147,6 +152,23 @@ class LibraryServiceTest {
             CustomException ex = assertThrows(CustomException.class, () -> libraryCommandService.registerBook(1L, 1L));
 
             assertThat(ex.getErrorCode()).isEqualTo(LibraryErrorCode.BOOK_ALREADY_EXIST);
+        }
+
+        @Test
+        @DisplayName("접근 권한이 없는 도서면 예외를 던진다")
+        void save_도서접근권한없음_예외() {
+            User user = UserFixture.user();
+            Book book = BookFixture.book();
+
+            given(bookRepository.findById(1L)).willReturn(Optional.of(book));
+            given(userRepository.findById(1L)).willReturn(Optional.of(user));
+            willThrow(new CustomException(BookErrorCode.BOOK_ACCESS_DENIED))
+                    .given(bookAccessService).assertCanAddToLibrary(user, book);
+
+            CustomException ex = assertThrows(CustomException.class, () -> libraryCommandService.registerBook(1L, 1L));
+
+            assertThat(ex.getErrorCode()).isEqualTo(BookErrorCode.BOOK_ACCESS_DENIED);
+            verify(libraryRepository, never()).saveAndFlush(any());
         }
     }
 


### PR DESCRIPTION
## 📄 작업 내용 요약
<!-- 무엇을 작업했는지 간단하게 요약해주세요 -->

- USER 도서 접근 권한 검증 로직 추가
- 도서 상세 조회 및 서재 등록 시 권한 검증 적용
- 권한 없는 USER 도서 접근 시 `BOOK_ACCESS_DENIED` 반환

---

## 📎 Issue 번호
<!-- 관련된 이슈가 있다면 닫히도록 연결해주세요 (ex: closed #1) -->

- closed #271 

---

## ✅ 작업 목록
<!-- 체크박스로 완료한 작업을 표시해주세요 -->

- [x] 기능 구현
- [x] 코드 리뷰 반영
- [x] 테스트 코드 작성
- [ ] 문서 업데이트

---

## 📝 기타 참고사항
<!-- 리뷰어가 참고하면 좋을 추가 정보나 질문이 있다면 자유롭게 작성해주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 도서 접근 권한 검증 시스템 추가
  * 공개 도서와 개인 도서에 대한 접근 제어 강화
  * 서재 등록 및 도서 수정 시 권한 확인 프로세스 적용

* **테스트**
  * 접근 권한 검증 기능에 대한 포괄적 테스트 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/UMC-NOOK/Server/pull/277?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->