### PR TITLE
[REFACTOR] 서재 ID 응답에 libraryId 추가

### DIFF
--- a/src/main/java/app/nook/book/converter/BookConverter.java
+++ b/src/main/java/app/nook/book/converter/BookConverter.java
@@ -26,6 +26,7 @@ public class BookConverter {
                 .aladinLink(book.getAladinLink())
                 .sourceType(book.getSourceType())
                 .bookShelfId(library == null ? null : library.getId())
+                .libraryId(library == null ? null : library.getId())
                 .readingStatus(library == null ? null : library.getReadingStatus())
                 .build();
     }

--- a/src/main/java/app/nook/book/dto/BookResponseDto.java
+++ b/src/main/java/app/nook/book/dto/BookResponseDto.java
@@ -30,6 +30,7 @@ public class BookResponseDto {
         private String aladinLink;
         private SourceType sourceType;
         private Long bookShelfId;
+        private Long libraryId;
         private ReadingStatus readingStatus;
     }
 

--- a/src/main/java/app/nook/library/dto/LibraryViewDto.java
+++ b/src/main/java/app/nook/library/dto/LibraryViewDto.java
@@ -18,6 +18,7 @@ public class LibraryViewDto {
     public record BookStatusResponseDto(
             Long bookId,
             Long bookShelfId,
+            Long libraryId,
             ReadingStatus readingStatus
     ){}
 

--- a/src/main/java/app/nook/library/service/LibraryCommandService.java
+++ b/src/main/java/app/nook/library/service/LibraryCommandService.java
@@ -83,7 +83,7 @@ public class LibraryCommandService {
         libraryRepository.delete(library);
 
         eventPublisher.publishEvent(LibraryCacheInvalidateEvent.monthly(userId, affectedYearMonths));
-        return new LibraryViewDto.BookStatusResponseDto(bookId, null, null);
+        return new LibraryViewDto.BookStatusResponseDto(bookId, null, null, null);
     }
 
     @Transactional
@@ -114,6 +114,7 @@ public class LibraryCommandService {
     private LibraryViewDto.BookStatusResponseDto toBookStatusResponse(Library library) {
         return new LibraryViewDto.BookStatusResponseDto(
                 library.getBook().getId(),
+                library.getId(),
                 library.getId(),
                 library.getReadingStatus()
         );

--- a/src/test/java/app/nook/book/service/BookServiceTest.java
+++ b/src/test/java/app/nook/book/service/BookServiceTest.java
@@ -136,6 +136,7 @@ class BookServiceTest {
         assertThat(result.getPublisher()).isEqualTo(TEST_PUBLISHER);
         assertThat(result.getPages()).isEqualTo(184);
         assertThat(result.getBookShelfId()).isNull();
+        assertThat(result.getLibraryId()).isNull();
         assertThat(result.getReadingStatus()).isNull();
 
         // DB에 있었으므로 알라딘 API는 호출되지 않아야 함
@@ -168,6 +169,7 @@ class BookServiceTest {
 
         // then
         assertThat(result.getBookShelfId()).isEqualTo(10L);
+        assertThat(result.getLibraryId()).isEqualTo(10L);
         assertThat(result.getReadingStatus()).isEqualTo(ReadingStatus.READING);
     }
 
@@ -195,6 +197,7 @@ class BookServiceTest {
         assertThat(result.getIsbn13()).isEqualTo(TEST_ISBN_1);
         assertThat(result.getTitle()).isEqualTo("채식주의자");
         assertThat(result.getBookShelfId()).isNull();
+        assertThat(result.getLibraryId()).isNull();
         assertThat(result.getReadingStatus()).isNull();
 
         // then 2. 저장 메서드에 넘겨진 실제 엔티티 '나포'
@@ -260,6 +263,7 @@ class BookServiceTest {
         assertThat(result.getBookId()).isEqualTo(20L);
         assertThat(result.getTitle()).isEqualTo("제목");
         assertThat(result.getBookShelfId()).isNull();
+        assertThat(result.getLibraryId()).isNull();
         assertThat(result.getReadingStatus()).isNull();
     }
 
@@ -285,6 +289,7 @@ class BookServiceTest {
 
         assertThat(result.getBookId()).isEqualTo(20L);
         assertThat(result.getBookShelfId()).isEqualTo(10L);
+        assertThat(result.getLibraryId()).isEqualTo(10L);
         assertThat(result.getReadingStatus()).isEqualTo(ReadingStatus.READING);
     }
 

--- a/src/test/java/app/nook/controller/book/BookControllerTest.java
+++ b/src/test/java/app/nook/controller/book/BookControllerTest.java
@@ -83,6 +83,7 @@
                   .aladinLink("http://aladin.com/book")
                   .sourceType(SourceType.ALADIN)
                   .bookShelfId(null)
+                  .libraryId(null)
                   .readingStatus(null)
                   .build();
 
@@ -92,6 +93,7 @@
                   .andExpect(status().isOk())
                   .andExpect(jsonPath("$.result.title").value("채식주의자"))
                   .andExpect(jsonPath("$.result.bookShelfId").value(nullValue()))
+                  .andExpect(jsonPath("$.result.libraryId").value(nullValue()))
                   .andExpect(jsonPath("$.result.readingStatus").value(nullValue()))
                   .andDo(documentWithAuth(
                           "{class-name}/{method-name}",
@@ -112,6 +114,7 @@
                                   fieldWithPath("result.aladinLink").description("알라딘 링크"),
                                   fieldWithPath("result.sourceType").description("데이터 출처"),
                                   fieldWithPath("result.bookShelfId").description("서재 ID (없으면 null)").optional(),
+                                  fieldWithPath("result.libraryId").description("서재 ID (없으면 null)").optional(),
                                   fieldWithPath("result.readingStatus").description("독서 상태 (서재에 없으면 null)").optional()
                           ))
                   ));
@@ -156,6 +159,7 @@
                   .coverImageUrl("http://example.com/cover.jpg")
                   .sourceType(SourceType.USER)
                   .bookShelfId(3L)
+                  .libraryId(3L)
                   .readingStatus(ReadingStatus.READING)
                   .build();
 
@@ -165,6 +169,8 @@
                   .andExpect(status().isOk())
                   .andExpect(jsonPath("$.result.bookId").value(1L))
                   .andExpect(jsonPath("$.result.title").value("테스트책"))
+                  .andExpect(jsonPath("$.result.bookShelfId").value(3L))
+                  .andExpect(jsonPath("$.result.libraryId").value(3L))
                   .andExpect(jsonPath("$.result.readingStatus").value("READING"))
                   .andDo(documentWithAuth(
                           "{class-name}/{method-name}",
@@ -185,6 +191,7 @@
                                   fieldWithPath("result.aladinLink").description("알라딘 링크").optional(),
                                   fieldWithPath("result.sourceType").description("데이터 출처"),
                                   fieldWithPath("result.bookShelfId").description("서재 ID").optional(),
+                                  fieldWithPath("result.libraryId").description("서재 ID").optional(),
                                   fieldWithPath("result.readingStatus").description("독서 상태").optional()
                           ))
                   ));
@@ -254,6 +261,7 @@
                   .category("소설/시/희곡")
                   .sourceType(SourceType.USER)
                   .bookShelfId(5L)
+                  .libraryId(5L)
                   .readingStatus(ReadingStatus.BEFORE)
                   .build();
 
@@ -280,6 +288,8 @@
                   .andExpect(jsonPath("$.code").value("SUCCESS-201"))
                   .andExpect(jsonPath("$.result.bookId").value(101L))
                   .andExpect(jsonPath("$.result.sourceType").value("USER"))
+                  .andExpect(jsonPath("$.result.bookShelfId").value(5L))
+                  .andExpect(jsonPath("$.result.libraryId").value(5L))
                   .andExpect(jsonPath("$.result.readingStatus").value("BEFORE"))
                   .andDo(documentWithAuth(
                           "{class-name}/{method-name}",
@@ -310,6 +320,7 @@
                                   fieldWithPath("result.aladinLink").description("알라딘 링크").optional(),
                                   fieldWithPath("result.sourceType").description("데이터 출처"),
                                   fieldWithPath("result.bookShelfId").description("서재 ID").optional(),
+                                  fieldWithPath("result.libraryId").description("서재 ID").optional(),
                                   fieldWithPath("result.readingStatus").description("독서 상태").optional()
                           ))
                   ));
@@ -332,6 +343,7 @@
                   .coverImageUrl("http://example.com/cover.jpg")
                   .sourceType(SourceType.USER)
                   .bookShelfId(5L)
+                  .libraryId(5L)
                   .readingStatus(ReadingStatus.READING)
                   .build();
 
@@ -356,6 +368,8 @@
                           .header(AUTH_HEADER, AUTH_TOKEN))
                   .andExpect(status().isOk())
                   .andExpect(jsonPath("$.result.bookId").value(101L))
+                  .andExpect(jsonPath("$.result.bookShelfId").value(5L))
+                  .andExpect(jsonPath("$.result.libraryId").value(5L))
                   .andExpect(jsonPath("$.result.readingStatus").value("READING"))
                   .andDo(documentWithAuth(
                           "{class-name}/{method-name}",
@@ -389,6 +403,7 @@
                                   fieldWithPath("result.aladinLink").description("알라딘 링크").optional(),
                                   fieldWithPath("result.sourceType").description("데이터 출처"),
                                   fieldWithPath("result.bookShelfId").description("서재 ID").optional(),
+                                  fieldWithPath("result.libraryId").description("서재 ID").optional(),
                                   fieldWithPath("result.readingStatus").description("독서 상태").optional()
                           ))
                   ));

--- a/src/test/java/app/nook/controller/library/LibraryControllerTest.java
+++ b/src/test/java/app/nook/controller/library/LibraryControllerTest.java
@@ -80,7 +80,7 @@ class LibraryControllerTest extends AbstractWebMvcRestDocsTests {
     @WithCustomUser
     void 서재_책_등록_성공() throws Exception {
         LibraryViewDto.BookStatusResponseDto response =
-                new LibraryViewDto.BookStatusResponseDto(1L, 10L, ReadingStatus.BEFORE);
+                new LibraryViewDto.BookStatusResponseDto(1L, 10L, 10L, ReadingStatus.BEFORE);
 
         given(libraryCommandService.registerBook(anyLong(), anyLong())).willReturn(response);
 
@@ -93,6 +93,7 @@ class LibraryControllerTest extends AbstractWebMvcRestDocsTests {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.result.bookId").value(1L))
                 .andExpect(jsonPath("$.result.bookShelfId").value(10L))
+                .andExpect(jsonPath("$.result.libraryId").value(10L))
                 .andExpect(jsonPath("$.result.readingStatus").value("BEFORE"))
                 .andDo(documentWithAuth(
                         "{class-name}/{method-name}",
@@ -102,6 +103,7 @@ class LibraryControllerTest extends AbstractWebMvcRestDocsTests {
                         responseFields(ApiResponseSnippet.withResult(
                                 fieldWithPath("result.bookId").type(NUMBER).description("도서 ID"),
                                 fieldWithPath("result.bookShelfId").type(NUMBER).description("서재 ID"),
+                                fieldWithPath("result.libraryId").type(NUMBER).description("서재 ID"),
                                 fieldWithPath("result.readingStatus").type(STRING).description("독서 상태")
                         ))
                 ));
@@ -112,7 +114,7 @@ class LibraryControllerTest extends AbstractWebMvcRestDocsTests {
     @WithCustomUser
     void 서재_책_삭제_성공() throws Exception {
         LibraryViewDto.BookStatusResponseDto response =
-                new LibraryViewDto.BookStatusResponseDto(1L, null, null);
+                new LibraryViewDto.BookStatusResponseDto(1L, null, null, null);
 
         given(libraryCommandService.deleteByBookId(anyLong(), anyLong())).willReturn(response);
 
@@ -125,6 +127,7 @@ class LibraryControllerTest extends AbstractWebMvcRestDocsTests {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.result.bookId").value(1L))
                 .andExpect(jsonPath("$.result.bookShelfId").value(nullValue()))
+                .andExpect(jsonPath("$.result.libraryId").value(nullValue()))
                 .andExpect(jsonPath("$.result.readingStatus").value(nullValue()))
                 .andDo(documentWithAuth(
                         "{class-name}/{method-name}",
@@ -134,6 +137,7 @@ class LibraryControllerTest extends AbstractWebMvcRestDocsTests {
                         responseFields(ApiResponseSnippet.withResult(
                                 fieldWithPath("result.bookId").type(NUMBER).description("도서 ID"),
                                 fieldWithPath("result.bookShelfId").type(NULL).description("서재 ID (삭제 후 null)"),
+                                fieldWithPath("result.libraryId").type(NULL).description("서재 ID (삭제 후 null)"),
                                 fieldWithPath("result.readingStatus").type(NULL).description("독서 상태 (삭제 후 null)")
                         ))
                 ));
@@ -145,7 +149,7 @@ class LibraryControllerTest extends AbstractWebMvcRestDocsTests {
     void 서재_책_상태변경_성공() throws Exception {
         ReadingStatusRequestDto request = new ReadingStatusRequestDto(1L, ReadingStatus.READING);
         LibraryViewDto.BookStatusResponseDto response =
-                new LibraryViewDto.BookStatusResponseDto(1L, 10L, ReadingStatus.READING);
+                new LibraryViewDto.BookStatusResponseDto(1L, 10L, 10L, ReadingStatus.READING);
 
         given(libraryCommandService.changeReadingStatus(anyLong(), any())).willReturn(response);
 
@@ -160,6 +164,7 @@ class LibraryControllerTest extends AbstractWebMvcRestDocsTests {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.result.bookId").value(1L))
                 .andExpect(jsonPath("$.result.bookShelfId").value(10L))
+                .andExpect(jsonPath("$.result.libraryId").value(10L))
                 .andExpect(jsonPath("$.result.readingStatus").value("READING"))
                 .andDo(documentWithAuth(
                         "{class-name}/{method-name}",
@@ -170,6 +175,7 @@ class LibraryControllerTest extends AbstractWebMvcRestDocsTests {
                         responseFields(ApiResponseSnippet.withResult(
                                 fieldWithPath("result.bookId").type(NUMBER).description("도서 ID"),
                                 fieldWithPath("result.bookShelfId").type(NUMBER).description("서재 ID"),
+                                fieldWithPath("result.libraryId").type(NUMBER).description("서재 ID"),
                                 fieldWithPath("result.readingStatus").type(STRING).description("변경된 독서 상태")
                         ))
                 ));

--- a/src/test/java/app/nook/library/service/LibraryServiceTest.java
+++ b/src/test/java/app/nook/library/service/LibraryServiceTest.java
@@ -123,6 +123,7 @@ class LibraryServiceTest {
 
             assertThat(response.bookId()).isEqualTo(1L);
             assertThat(response.bookShelfId()).isEqualTo(1L);
+            assertThat(response.libraryId()).isEqualTo(1L);
             assertThat(response.readingStatus()).isEqualTo(ReadingStatus.BEFORE);
             verify(timelineCommandService).appendRegister(any());
         }
@@ -191,6 +192,7 @@ class LibraryServiceTest {
 
             assertThat(response.bookId()).isEqualTo(1L);
             assertThat(response.bookShelfId()).isNull();
+            assertThat(response.libraryId()).isNull();
             assertThat(response.readingStatus()).isNull();
             verify(libraryRepository).delete(library);
         }
@@ -292,6 +294,7 @@ class LibraryServiceTest {
 
             assertThat(response.bookId()).isEqualTo(1L);
             assertThat(response.bookShelfId()).isEqualTo(library.getId());
+            assertThat(response.libraryId()).isEqualTo(library.getId());
             assertThat(response.readingStatus()).isEqualTo(ReadingStatus.READING);
             assertThat(library.getReadingStatus()).isEqualTo(ReadingStatus.READING);
             verify(timelineCommandService).appendStatusChanged(any(), any());


### PR DESCRIPTION
## 📄 작업 내용 요약
<!-- 무엇을 작업했는지 간단하게 요약해주세요 -->

- 서재 ID 응답 필드 전환을 위해 `libraryId` 반환 추가
- 기존 `bookShelfId`는 클라이언트 전환 전까지 유지

---

## 📎 Issue 번호
<!-- 관련된 이슈가 있다면 닫히도록 연결해주세요 (ex: closed #1) -->

- closed #266 

---

## ✅ 작업 목록
<!-- 체크박스로 완료한 작업을 표시해주세요 -->

- [x] 기능 구현
- [x] 코드 리뷰 반영
- [x] 테스트 코드 작성
- [ ] 문서 업데이트

---

## 📝 기타 참고사항
<!-- 리뷰어가 참고하면 좋을 추가 정보나 질문이 있다면 자유롭게 작성해주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 도서 상세 정보 응답에 서재 식별자가 추가되었습니다.
  * 도서가 서재에 등록된 경우 해당 서재 ID가 포함되며, 미등록 도서는 null 값으로 표시됩니다.

* **Tests**
  * 도서 상세 조회, 등록, 수정 및 서재 도서 관리 기능에 대한 테스트 검증이 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->