### PR TITLE
[FIX] 도서 상세 조회 시 미등록 상태를 UNREGISTERED로 반환

### DIFF
--- a/src/main/java/app/nook/book/converter/BookConverter.java
+++ b/src/main/java/app/nook/book/converter/BookConverter.java
@@ -5,6 +5,7 @@ import app.nook.book.domain.Book;
 import app.nook.book.domain.Category;
 import app.nook.book.domain.enums.SourceType;
 import app.nook.library.domain.Library;
+import app.nook.library.dto.ReadingStatusResponse;
 
 public class BookConverter {
     public static BookResponseDto.BookDetailDto toBookDetailDto(Book book, Library library) {
@@ -27,7 +28,9 @@ public class BookConverter {
                 .sourceType(book.getSourceType())
                 .bookShelfId(library == null ? null : library.getId())
                 .libraryId(library == null ? null : library.getId())
-                .readingStatus(library == null ? null : library.getReadingStatus())
+                .readingStatus(library == null
+                        ? ReadingStatusResponse.UNREGISTERED
+                        : ReadingStatusResponse.from(library.getReadingStatus()))
                 .build();
     }
 

--- a/src/main/java/app/nook/book/dto/BookResponseDto.java
+++ b/src/main/java/app/nook/book/dto/BookResponseDto.java
@@ -3,6 +3,7 @@ package app.nook.book.dto;
 import app.nook.book.domain.enums.MallType;
 import app.nook.book.domain.enums.SourceType;
 import app.nook.library.domain.enums.ReadingStatus;
+import app.nook.library.dto.ReadingStatusResponse;
 import lombok.*;
 
 import java.util.List;
@@ -31,7 +32,7 @@ public class BookResponseDto {
         private SourceType sourceType;
         private Long bookShelfId;
         private Long libraryId;
-        private ReadingStatus readingStatus;
+        private ReadingStatusResponse readingStatus;
     }
 
     public record BookPreviewDto( // 검색 베스트셀러 프리뷰 DTO

--- a/src/test/java/app/nook/book/service/BookServiceTest.java
+++ b/src/test/java/app/nook/book/service/BookServiceTest.java
@@ -13,6 +13,7 @@ import app.nook.book.repository.CategoryRepository;
 import app.nook.global.exception.CustomException;
 import app.nook.library.domain.Library;
 import app.nook.library.domain.enums.ReadingStatus;
+import app.nook.library.dto.ReadingStatusResponse;
 import app.nook.library.repository.LibraryRepository;
 import app.nook.r2.service.PresignedUrlService;
 import app.nook.user.domain.User;
@@ -137,7 +138,7 @@ class BookServiceTest {
         assertThat(result.getPages()).isEqualTo(184);
         assertThat(result.getBookShelfId()).isNull();
         assertThat(result.getLibraryId()).isNull();
-        assertThat(result.getReadingStatus()).isNull();
+        assertThat(result.getReadingStatus()).isEqualTo(ReadingStatusResponse.UNREGISTERED);
 
         // DB에 있었으므로 알라딘 API는 호출되지 않아야 함
         verify(bookRepository, times(1)).findByIsbn13AndSourceType(TEST_ISBN_1, SourceType.ALADIN);
@@ -170,7 +171,7 @@ class BookServiceTest {
         // then
         assertThat(result.getBookShelfId()).isEqualTo(10L);
         assertThat(result.getLibraryId()).isEqualTo(10L);
-        assertThat(result.getReadingStatus()).isEqualTo(ReadingStatus.READING);
+        assertThat(result.getReadingStatus()).isEqualTo(ReadingStatusResponse.READING);
     }
 
     @Test
@@ -198,7 +199,7 @@ class BookServiceTest {
         assertThat(result.getTitle()).isEqualTo("채식주의자");
         assertThat(result.getBookShelfId()).isNull();
         assertThat(result.getLibraryId()).isNull();
-        assertThat(result.getReadingStatus()).isNull();
+        assertThat(result.getReadingStatus()).isEqualTo(ReadingStatusResponse.UNREGISTERED);
 
         // then 2. 저장 메서드에 넘겨진 실제 엔티티 '나포'
         verify(bookRepository).save(bookCaptor.capture());
@@ -264,7 +265,7 @@ class BookServiceTest {
         assertThat(result.getTitle()).isEqualTo("제목");
         assertThat(result.getBookShelfId()).isNull();
         assertThat(result.getLibraryId()).isNull();
-        assertThat(result.getReadingStatus()).isNull();
+        assertThat(result.getReadingStatus()).isEqualTo(ReadingStatusResponse.UNREGISTERED);
     }
 
     @Test
@@ -290,7 +291,7 @@ class BookServiceTest {
         assertThat(result.getBookId()).isEqualTo(20L);
         assertThat(result.getBookShelfId()).isEqualTo(10L);
         assertThat(result.getLibraryId()).isEqualTo(10L);
-        assertThat(result.getReadingStatus()).isEqualTo(ReadingStatus.READING);
+        assertThat(result.getReadingStatus()).isEqualTo(ReadingStatusResponse.READING);
     }
 
     @Test

--- a/src/test/java/app/nook/controller/book/BookControllerTest.java
+++ b/src/test/java/app/nook/controller/book/BookControllerTest.java
@@ -13,7 +13,7 @@
   import app.nook.global.config.WebSecurityConfig;
   import app.nook.global.docs.ApiResponseSnippet;
   import app.nook.global.exception.CustomException;
-  import app.nook.library.domain.enums.ReadingStatus;
+  import app.nook.library.dto.ReadingStatusResponse;
   import app.nook.user.filter.JwtExceptionFilter;
   import app.nook.user.filter.JwtFilter;
   import org.junit.jupiter.api.DisplayName;
@@ -84,7 +84,7 @@
                   .sourceType(SourceType.ALADIN)
                   .bookShelfId(null)
                   .libraryId(null)
-                  .readingStatus(null)
+                  .readingStatus(ReadingStatusResponse.UNREGISTERED)
                   .build();
 
           given(bookService.getBookDetailByIsbn(any(), eq(isbn13))).willReturn(response);
@@ -94,7 +94,7 @@
                   .andExpect(jsonPath("$.result.title").value("채식주의자"))
                   .andExpect(jsonPath("$.result.bookShelfId").value(nullValue()))
                   .andExpect(jsonPath("$.result.libraryId").value(nullValue()))
-                  .andExpect(jsonPath("$.result.readingStatus").value(nullValue()))
+                  .andExpect(jsonPath("$.result.readingStatus").value("UNREGISTERED"))
                   .andDo(documentWithAuth(
                           "{class-name}/{method-name}",
                           pathParameters(parameterWithName("isbn13").description("도서 ISBN13 (13자리 숫자)")),
@@ -115,7 +115,7 @@
                                   fieldWithPath("result.sourceType").description("데이터 출처"),
                                   fieldWithPath("result.bookShelfId").description("서재 ID (없으면 null)").optional(),
                                   fieldWithPath("result.libraryId").description("서재 ID (없으면 null)").optional(),
-                                  fieldWithPath("result.readingStatus").description("독서 상태 (서재에 없으면 null)").optional()
+                                  fieldWithPath("result.readingStatus").description("독서 상태 (서재에 없으면 UNREGISTERED)").optional()
                           ))
                   ));
       }
@@ -160,7 +160,7 @@
                   .sourceType(SourceType.USER)
                   .bookShelfId(3L)
                   .libraryId(3L)
-                  .readingStatus(ReadingStatus.READING)
+                  .readingStatus(ReadingStatusResponse.READING)
                   .build();
 
           given(bookService.getBookDetailById(any(), eq(1L))).willReturn(response);
@@ -262,7 +262,7 @@
                   .sourceType(SourceType.USER)
                   .bookShelfId(5L)
                   .libraryId(5L)
-                  .readingStatus(ReadingStatus.BEFORE)
+                  .readingStatus(ReadingStatusResponse.BEFORE)
                   .build();
 
           given(userBookFacade.createUserBook(any(), any(BookRequestDto.CreateUserBookRequest.class)))
@@ -344,7 +344,7 @@
                   .sourceType(SourceType.USER)
                   .bookShelfId(5L)
                   .libraryId(5L)
-                  .readingStatus(ReadingStatus.READING)
+                  .readingStatus(ReadingStatusResponse.READING)
                   .build();
 
           given(userBookFacade.updateUserBook(any(), anyLong(), any(BookRequestDto.UpdateUserBookRequest.class)))

--- a/src/test/java/app/nook/controller/book/BookControllerTest.java
+++ b/src/test/java/app/nook/controller/book/BookControllerTest.java
@@ -115,7 +115,7 @@
                                   fieldWithPath("result.sourceType").description("데이터 출처"),
                                   fieldWithPath("result.bookShelfId").description("서재 ID (없으면 null)").optional(),
                                   fieldWithPath("result.libraryId").description("서재 ID (없으면 null)").optional(),
-                                  fieldWithPath("result.readingStatus").description("독서 상태 (서재에 없으면 UNREGISTERED)").optional()
+                                  fieldWithPath("result.readingStatus").description("독서 상태 (BEFORE, READING, FINISHED, UNREGISTERED)")
                           ))
                   ));
       }
@@ -192,7 +192,7 @@
                                   fieldWithPath("result.sourceType").description("데이터 출처"),
                                   fieldWithPath("result.bookShelfId").description("서재 ID").optional(),
                                   fieldWithPath("result.libraryId").description("서재 ID").optional(),
-                                  fieldWithPath("result.readingStatus").description("독서 상태").optional()
+                                  fieldWithPath("result.readingStatus").description("독서 상태 (BEFORE, READING, FINISHED, UNREGISTERED)")
                           ))
                   ));
       }


### PR DESCRIPTION
## 📄 작업 내용 요약
<!-- 무엇을 작업했는지 간단하게 요약해주세요 -->

- 도서 상세 조회 응답의 `readingStatus` 타입을 `ReadingStatusResponse`로 변경
- 서재에 등록되지 않은 도서 상세 조회 시 `readingStatus`를 `UNREGISTERED`로 반환하도록 수정

---
## 📎 Issue 번호
<!-- 관련된 이슈가 있다면 닫히도록 연결해주세요 (ex: closed #1) -->

- closed #287 

---

## ✅ 작업 목록
<!-- 체크박스로 완료한 작업을 표시해주세요 -->

- [x] 기능 구현
- [x] 코드 리뷰 반영
- [x] 테스트 코드 작성
- [x] 문서 업데이트

---

## 📝 기타 참고사항
<!-- 리뷰어가 참고하면 좋을 추가 정보나 질문이 있다면 자유롭게 작성해주세요 -->