### PR TITLE
[REFACTOR] 서재 검색 결과에 bookId 추가

### DIFF
--- a/src/main/java/app/nook/book/converter/BookConverter.java
+++ b/src/main/java/app/nook/book/converter/BookConverter.java
@@ -53,6 +53,7 @@ public class BookConverter {
         Category category = book.getCategory();
 
         return BookResponseDto.BookSearchDto.builder()
+                .bookId(book.getId())
                 .isbn13(book.getIsbn13())
                 .title(book.getTitle())
                 .mallType(category.getMallType().getDisplayName())

--- a/src/main/java/app/nook/book/dto/BookResponseDto.java
+++ b/src/main/java/app/nook/book/dto/BookResponseDto.java
@@ -48,6 +48,7 @@ public class BookResponseDto {
     @AllArgsConstructor
     @Setter
     public static class BookSearchDto { // 검색 결과 DTO
+        private Long bookId;
         private String isbn13;
         private String title;
         private String mallType;

--- a/src/main/java/app/nook/library/repository/LibraryRepository.java
+++ b/src/main/java/app/nook/library/repository/LibraryRepository.java
@@ -76,9 +76,15 @@ public interface LibraryRepository extends JpaRepository<Library,Long> {
     long countByUserIdAndReadingStatus(Long userId, ReadingStatus status);
 
 
-    // [전체 검색 - 서재 보유 여부 매핑용] ISBN 목록 중 서재에 있는 ISBN들 반환
-    @Query("SELECT l.book.isbn13 FROM Library l WHERE l.user.id = :userId AND l.book.isbn13 IN :isbns")
-    Set<String> findIsbnsByUserIdAndIsbnIn(@Param("userId") Long userId, @Param("isbns") List<String> isbns);
+    // [전체 검색 - 서재 보유 여부 매핑용] ALADIN 소스 도서 중 ISBN 목록에 포함된 값만 반환
+    @Query("""
+        select l.book.isbn13
+        from Library l
+        where l.user.id = :userId
+          and l.book.sourceType = app.nook.book.domain.enums.SourceType.ALADIN
+          and l.book.isbn13 in :isbns
+    """)
+    Set<String> findAladinIsbnsByUserIdAndIsbnIn(@Param("userId") Long userId, @Param("isbns") List<String> isbns);
 
     // [서재 내 검색] 사용자의 서재에서 제목/저자/ISBN 키워드 검색
     @Query(value = "SELECT l FROM Library l JOIN FETCH l.book b JOIN FETCH b.category " +

--- a/src/main/java/app/nook/library/service/LibraryQueryService.java
+++ b/src/main/java/app/nook/library/service/LibraryQueryService.java
@@ -76,7 +76,7 @@ public class LibraryQueryService {
     }
 
     public Set<String> getOwnedIsbns(Long userId, List<String> isbns) {
-        return libraryRepository.findIsbnsByUserIdAndIsbnIn(userId, isbns);
+        return libraryRepository.findAladinIsbnsByUserIdAndIsbnIn(userId, isbns);
     }
 
     public Page<Library> searchBooksInLibrary(Long userId, String keyword, int page, int size) {

--- a/src/main/java/app/nook/library/service/LibraryQueryService.java
+++ b/src/main/java/app/nook/library/service/LibraryQueryService.java
@@ -76,6 +76,9 @@ public class LibraryQueryService {
     }
 
     public Set<String> getOwnedIsbns(Long userId, List<String> isbns) {
+        if (isbns.isEmpty()) {
+            return Set.of();
+        }
         return libraryRepository.findAladinIsbnsByUserIdAndIsbnIn(userId, isbns);
     }
 

--- a/src/test/java/app/nook/controller/book/BookSearchControllerTest.java
+++ b/src/test/java/app/nook/controller/book/BookSearchControllerTest.java
@@ -194,6 +194,7 @@ class BookSearchControllerTest extends AbstractWebMvcRestDocsTests {
                                         fieldWithPath("result.hasNext").description("다음 페이지 존재 여부"),
                                         fieldWithPath("result.nextCursor").description("다음 페이지 커서 (없으면 null)").optional(),
                                         fieldWithPath("result.books").description("검색된 도서 목록"),
+                                        fieldWithPath("result.books[].bookId").description("도서 ID (GLOBAL 검색에서는 null, LIBRARY 검색에서는 내부 도서 ID)").optional(),
                                         fieldWithPath("result.books[].isbn13").description("ISBN13"),
                                         fieldWithPath("result.books[].title").description("도서 제목"),
                                         fieldWithPath("result.books[].mallType").description("몰 타입(국내 도서, 전자책)"),

--- a/src/test/java/app/nook/library/repository/LibraryRepositoryTest.java
+++ b/src/test/java/app/nook/library/repository/LibraryRepositoryTest.java
@@ -261,7 +261,7 @@ class LibraryRepositoryTest {
     }
 
     @Test
-    void findIsbnsByUserIdAndIsbnIn_서재보유ISBN만반환한다() {
+    void findAladinIsbnsByUserIdAndIsbnIn_서재보유ISBN만반환한다() {
         User user = User.builder()
                 .email("isbn@library.com")
                 .nickName("isbn")
@@ -278,8 +278,17 @@ class LibraryRepositoryTest {
                 .build();
         bookRepository.save(ownedBook);
         libraryRepository.save(Library.builder().user(user).book(ownedBook).build());
+        Book userBook = Book.builder()
+                .isbn13("8888888888888")
+                .title("사용자 등록 도서")
+                .author("작가")
+                .sourceType(SourceType.USER)
+                .createdByUserId(user.getId())
+                .build();
+        bookRepository.save(userBook);
+        libraryRepository.save(Library.builder().user(user).book(userBook).build());
 
-        var result = libraryRepository.findIsbnsByUserIdAndIsbnIn(
+        var result = libraryRepository.findAladinIsbnsByUserIdAndIsbnIn(
                 user.getId(),
                 java.util.List.of("7777777777777", "8888888888888")
         );

--- a/src/test/java/app/nook/library/service/LibraryServiceTest.java
+++ b/src/test/java/app/nook/library/service/LibraryServiceTest.java
@@ -464,7 +464,7 @@ class LibraryServiceTest {
             List<String> isbns = List.of("978123", "978456");
             Set<String> owned = Set.of("978123");
 
-            given(libraryRepository.findIsbnsByUserIdAndIsbnIn(userId, isbns)).willReturn(owned);
+            given(libraryRepository.findAladinIsbnsByUserIdAndIsbnIn(userId, isbns)).willReturn(owned);
 
             Set<String> result = libraryQueryService.getOwnedIsbns(userId, isbns);
 

--- a/src/test/java/app/nook/library/service/LibraryServiceTest.java
+++ b/src/test/java/app/nook/library/service/LibraryServiceTest.java
@@ -470,6 +470,15 @@ class LibraryServiceTest {
 
             assertThat(result).containsExactly("978123");
         }
+
+        @Test
+        @DisplayName("ISBN 목록이 비어 있으면 repository를 호출하지 않는다")
+        void findOwnedIsbns_빈목록() {
+            Set<String> result = libraryQueryService.getOwnedIsbns(1L, List.of());
+
+            assertThat(result).isEmpty();
+            verify(libraryRepository, never()).findAladinIsbnsByUserIdAndIsbnIn(anyLong(), any());
+        }
     }
 
     @Nested


### PR DESCRIPTION
## 📄 작업 내용 요약
<!-- 무엇을 작업했는지 간단하게 요약해주세요 -->

- 검색 결과 DTO에 `bookId` 필드 추가
- 서재 검색 결과에 내부 도서 ID 매핑
- 전체 검색의 서재 보유 여부를 ALADIN 도서 기준으로 판정하도록 수정

---

## 📎 Issue 번호
<!-- 관련된 이슈가 있다면 닫히도록 연결해주세요 (ex: closed #1) -->

- closed #279 

---

## ✅ 작업 목록
<!-- 체크박스로 완료한 작업을 표시해주세요 -->

- [x] 기능 구현
- [x] 코드 리뷰 반영
- [x] 테스트 코드 작성
- [ ] 문서 업데이트

---

## 📝 기타 참고사항
<!-- 리뷰어가 참고하면 좋을 추가 정보나 질문이 있다면 자유롭게 작성해주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 도서 검색 응답에 도서 식별자 정보 추가 - 서재 내 검색 결과에서 도서를 구분할 수 있도록 개선

* **Bug Fixes**
  * 서재 검색 시 특정 소스의 도서만 반환하도록 조회 로직 수정

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/UMC-NOOK/Server/pull/280?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->