### PR TITLE
[REFACTOR] 테스트 DB를 H2에서 PostgreSQL Testcontainers로 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,7 +72,9 @@ dependencies {
 	runtimeOnly 'org.postgresql:postgresql'
 
 	// test db
-	testImplementation 'com.h2database:h2'
+	testImplementation 'org.springframework.boot:spring-boot-testcontainers'
+	testImplementation 'org.testcontainers:junit-jupiter'
+	testImplementation 'org.testcontainers:postgresql'
 
 	// restdocs
 	asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,19 +25,6 @@ services:
       - redis_data:/data
     restart: unless-stopped
 
-  h2:
-    image: oscarfonts/h2
-    container_name: local-h2
-    ports:
-      - "1521:1521"   # TCP
-      - "8082:81"     # H2 Console
-    environment:
-      H2_OPTIONS: -ifNotExists
-    volumes:
-      - h2_data:/opt/h2-data
-    restart: unless-stopped
-
 volumes:
   postgres_data:
   redis_data:
-  h2_data:

--- a/src/test/java/app/nook/book/repository/BookRepositoryTest.java
+++ b/src/test/java/app/nook/book/repository/BookRepositoryTest.java
@@ -4,6 +4,7 @@ import app.nook.book.domain.Book;
 import app.nook.book.domain.Category;
 import app.nook.book.domain.enums.MallType;
 import app.nook.book.domain.enums.SourceType;
+import app.nook.global.common.AbstractPostgresContainerTests;
 import app.nook.global.config.QueryDslConfig;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -17,12 +18,10 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@DataJpaTest(properties = {
-        "spring.jpa.hibernate.ddl-auto=create-drop"
-})
+@DataJpaTest
 @ActiveProfiles("test")
 @Import(QueryDslConfig.class)
-public class BookRepositoryTest {
+public class BookRepositoryTest extends AbstractPostgresContainerTests {
     @Autowired
     private BookRepository bookRepository;
 
@@ -33,8 +32,8 @@ public class BookRepositoryTest {
 
     @BeforeEach
     void setUp() {
-        category = Category.of(MallType.BOOK, "소설/시/희곡", 1);
-        categoryRepository.save(category);
+        category = categoryRepository.findByMallTypeAndCategoryName(MallType.BOOK, "소설/시/희곡")
+                .orElseThrow();
     }
 
     @Test

--- a/src/test/java/app/nook/book/repository/BookViewHistoryRepositoryTest.java
+++ b/src/test/java/app/nook/book/repository/BookViewHistoryRepositoryTest.java
@@ -2,6 +2,7 @@ package app.nook.book.repository;
 
 import app.nook.book.domain.Book;
 import app.nook.book.domain.BookViewHistory;
+import app.nook.global.common.AbstractPostgresContainerTests;
 import app.nook.global.config.QueryDslConfig;
 import app.nook.user.domain.User;
 import app.nook.user.domain.enums.UserRole;
@@ -19,12 +20,10 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@DataJpaTest(properties = {
-        "spring.jpa.hibernate.ddl-auto=create-drop"
-})
+@DataJpaTest
 @ActiveProfiles("test")
 @Import(QueryDslConfig.class)
-class BookViewHistoryRepositoryTest {
+class BookViewHistoryRepositoryTest extends AbstractPostgresContainerTests {
 
     @Autowired
     private BookViewHistoryRepository bookViewHistoryRepository;

--- a/src/test/java/app/nook/book/repository/SearchHistoryRepositoryTest.java
+++ b/src/test/java/app/nook/book/repository/SearchHistoryRepositoryTest.java
@@ -2,6 +2,7 @@ package app.nook.book.repository;
 
 import app.nook.book.domain.SearchHistory;
 import app.nook.book.domain.enums.SearchType;
+import app.nook.global.common.AbstractPostgresContainerTests;
 import app.nook.global.config.QueryDslConfig;
 import app.nook.user.domain.User;
 import app.nook.user.domain.enums.UserRole;
@@ -19,12 +20,10 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@DataJpaTest(properties = {
-        "spring.jpa.hibernate.ddl-auto=create-drop"
-})
+@DataJpaTest
 @ActiveProfiles("test")
 @Import(QueryDslConfig.class)
-class SearchHistoryRepositoryTest {
+class SearchHistoryRepositoryTest extends AbstractPostgresContainerTests {
 
     private static final String TEST_KEYWORD_1 = "채식주의자";
     private static final String TEST_KEYWORD_2 = "소년이 온다";

--- a/src/test/java/app/nook/focus/repository/FocusRepositoryTest.java
+++ b/src/test/java/app/nook/focus/repository/FocusRepositoryTest.java
@@ -4,6 +4,7 @@ import app.nook.book.domain.Book;
 import app.nook.focus.domain.Focus;
 import app.nook.focus.domain.Theme;
 import app.nook.focus.domain.enums.ThemeName;
+import app.nook.global.common.AbstractPostgresContainerTests;
 import app.nook.global.config.QueryDslConfig;
 import app.nook.library.domain.Library;
 import app.nook.user.domain.User;
@@ -26,14 +27,12 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@DataJpaTest(properties = {
-        "spring.jpa.hibernate.ddl-auto=create-drop"
-})
+@DataJpaTest
 @ActiveProfiles("test")
 @EnableJpaRepositories(basePackages = "app.nook.focus.repository")
 @EntityScan(basePackages = "app.nook")
 @Import(QueryDslConfig.class)
-public class FocusRepositoryTest {
+public class FocusRepositoryTest extends AbstractPostgresContainerTests {
 
     @Autowired
     private FocusRepository focusRepository;

--- a/src/test/java/app/nook/focus/repository/ThemeRepositoryTest.java
+++ b/src/test/java/app/nook/focus/repository/ThemeRepositoryTest.java
@@ -2,6 +2,7 @@ package app.nook.focus.repository;
 
 import app.nook.focus.domain.Theme;
 import app.nook.focus.domain.enums.ThemeName;
+import app.nook.global.common.AbstractPostgresContainerTests;
 import app.nook.global.config.QueryDslConfig;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -16,14 +17,12 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@DataJpaTest(properties = {
-        "spring.jpa.hibernate.ddl-auto=create-drop"
-})
+@DataJpaTest
 @ActiveProfiles("test")
 @EnableJpaRepositories(basePackages = "app.nook.focus.repository")
 @EntityScan(basePackages = "app.nook")
 @Import(QueryDslConfig.class)
-public class ThemeRepositoryTest {
+public class ThemeRepositoryTest extends AbstractPostgresContainerTests {
 
     @Autowired
     private ThemeRepository themeRepository;

--- a/src/test/java/app/nook/global/common/AbstractPostgresContainerTests.java
+++ b/src/test/java/app/nook/global/common/AbstractPostgresContainerTests.java
@@ -1,0 +1,26 @@
+package app.nook.global.common;
+
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+public abstract class AbstractPostgresContainerTests {
+
+    private static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>("postgres:16")
+            .withDatabaseName("nook_test")
+            .withUsername("test")
+            .withPassword("test")
+            .withEnv("POSTGRES_INITDB_ARGS", "--locale=C --encoding=UTF8");
+
+    static {
+        POSTGRES.start();
+    }
+
+    @DynamicPropertySource
+    static void registerDataSourceProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", POSTGRES::getJdbcUrl);
+        registry.add("spring.datasource.username", POSTGRES::getUsername);
+        registry.add("spring.datasource.password", POSTGRES::getPassword);
+        registry.add("spring.datasource.driver-class-name", () -> "org.postgresql.Driver");
+    }
+}

--- a/src/test/java/app/nook/global/common/AbstractPostgresContainerTests.java
+++ b/src/test/java/app/nook/global/common/AbstractPostgresContainerTests.java
@@ -1,11 +1,11 @@
 package app.nook.global.common;
 
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.testcontainers.containers.PostgreSQLContainer;
 
 public abstract class AbstractPostgresContainerTests {
 
+    @ServiceConnection
     private static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>("postgres:16")
             .withDatabaseName("nook_test")
             .withUsername("test")
@@ -14,13 +14,5 @@ public abstract class AbstractPostgresContainerTests {
 
     static {
         POSTGRES.start();
-    }
-
-    @DynamicPropertySource
-    static void registerDataSourceProperties(DynamicPropertyRegistry registry) {
-        registry.add("spring.datasource.url", POSTGRES::getJdbcUrl);
-        registry.add("spring.datasource.username", POSTGRES::getUsername);
-        registry.add("spring.datasource.password", POSTGRES::getPassword);
-        registry.add("spring.datasource.driver-class-name", () -> "org.postgresql.Driver");
     }
 }

--- a/src/test/java/app/nook/global/common/AbstractRestDocsTests.java
+++ b/src/test/java/app/nook/global/common/AbstractRestDocsTests.java
@@ -36,7 +36,7 @@ import static org.springframework.security.test.web.servlet.setup.SecurityMockMv
         "spring.profiles.active=test"
 })
 @ActiveProfiles("test")
-public abstract class AbstractRestDocsTests {
+public abstract class AbstractRestDocsTests extends AbstractPostgresContainerTests {
 
     protected static final String AUTH_HEADER = "Authorization";
     protected static final String AUTH_TOKEN = "Bearer test-access-token";

--- a/src/test/java/app/nook/library/repository/LibraryRepositoryTest.java
+++ b/src/test/java/app/nook/library/repository/LibraryRepositoryTest.java
@@ -9,6 +9,7 @@ import app.nook.book.repository.CategoryRepository;
 import app.nook.focus.domain.Focus;
 import app.nook.focus.domain.Theme;
 import app.nook.focus.domain.enums.ThemeName;
+import app.nook.global.common.AbstractPostgresContainerTests;
 import app.nook.global.config.QueryDslConfig;
 import app.nook.library.domain.Library;
 import app.nook.library.domain.enums.LibrarySortType;
@@ -35,12 +36,10 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@DataJpaTest(properties = {
-        "spring.jpa.hibernate.ddl-auto=create-drop"
-})
+@DataJpaTest
 @ActiveProfiles("test")
 @Import(QueryDslConfig.class)
-class LibraryRepositoryTest {
+class LibraryRepositoryTest extends AbstractPostgresContainerTests {
 
     @Autowired
     private LibraryRepository libraryRepository;
@@ -451,8 +450,8 @@ class LibraryRepositoryTest {
                 .build();
         userRepository.save(user);
 
-        Category novel = categoryRepository.save(Category.of(MallType.BOOK, "소설", 1001));
-        Category essay = categoryRepository.save(Category.of(MallType.BOOK, "에세이", 1002));
+        Category novel = categoryRepository.save(Category.of(MallType.BOOK, "테스트 소설", 1001));
+        Category essay = categoryRepository.save(Category.of(MallType.BOOK, "테스트 에세이", 1002));
 
         Book novelBook1 = Book.builder()
                 .isbn13("3030303030301")

--- a/src/test/java/app/nook/library/service/LibraryCachingIntegrationTest.java
+++ b/src/test/java/app/nook/library/service/LibraryCachingIntegrationTest.java
@@ -5,6 +5,7 @@ import app.nook.book.domain.Book;
 import app.nook.book.repository.BookRepository;
 import app.nook.focus.repository.FocusRepository;
 import app.nook.focus.repository.dto.MonthlyFocusStatsDto;
+import app.nook.global.common.AbstractPostgresContainerTests;
 import app.nook.global.config.CacheConfig;
 import app.nook.global.common.security.WithCustomUser;
 import app.nook.library.domain.Library;
@@ -42,7 +43,7 @@ import static org.mockito.Mockito.verify;
 @SpringBootTest(classes = NookApplication.class)
 @ActiveProfiles("test")
 @WithCustomUser(userId = 1L)
-class LibraryCachingIntegrationTest {
+class LibraryCachingIntegrationTest extends AbstractPostgresContainerTests {
 
     @Autowired
     private LibraryStatsService libraryStatsService;

--- a/src/test/java/app/nook/record/repository/RecordRepositoryTest.java
+++ b/src/test/java/app/nook/record/repository/RecordRepositoryTest.java
@@ -2,6 +2,7 @@ package app.nook.record.repository;
 
 import app.nook.book.domain.Book;
 import app.nook.book.domain.enums.SourceType;
+import app.nook.global.common.AbstractPostgresContainerTests;
 import app.nook.global.config.QueryDslConfig;
 import app.nook.library.domain.Library;
 import app.nook.record.domain.Record;
@@ -25,12 +26,10 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@DataJpaTest(properties = {
-        "spring.jpa.hibernate.ddl-auto=create-drop"
-})
+@DataJpaTest
 @ActiveProfiles("test")
 @Import(QueryDslConfig.class)
-class RecordRepositoryTest {
+class RecordRepositoryTest extends AbstractPostgresContainerTests {
 
     @Autowired
     private RecordRepository recordRepository;

--- a/src/test/java/app/nook/timeline/repository/TimelineRepositoryTest.java
+++ b/src/test/java/app/nook/timeline/repository/TimelineRepositoryTest.java
@@ -2,6 +2,7 @@ package app.nook.timeline.repository;
 
 import app.nook.book.domain.Book;
 import app.nook.book.domain.enums.SourceType;
+import app.nook.global.common.AbstractPostgresContainerTests;
 import app.nook.global.config.QueryDslConfig;
 import app.nook.library.domain.Library;
 import app.nook.library.repository.LibraryRepository;
@@ -24,12 +25,10 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@DataJpaTest(properties = {
-        "spring.jpa.hibernate.ddl-auto=create-drop"
-})
+@DataJpaTest
 @ActiveProfiles("test")
 @Import(QueryDslConfig.class)
-class TimelineRepositoryTest {
+class TimelineRepositoryTest extends AbstractPostgresContainerTests {
 
     @Autowired
     private TimelineRepository timelineRepository;

--- a/src/test/java/app/nook/user/repository/UserRepositoryTest.java
+++ b/src/test/java/app/nook/user/repository/UserRepositoryTest.java
@@ -1,5 +1,6 @@
 package app.nook.user.repository;
 
+import app.nook.global.common.AbstractPostgresContainerTests;
 import app.nook.user.domain.User;
 import app.nook.user.domain.enums.UserRole;
 import app.nook.global.config.QueryDslConfig;
@@ -13,12 +14,10 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@DataJpaTest(properties = {
-        "spring.jpa.hibernate.ddl-auto=create-drop"
-})
+@DataJpaTest
 @ActiveProfiles("test")
 @Import(QueryDslConfig.class)
-class UserRepositoryTest {
+class UserRepositoryTest extends AbstractPostgresContainerTests {
 
     @Autowired
     private UserRepository userRepository;

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,26 +1,27 @@
 spring:
-  datasource:
-    url: jdbc:h2:mem:testdb
-    driver-class-name: org.h2.Driver
-    username: sa
-    password:
-
   jpa:
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: validate
     show-sql: false
-    database-platform: org.hibernate.dialect.H2Dialect
     properties:
       hibernate:
-        dialect: org.hibernate.dialect.H2Dialect
+        dialect: org.hibernate.dialect.PostgreSQLDialect
         default_batch_fetch_size: 100
+    open-in-view: false
 
   sql:
     init:
       mode: never
 
   flyway:
-    enabled: false
+    enabled: true
+    locations: classpath:db/migration
+    baseline-on-migrate: true
+    baseline-version: 1
+
+  test:
+    database:
+      replace: none
 
   data:
     redis:


### PR DESCRIPTION
## 📄 작업 내용 요약
<!-- 무엇을 작업했는지 간단하게 요약해주세요 -->

- 테스트 DB를 H2에서 PostgreSQL Testcontainers 기반으로 변경
- JPA Repository 테스트가 실제 PostgreSQL 환경에서 실행되도록 공통 테스트 컨테이너 설정 추가
- 테스트 설정에서 H2 의존성 및 H2 전용 datasource 설정 제거
- PostgreSQL 환경 기준으로 테스트 fixture 일부 정리

---

## 📎 Issue 번호
<!-- 관련된 이슈가 있다면 닫히도록 연결해주세요 (ex: closed #1) -->

- closed #295 

---

## ✅ 작업 목록
<!-- 체크박스로 완료한 작업을 표시해주세요 -->

- [x] 기능 구현
- [x] 코드 리뷰 반영
- [x] 테스트 코드 작성
- [ ] 문서 업데이트

---

## 📝 기타 참고사항
<!-- 리뷰어가 참고하면 좋을 추가 정보나 질문이 있다면 자유롭게 작성해주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **테스트 환경 개선**
  * 테스트 데이터베이스를 H2에서 PostgreSQL 기반 Testcontainers 환경으로 전환했습니다.
  * 테스트에서 Flyway 마이그레이션이 활성화되며, 스키마는 생성/드롭 대신 검증 모드로 실행됩니다.
  * Docker Compose에서 더 이상 사용하지 않는 H2 관련 서비스/볼륨을 제거했습니다.
  * 관련 리포지토리·통합 테스트가 공통 Postgres 컨테이너 기반 실행 방식으로 정리되었습니다.
  * 테스트 설정에서 DB 교체 동작을 비활성화하고 테스트용 JPA 설정을 조정했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->