### PR TITLE
[REFACTOR] 홈 독서 목표 조회 Redis 캐시 적용

### DIFF
--- a/src/main/java/app/nook/focus/service/FocusService.java
+++ b/src/main/java/app/nook/focus/service/FocusService.java
@@ -11,10 +11,12 @@ import app.nook.focus.repository.ThemeRepository;
 import app.nook.global.exception.CustomException;
 import app.nook.library.domain.Library;
 import app.nook.library.domain.enums.ReadingStatus;
+import app.nook.library.event.LibraryCacheInvalidateEvent;
 import app.nook.library.repository.LibraryRepository;
 import app.nook.timeline.service.TimelineCommandService;
 import app.nook.user.domain.User;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,6 +31,7 @@ public class FocusService {
     private final LibraryRepository libraryRepository;
     private final ThemeRepository themeRepository;
     private final TimelineCommandService timelineCommandService;
+    private final ApplicationEventPublisher eventPublisher;
 
     public FocusResponseDto.FocusStart startFocus(User user, FocusRequestDto.FocusStart request) {
 
@@ -81,6 +84,7 @@ public class FocusService {
 
         if (Boolean.TRUE.equals(request.isFinished())) {
             library.updateStatus(ReadingStatus.FINISHED);
+            eventPublisher.publishEvent(LibraryCacheInvalidateEvent.onboardingGoal(userId));
         } else if (library.getReadingStatus() == ReadingStatus.BEFORE) {
             library.updateStatus(ReadingStatus.READING);
         }

--- a/src/main/java/app/nook/global/config/CacheConfig.java
+++ b/src/main/java/app/nook/global/config/CacheConfig.java
@@ -20,6 +20,7 @@ public class CacheConfig {
     public static final String ALADIN_SEARCH_CACHE = "aladinSearchResults";
     public static final String WEEKLY_BESTSELLERS_CACHE = "weeklyBestsellers";
     public static final String PERSONALIZED_BESTSELLERS_CACHE = "personalizedBestsellers";
+    public static final String ONBOARDING_GOAL_CACHE = "onboardingGoal";
 
     @Bean
     public RedisCacheManager cacheManager(RedisConnectionFactory connectionFactory) {
@@ -38,6 +39,8 @@ public class CacheConfig {
                 defaultConfig.entryTtl(Duration.ofMinutes(30)));
         cacheConfigs.put(PERSONALIZED_BESTSELLERS_CACHE,
                 defaultConfig.entryTtl(Duration.ofMinutes(30)));
+        cacheConfigs.put(ONBOARDING_GOAL_CACHE,
+                defaultConfig.entryTtl(Duration.ofMinutes(2)));
 
         return RedisCacheManager.builder(connectionFactory)
                 .cacheDefaults(defaultConfig)

--- a/src/main/java/app/nook/library/event/LibraryCacheInvalidateEvent.java
+++ b/src/main/java/app/nook/library/event/LibraryCacheInvalidateEvent.java
@@ -8,9 +8,21 @@ import java.util.Set;
  */
 public record LibraryCacheInvalidateEvent(
         Long userId,
-        Set<YearMonth> affectedYearMonths
+        Set<YearMonth> affectedYearMonths,
+        boolean evictOnboardingGoal
 ) {
     public static LibraryCacheInvalidateEvent monthly(Long userId, Set<YearMonth> affectedYearMonths) {
-        return new LibraryCacheInvalidateEvent(userId, Set.copyOf(affectedYearMonths));
+        return new LibraryCacheInvalidateEvent(userId, Set.copyOf(affectedYearMonths), false);
+    }
+
+    public static LibraryCacheInvalidateEvent onboardingGoal(Long userId) {
+        return new LibraryCacheInvalidateEvent(userId, Set.of(), true);
+    }
+
+    public static LibraryCacheInvalidateEvent monthlyAndOnboardingGoal(
+            Long userId,
+            Set<YearMonth> affectedYearMonths
+    ) {
+        return new LibraryCacheInvalidateEvent(userId, Set.copyOf(affectedYearMonths), true);
     }
 }

--- a/src/main/java/app/nook/library/event/LibraryCacheInvalidationListener.java
+++ b/src/main/java/app/nook/library/event/LibraryCacheInvalidationListener.java
@@ -19,5 +19,8 @@ public class LibraryCacheInvalidationListener {
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleAfterCommit(LibraryCacheInvalidateEvent event) {
         redisCacheService.evictLibraryMonthlyCaches(event.userId(), event.affectedYearMonths());
+        if (event.evictOnboardingGoal()) {
+            redisCacheService.evictOnboardingGoal(event.userId());
+        }
     }
 }

--- a/src/main/java/app/nook/library/service/LibraryCommandService.java
+++ b/src/main/java/app/nook/library/service/LibraryCommandService.java
@@ -8,6 +8,7 @@ import app.nook.focus.repository.FocusRepository;
 import app.nook.global.exception.CustomException;
 import app.nook.global.response.AuthErrorCode;
 import app.nook.library.domain.Library;
+import app.nook.library.domain.enums.ReadingStatus;
 import app.nook.library.dto.LibraryViewDto;
 import app.nook.library.dto.ReadingStatusRequestDto;
 import app.nook.library.dto.ReadingStatusResponse;
@@ -75,7 +76,7 @@ public class LibraryCommandService {
         Library library = libraryRepository.findByUserIdAndBook(userId, book)
                 .orElseThrow(() -> new CustomException(LibraryErrorCode.BOOK_NOT_EXIST));
 
-        // 삭제 이후 상태 캐시와 월별 캐시를 함께 무효화
+        boolean evictOnboardingGoal = library.getReadingStatus() == ReadingStatus.FINISHED;
         Set<YearMonth> affectedYearMonths = focusRepository.findDistinctFocusDatesByLibraryAndUser(library.getId(), userId)
                 .stream()
                 .map(YearMonth::from)
@@ -83,7 +84,9 @@ public class LibraryCommandService {
 
         libraryRepository.delete(library);
 
-        eventPublisher.publishEvent(LibraryCacheInvalidateEvent.monthly(userId, affectedYearMonths));
+        eventPublisher.publishEvent(evictOnboardingGoal
+                ? LibraryCacheInvalidateEvent.monthlyAndOnboardingGoal(userId, affectedYearMonths)
+                : LibraryCacheInvalidateEvent.monthly(userId, affectedYearMonths));
         return new LibraryViewDto.BookStatusResponseDto(
                 bookId,
                 null,
@@ -105,11 +108,18 @@ public class LibraryCommandService {
             throw new CustomException(LibraryErrorCode.BOOK_STATUS_INVALID);
         }
 
-        // 상태 변경 이력과 첫 페이지 캐시를 함께 갱신
         LocalDateTime occurredAt = LocalDateTime.now();
+        ReadingStatus beforeStatus = library.getReadingStatus();
         library.updateStatus(requestDto.readingStatus());
         timelineCommandService.appendStatusChanged(library, occurredAt);
+        if (affectsFinishedCount(beforeStatus, requestDto.readingStatus())) {
+            eventPublisher.publishEvent(LibraryCacheInvalidateEvent.onboardingGoal(userId));
+        }
         return toBookStatusResponse(library);
+    }
+
+    private boolean affectsFinishedCount(ReadingStatus beforeStatus, ReadingStatus afterStatus) {
+        return beforeStatus == ReadingStatus.FINISHED || afterStatus == ReadingStatus.FINISHED;
     }
 
     private User getUser(Long userId) {

--- a/src/main/java/app/nook/redis/service/RedisCacheService.java
+++ b/src/main/java/app/nook/redis/service/RedisCacheService.java
@@ -1,6 +1,9 @@
 package app.nook.redis.service;
 
+import app.nook.global.config.CacheConfig;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
 import org.springframework.stereotype.Service;
 
 import java.time.YearMonth;
@@ -11,6 +14,7 @@ import java.util.Collection;
 public class RedisCacheService {
 
     private final RedisZSETService redisZSETService;
+    private final CacheManager cacheManager;
 
     // 월별 캐시 정보 무효화
     public void evictLibraryMonthlyCaches(Long userId, Collection<YearMonth> affectedYearMonths) {
@@ -19,5 +23,13 @@ public class RedisCacheService {
             redisZSETService.evictMonthlyFocusTime(userId, affectedYearMonth);
             redisZSETService.evictMonthlyHourlyFocus(userId, affectedYearMonth);
         }
+    }
+
+    public void evictOnboardingGoal(Long userId) {
+        Cache onboardingGoalCache = cacheManager.getCache(CacheConfig.ONBOARDING_GOAL_CACHE);
+        if (onboardingGoalCache == null) {
+            return;
+        }
+        onboardingGoalCache.evict(userId);
     }
 }

--- a/src/main/java/app/nook/user/service/OnboardingService.java
+++ b/src/main/java/app/nook/user/service/OnboardingService.java
@@ -4,6 +4,7 @@ import app.nook.book.domain.Category;
 import app.nook.book.domain.enums.MallType;
 import app.nook.book.exception.BookErrorCode;
 import app.nook.book.repository.CategoryRepository;
+import app.nook.global.config.CacheConfig;
 import app.nook.global.exception.CustomException;
 import app.nook.global.response.AuthErrorCode;
 import app.nook.global.response.CommonErrorCode;
@@ -16,6 +17,8 @@ import app.nook.user.event.ProfileImageCleanupEvent;
 import app.nook.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -37,6 +40,7 @@ public class OnboardingService {
 
 
     @Transactional
+    @CacheEvict(cacheNames = CacheConfig.ONBOARDING_GOAL_CACHE, key = "#userId")
     public OnboardingDto.CompleteResponse completeOnboarding(
             Long userId,
             OnboardingDto.CompleteRequest request
@@ -120,6 +124,11 @@ public class OnboardingService {
         );
     }
 
+    @Cacheable(
+            cacheNames = CacheConfig.ONBOARDING_GOAL_CACHE,
+            key = "#userId",
+            sync = true
+    )
     public OnboardingDto.GoalResponse getGoal(Long userId) {
         User user = getUser(userId);
         long finishedCount = libraryRepository.countByUserAndReadingStatus(user, ReadingStatus.FINISHED);
@@ -133,6 +142,7 @@ public class OnboardingService {
     }
 
     @Transactional
+    @CacheEvict(cacheNames = CacheConfig.ONBOARDING_GOAL_CACHE, key = "#userId")
     public OnboardingDto.GoalUpdateResponse updateGoal(
             Long userId,
             OnboardingDto.GoalUpdateRequest request

--- a/src/test/java/app/nook/focus/service/FocusServiceTest.java
+++ b/src/test/java/app/nook/focus/service/FocusServiceTest.java
@@ -15,6 +15,7 @@ import app.nook.global.fixture.ThemeFixture;
 import app.nook.global.fixture.UserFixture;
 import app.nook.library.domain.Library;
 import app.nook.library.domain.enums.ReadingStatus;
+import app.nook.library.event.LibraryCacheInvalidateEvent;
 import app.nook.library.repository.LibraryRepository;
 import app.nook.timeline.service.TimelineCommandService;
 import app.nook.user.domain.User;
@@ -26,6 +27,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDateTime;
@@ -34,6 +36,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
@@ -52,6 +55,9 @@ class FocusServiceTest {
 
     @Mock
     private TimelineCommandService timelineCommandService;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
 
     @InjectMocks
     private FocusService focusService;
@@ -180,6 +186,12 @@ class FocusServiceTest {
             assertThat(result.totalFocusSec()).isGreaterThanOrEqualTo(0L);
             assertThat(result.readingStatus()).isEqualTo("FINISHED");
             verify(timelineCommandService).appendFocusCompleted(focus);
+            verify(eventPublisher).publishEvent(argThat((Object event) ->
+                    event instanceof LibraryCacheInvalidateEvent cacheEvent
+                            && cacheEvent.userId().equals(user.getId())
+                            && cacheEvent.evictOnboardingGoal()
+                            && cacheEvent.affectedYearMonths().isEmpty()
+            ));
         }
 
         @Test

--- a/src/test/java/app/nook/focus/service/FocusServiceTest.java
+++ b/src/test/java/app/nook/focus/service/FocusServiceTest.java
@@ -38,6 +38,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -210,6 +211,7 @@ class FocusServiceTest {
             assertThat(focus.getEndPage()).isEqualTo(45);
             assertThat(result.readingStatus()).isEqualTo("READING");
             verify(timelineCommandService).appendFocusCompleted(focus);
+            verify(eventPublisher, never()).publishEvent(any());
         }
 
         @Test

--- a/src/test/java/app/nook/library/service/LibraryCachingIntegrationTest.java
+++ b/src/test/java/app/nook/library/service/LibraryCachingIntegrationTest.java
@@ -140,6 +140,7 @@ class LibraryCachingIntegrationTest {
             verify(redisZSETService, times(1)).evictMonthlyFocusTime(userId, affectedYearMonth);
             verify(redisZSETService, times(1)).evictMonthlyHourlyFocus(userId, affectedYearMonth);
         }
+        verify(cacheManager, never()).getCache(CacheConfig.ONBOARDING_GOAL_CACHE);
     }
 
     @Test

--- a/src/test/java/app/nook/library/service/LibraryCachingIntegrationTest.java
+++ b/src/test/java/app/nook/library/service/LibraryCachingIntegrationTest.java
@@ -5,14 +5,19 @@ import app.nook.book.domain.Book;
 import app.nook.book.repository.BookRepository;
 import app.nook.focus.repository.FocusRepository;
 import app.nook.focus.repository.dto.MonthlyFocusStatsDto;
+import app.nook.global.config.CacheConfig;
 import app.nook.global.common.security.WithCustomUser;
 import app.nook.library.domain.Library;
+import app.nook.library.domain.enums.ReadingStatus;
+import app.nook.library.dto.ReadingStatusRequestDto;
 import app.nook.library.repository.LibraryRepository;
 import app.nook.redis.service.RedisZSETService;
 import app.nook.timeline.service.TimelineCommandService;
 import app.nook.user.domain.User;
 import app.nook.user.service.CustomUserDetails;
 import org.junit.jupiter.api.Test;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -59,6 +64,12 @@ class LibraryCachingIntegrationTest {
 
     @MockitoBean
     private TimelineCommandService timelineCommandService;
+
+    @MockitoBean
+    private CacheManager cacheManager;
+
+    @MockitoBean
+    private Cache cache;
 
     @Test
     void viewMonthly_redisHit이면_db를_조회하지_않는다() {
@@ -129,6 +140,64 @@ class LibraryCachingIntegrationTest {
             verify(redisZSETService, times(1)).evictMonthlyFocusTime(userId, affectedYearMonth);
             verify(redisZSETService, times(1)).evictMonthlyHourlyFocus(userId, affectedYearMonth);
         }
+    }
+
+    @Test
+    void deleteByBookId_완독도서_후_월별_zset과_온보딩목표_캐시무효화가_호출된다() {
+        Long userId = currentUserId();
+        Long bookId = 100L;
+        User user = currentUser();
+
+        Book book = Book.builder()
+                .isbn13("9780000000001")
+                .title("book")
+                .build();
+        ReflectionTestUtils.setField(book, "id", bookId);
+
+        Library library = new Library(user, book);
+        ReflectionTestUtils.setField(library, "id", 999L);
+        ReflectionTestUtils.setField(library, "readingStatus", ReadingStatus.FINISHED);
+
+        given(bookRepository.findById(bookId)).willReturn(Optional.of(book));
+        given(libraryRepository.findByUserIdAndBook(userId, book)).willReturn(Optional.of(library));
+        given(focusRepository.findDistinctFocusDatesByLibraryAndUser(library.getId(), userId))
+                .willReturn(List.of(LocalDate.of(2026, 2, 1)));
+        given(cacheManager.getCache(CacheConfig.ONBOARDING_GOAL_CACHE)).willReturn(cache);
+
+        libraryCommandService.deleteByBookId(userId, bookId);
+
+        YearMonth affectedYearMonth = YearMonth.of(2026, 2);
+        verify(redisZSETService).evictMonthlyBooks(userId, affectedYearMonth);
+        verify(redisZSETService).evictMonthlyFocusTime(userId, affectedYearMonth);
+        verify(redisZSETService).evictMonthlyHourlyFocus(userId, affectedYearMonth);
+        verify(cache).evict(userId);
+    }
+
+    @Test
+    void changeReadingStatus_완독_후_온보딩목표_캐시무효화가_호출된다() {
+        Long userId = currentUserId();
+        Long bookId = 100L;
+        User user = currentUser();
+
+        Book book = Book.builder()
+                .isbn13("9780000000001")
+                .title("book")
+                .build();
+        ReflectionTestUtils.setField(book, "id", bookId);
+
+        Library library = new Library(user, book);
+        ReflectionTestUtils.setField(library, "id", 999L);
+
+        given(bookRepository.findById(bookId)).willReturn(Optional.of(book));
+        given(libraryRepository.findByUserIdAndBook(userId, book)).willReturn(Optional.of(library));
+        given(cacheManager.getCache(CacheConfig.ONBOARDING_GOAL_CACHE)).willReturn(cache);
+
+        libraryCommandService.changeReadingStatus(
+                userId,
+                new ReadingStatusRequestDto(bookId, ReadingStatus.FINISHED)
+        );
+
+        verify(cache).evict(userId);
     }
 
     private Long currentUserId() {

--- a/src/test/java/app/nook/library/service/LibraryServiceTest.java
+++ b/src/test/java/app/nook/library/service/LibraryServiceTest.java
@@ -246,7 +246,8 @@ class LibraryServiceTest {
                             && cacheEvent.affectedYearMonths().equals(Set.of(
                             java.time.YearMonth.of(2026, 2),
                             java.time.YearMonth.of(2026, 3)
-                    ))
+                            ))
+                            && !cacheEvent.evictOnboardingGoal()
             ));
         }
 
@@ -347,7 +348,7 @@ class LibraryServiceTest {
         }
 
         @Test
-        @DisplayName("상태 변경 성공 시 월별 캐시 무효화 이벤트는 발행하지 않는다")
+        @DisplayName("완독 수가 바뀌지 않는 상태 변경 성공 시 캐시 무효화 이벤트는 발행하지 않는다")
         void changeStatus_성공_이벤트미발행() {
             User user = UserFixture.user();
             Book book = BookFixture.book();
@@ -360,6 +361,27 @@ class LibraryServiceTest {
             libraryCommandService.changeReadingStatus(1L, request);
 
             verify(eventPublisher, never()).publishEvent(any());
+        }
+
+        @Test
+        @DisplayName("완독 수가 바뀌는 상태 변경 성공 시 온보딩 목표 캐시 무효화 이벤트를 발행한다")
+        void changeStatus_finishedCountChanged_온보딩목표캐시무효화_이벤트발행() {
+            User user = UserFixture.user();
+            Book book = BookFixture.book();
+            Library library = LibraryFixture.library(user, book);
+            ReadingStatusRequestDto request = new ReadingStatusRequestDto(1L, ReadingStatus.FINISHED);
+
+            given(bookRepository.findById(1L)).willReturn(Optional.of(book));
+            given(libraryRepository.findByUserIdAndBook(1L, book)).willReturn(Optional.of(library));
+
+            libraryCommandService.changeReadingStatus(1L, request);
+
+            verify(eventPublisher).publishEvent(argThat((Object event) ->
+                    event instanceof LibraryCacheInvalidateEvent cacheEvent
+                            && cacheEvent.userId().equals(1L)
+                            && cacheEvent.evictOnboardingGoal()
+                            && cacheEvent.affectedYearMonths().isEmpty()
+            ));
         }
     }
 

--- a/src/test/java/app/nook/user/service/OnboardingServiceTest.java
+++ b/src/test/java/app/nook/user/service/OnboardingServiceTest.java
@@ -4,6 +4,7 @@ import app.nook.book.domain.Category;
 import app.nook.book.domain.enums.MallType;
 import app.nook.book.exception.BookErrorCode;
 import app.nook.book.repository.CategoryRepository;
+import app.nook.global.config.CacheConfig;
 import app.nook.global.exception.CustomException;
 import app.nook.global.response.AuthErrorCode;
 import app.nook.global.response.CommonErrorCode;
@@ -22,9 +23,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Optional;
 
@@ -265,6 +270,18 @@ class OnboardingServiceTest {
     }
 
     @Test
+    @DisplayName("getGoal은 사용자별 온보딩 목표 캐시에 sync=true로 저장한다")
+    void getGoal_cacheable() throws NoSuchMethodException {
+        Method method = OnboardingService.class.getDeclaredMethod("getGoal", Long.class);
+        Cacheable cacheable = AnnotationUtils.findAnnotation(method, Cacheable.class);
+
+        assertThat(cacheable).isNotNull();
+        assertThat(cacheable.cacheNames()).containsExactly(CacheConfig.ONBOARDING_GOAL_CACHE);
+        assertThat(cacheable.key()).isEqualTo("#userId");
+        assertThat(cacheable.sync()).isTrue();
+    }
+
+    @Test
     @DisplayName("getGoal: finished가 goal보다 크면 remainingCount는 0, progressPercent는 100")
     void getGoal_floorZero() {
         user.updateGoal((short) 5);
@@ -312,6 +329,32 @@ class OnboardingServiceTest {
 
         assertThat(res.goal()).isEqualTo((short) 50);
         assertThat(user.getGoal()).isEqualTo((short) 50);
+    }
+
+    @Test
+    @DisplayName("completeOnboarding과 updateGoal은 성공 시 온보딩 목표 캐시를 사용자별로 무효화한다")
+    void goal_mutations_evictOnboardingGoalCache() throws NoSuchMethodException {
+        Method completeOnboarding = OnboardingService.class.getDeclaredMethod(
+                "completeOnboarding",
+                Long.class,
+                OnboardingDto.CompleteRequest.class
+        );
+        Method updateGoal = OnboardingService.class.getDeclaredMethod(
+                "updateGoal",
+                Long.class,
+                OnboardingDto.GoalUpdateRequest.class
+        );
+
+        CacheEvict completeEvict = AnnotationUtils.findAnnotation(completeOnboarding, CacheEvict.class);
+        CacheEvict updateEvict = AnnotationUtils.findAnnotation(updateGoal, CacheEvict.class);
+
+        assertThat(completeEvict).isNotNull();
+        assertThat(completeEvict.cacheNames()).containsExactly(CacheConfig.ONBOARDING_GOAL_CACHE);
+        assertThat(completeEvict.key()).isEqualTo("#userId");
+
+        assertThat(updateEvict).isNotNull();
+        assertThat(updateEvict.cacheNames()).containsExactly(CacheConfig.ONBOARDING_GOAL_CACHE);
+        assertThat(updateEvict.key()).isEqualTo("#userId");
     }
 
     @Test


### PR DESCRIPTION
## 📄 작업 내용 요약
<!-- 무엇을 작업했는지 간단하게 요약해주세요 -->

- 홈 독서 목표 조회에 Redis 캐시 적용
- `onboardingGoal` 캐시 이름 및 2분 TTL 설정 추가
- 목표 수정/온보딩 완료/완독 상태 변경/포커스 완독 처리 시 캐시 무효화 반영
---

## 📎 Issue 번호
<!-- 관련된 이슈가 있다면 닫히도록 연결해주세요 (ex: closed #1) -->

- closed #263 

---

## ✅ 작업 목록
<!-- 체크박스로 완료한 작업을 표시해주세요 -->

- [x] 기능 구현
- [x] 코드 리뷰 반영
- [x] 테스트 코드 작성
- [ ] 문서 업데이트

---

## 📝 기타 참고사항
<!-- 리뷰어가 참고하면 좋을 추가 정보나 질문이 있다면 자유롭게 작성해주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 온보딩 목표 정보에 캐싱 추가로 응답 속도 향상
  * 도서 삭제·읽기 상태 변경·포커스 종료(완독) 시 온보딩 목표 관련 캐시를 자동 무효화하여 최신 상태 유지

* **Tests**
  * 캐싱 동작 및 캐시 무효화 시나리오 검증 테스트 대폭 추가로 안정성 강화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->