### PR TITLE
[FEAT] 서재 책 삭제 응답에 미등록 상태 반환

### DIFF
--- a/src/main/java/app/nook/library/dto/LibraryViewDto.java
+++ b/src/main/java/app/nook/library/dto/LibraryViewDto.java
@@ -19,7 +19,7 @@ public class LibraryViewDto {
             Long bookId,
             Long bookShelfId,
             Long libraryId,
-            ReadingStatus readingStatus
+            ReadingStatusResponse readingStatus
     ){}
 
     public record MonthlyBookResponseDto(

--- a/src/main/java/app/nook/library/dto/ReadingStatusResponse.java
+++ b/src/main/java/app/nook/library/dto/ReadingStatusResponse.java
@@ -1,0 +1,18 @@
+package app.nook.library.dto;
+
+import app.nook.library.domain.enums.ReadingStatus;
+
+public enum ReadingStatusResponse {
+    BEFORE,
+    READING,
+    FINISHED,
+    UNREGISTERED;
+
+    public static ReadingStatusResponse from(ReadingStatus readingStatus) {
+        return switch (readingStatus) {
+            case BEFORE -> BEFORE;
+            case READING -> READING;
+            case FINISHED -> FINISHED;
+        };
+    }
+}

--- a/src/main/java/app/nook/library/service/LibraryCommandService.java
+++ b/src/main/java/app/nook/library/service/LibraryCommandService.java
@@ -10,6 +10,7 @@ import app.nook.global.response.AuthErrorCode;
 import app.nook.library.domain.Library;
 import app.nook.library.dto.LibraryViewDto;
 import app.nook.library.dto.ReadingStatusRequestDto;
+import app.nook.library.dto.ReadingStatusResponse;
 import app.nook.library.event.LibraryCacheInvalidateEvent;
 import app.nook.library.exception.LibraryErrorCode;
 import app.nook.library.repository.LibraryRepository;
@@ -83,7 +84,12 @@ public class LibraryCommandService {
         libraryRepository.delete(library);
 
         eventPublisher.publishEvent(LibraryCacheInvalidateEvent.monthly(userId, affectedYearMonths));
-        return new LibraryViewDto.BookStatusResponseDto(bookId, null, null, null);
+        return new LibraryViewDto.BookStatusResponseDto(
+                bookId,
+                null,
+                null,
+                ReadingStatusResponse.UNREGISTERED
+        );
     }
 
     @Transactional
@@ -116,7 +122,7 @@ public class LibraryCommandService {
                 library.getBook().getId(),
                 library.getId(),
                 library.getId(),
-                library.getReadingStatus()
+                ReadingStatusResponse.from(library.getReadingStatus())
         );
     }
 }

--- a/src/test/java/app/nook/controller/library/LibraryControllerTest.java
+++ b/src/test/java/app/nook/controller/library/LibraryControllerTest.java
@@ -9,6 +9,7 @@ import app.nook.library.domain.enums.ReadingStatus;
 import app.nook.library.controller.LibraryController;
 import app.nook.library.dto.LibraryViewDto;
 import app.nook.library.dto.ReadingStatusRequestDto;
+import app.nook.library.dto.ReadingStatusResponse;
 import app.nook.library.service.LibraryCommandService;
 import app.nook.library.service.LibraryQueryService;
 import app.nook.user.filter.JwtExceptionFilter;
@@ -80,7 +81,7 @@ class LibraryControllerTest extends AbstractWebMvcRestDocsTests {
     @WithCustomUser
     void 서재_책_등록_성공() throws Exception {
         LibraryViewDto.BookStatusResponseDto response =
-                new LibraryViewDto.BookStatusResponseDto(1L, 10L, 10L, ReadingStatus.BEFORE);
+                new LibraryViewDto.BookStatusResponseDto(1L, 10L, 10L, ReadingStatusResponse.BEFORE);
 
         given(libraryCommandService.registerBook(anyLong(), anyLong())).willReturn(response);
 
@@ -114,7 +115,7 @@ class LibraryControllerTest extends AbstractWebMvcRestDocsTests {
     @WithCustomUser
     void 서재_책_삭제_성공() throws Exception {
         LibraryViewDto.BookStatusResponseDto response =
-                new LibraryViewDto.BookStatusResponseDto(1L, null, null, null);
+                new LibraryViewDto.BookStatusResponseDto(1L, null, null, ReadingStatusResponse.UNREGISTERED);
 
         given(libraryCommandService.deleteByBookId(anyLong(), anyLong())).willReturn(response);
 
@@ -128,7 +129,7 @@ class LibraryControllerTest extends AbstractWebMvcRestDocsTests {
                 .andExpect(jsonPath("$.result.bookId").value(1L))
                 .andExpect(jsonPath("$.result.bookShelfId").value(nullValue()))
                 .andExpect(jsonPath("$.result.libraryId").value(nullValue()))
-                .andExpect(jsonPath("$.result.readingStatus").value(nullValue()))
+                .andExpect(jsonPath("$.result.readingStatus").value("UNREGISTERED"))
                 .andDo(documentWithAuth(
                         "{class-name}/{method-name}",
                         pathParameters(
@@ -138,7 +139,7 @@ class LibraryControllerTest extends AbstractWebMvcRestDocsTests {
                                 fieldWithPath("result.bookId").type(NUMBER).description("도서 ID"),
                                 fieldWithPath("result.bookShelfId").type(NULL).description("서재 ID (삭제 후 null)"),
                                 fieldWithPath("result.libraryId").type(NULL).description("서재 ID (삭제 후 null)"),
-                                fieldWithPath("result.readingStatus").type(NULL).description("독서 상태 (삭제 후 null)")
+                                fieldWithPath("result.readingStatus").type(STRING).description("독서 상태 (삭제 후 미등록 상태)")
                         ))
                 ));
     }
@@ -149,7 +150,7 @@ class LibraryControllerTest extends AbstractWebMvcRestDocsTests {
     void 서재_책_상태변경_성공() throws Exception {
         ReadingStatusRequestDto request = new ReadingStatusRequestDto(1L, ReadingStatus.READING);
         LibraryViewDto.BookStatusResponseDto response =
-                new LibraryViewDto.BookStatusResponseDto(1L, 10L, 10L, ReadingStatus.READING);
+                new LibraryViewDto.BookStatusResponseDto(1L, 10L, 10L, ReadingStatusResponse.READING);
 
         given(libraryCommandService.changeReadingStatus(anyLong(), any())).willReturn(response);
 

--- a/src/test/java/app/nook/library/service/LibraryServiceTest.java
+++ b/src/test/java/app/nook/library/service/LibraryServiceTest.java
@@ -14,6 +14,7 @@ import app.nook.library.domain.Library;
 import app.nook.library.domain.enums.ReadingStatus;
 import app.nook.library.dto.LibraryViewDto;
 import app.nook.library.dto.ReadingStatusRequestDto;
+import app.nook.library.dto.ReadingStatusResponse;
 import app.nook.library.event.LibraryCacheInvalidateEvent;
 import app.nook.library.exception.LibraryErrorCode;
 import app.nook.library.repository.LibraryRepository;
@@ -124,7 +125,7 @@ class LibraryServiceTest {
             assertThat(response.bookId()).isEqualTo(1L);
             assertThat(response.bookShelfId()).isEqualTo(1L);
             assertThat(response.libraryId()).isEqualTo(1L);
-            assertThat(response.readingStatus()).isEqualTo(ReadingStatus.BEFORE);
+            assertThat(response.readingStatus()).isEqualTo(ReadingStatusResponse.BEFORE);
             verify(timelineCommandService).appendRegister(any());
         }
 
@@ -193,7 +194,7 @@ class LibraryServiceTest {
             assertThat(response.bookId()).isEqualTo(1L);
             assertThat(response.bookShelfId()).isNull();
             assertThat(response.libraryId()).isNull();
-            assertThat(response.readingStatus()).isNull();
+            assertThat(response.readingStatus()).isEqualTo(ReadingStatusResponse.UNREGISTERED);
             verify(libraryRepository).delete(library);
         }
 
@@ -295,7 +296,7 @@ class LibraryServiceTest {
             assertThat(response.bookId()).isEqualTo(1L);
             assertThat(response.bookShelfId()).isEqualTo(library.getId());
             assertThat(response.libraryId()).isEqualTo(library.getId());
-            assertThat(response.readingStatus()).isEqualTo(ReadingStatus.READING);
+            assertThat(response.readingStatus()).isEqualTo(ReadingStatusResponse.READING);
             assertThat(library.getReadingStatus()).isEqualTo(ReadingStatus.READING);
             verify(timelineCommandService).appendStatusChanged(any(), any());
         }


### PR DESCRIPTION
## 📄 작업 내용 요약
<!-- 무엇을 작업했는지 간단하게 요약해주세요 -->

- 서재 책 삭제 응답의 `readingStatus`를 `null` 대신 `UNREGISTERED`로 반환하도록 수정
- 서재 등록/상태 변경 응답은 기존 독서 상태값이 유지되도록 응답 전용 상태 타입 추가
---

## 📎 Issue 번호
<!-- 관련된 이슈가 있다면 닫히도록 연결해주세요 (ex: closed #1) -->

- closed #282 

---

## ✅ 작업 목록
<!-- 체크박스로 완료한 작업을 표시해주세요 -->

- [x] 기능 구현
- [x] 코드 리뷰 반영
- [x] 테스트 코드 작성
- [x] 문서 업데이트

---

## 📝 기타 참고사항
<!-- 리뷰어가 참고하면 좋을 추가 정보나 질문이 있다면 자유롭게 작성해주세요 -->