### PR TITLE
[FIX] 서재 FK cascade 및 상태별 도서 개수 API

### DIFF
--- a/src/docs/asciidoc/library.adoc
+++ b/src/docs/asciidoc/library.adoc
@@ -30,6 +30,13 @@ include::{snippets}/library-controller-test/서재_상태별_책_조회_성공/q
 include::{snippets}/library-controller-test/서재_상태별_책_조회_성공/http-response.adoc[]
 include::{snippets}/library-controller-test/서재_상태별_책_조회_성공/response-fields.adoc[]
 
+=== 서재 상태별 책 개수 조회
+
+include::{snippets}/library-controller-test/서재_상태별_책_개수_조회_성공/http-request.adoc[]
+include::{snippets}/library-controller-test/서재_상태별_책_개수_조회_성공/request-headers.adoc[]
+include::{snippets}/library-controller-test/서재_상태별_책_개수_조회_성공/http-response.adoc[]
+include::{snippets}/library-controller-test/서재_상태별_책_개수_조회_성공/response-fields.adoc[]
+
 ==== 실패 케이스
 
 ===== status 누락 (400)

--- a/src/main/java/app/nook/library/controller/LibraryController.java
+++ b/src/main/java/app/nook/library/controller/LibraryController.java
@@ -82,6 +82,16 @@ public class LibraryController {
         return ApiResponse.onSuccess(response, SuccessCode.OK);
     }
 
+    // 서재 상태별 책 개수 조회
+    @GetMapping("/status-counts")
+    public ApiResponse<LibraryViewDto.StatusBookCountsResponseDto> viewBookCountsByStatus(
+            @CurrentUser User user
+    ) {
+        LibraryViewDto.StatusBookCountsResponseDto response =
+                libraryQueryService.getBookCountsByStatus(user.getId());
+        return ApiResponse.onSuccess(response, SuccessCode.OK);
+    }
+
     // 서재 책 개수 조회
     @GetMapping("/count")
     public ApiResponse<LibraryViewDto.BookCountResponseDto> viewBookCount(

--- a/src/main/java/app/nook/library/converter/LibraryConverter.java
+++ b/src/main/java/app/nook/library/converter/LibraryConverter.java
@@ -84,12 +84,10 @@ public class LibraryConverter {
 
     public static LibraryViewDto.StatusBookResponseDto toStatusBookResponse(
             ReadingStatus readingStatus,
-            int totalBookNum,
             CursorResponse<LibraryViewDto.UserStatusBookItem, Long> cursorResponse
     ) {
         return new LibraryViewDto.StatusBookResponseDto(
                 readingStatus,
-                totalBookNum,
                 cursorResponse
         );
     }

--- a/src/main/java/app/nook/library/dto/LibraryViewDto.java
+++ b/src/main/java/app/nook/library/dto/LibraryViewDto.java
@@ -44,8 +44,13 @@ public class LibraryViewDto {
     ){}
     public record StatusBookResponseDto(
             ReadingStatus readingStatus,
-            int totalBookNum,
             CursorResponse<UserStatusBookItem, Long> bookItems
+    ) {}
+
+    public record StatusBookCountsResponseDto(
+            long before,
+            long reading,
+            long finished
     ) {}
 
 

--- a/src/main/java/app/nook/library/repository/LibraryRepository.java
+++ b/src/main/java/app/nook/library/repository/LibraryRepository.java
@@ -4,6 +4,7 @@ import app.nook.book.domain.Book;
 import app.nook.book.domain.enums.MallType;
 import app.nook.library.domain.Library;
 import app.nook.library.domain.enums.ReadingStatus;
+import app.nook.library.repository.dto.LibraryStatusCount;
 import app.nook.user.domain.User;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.domain.Page;
@@ -71,9 +72,15 @@ public interface LibraryRepository extends JpaRepository<Library, Long>, Library
             Pageable pageable
     );
 
-    long countByUserAndReadingStatus(User user, ReadingStatus status);
+    @Query("""
+        select new app.nook.library.repository.dto.LibraryStatusCount(l.readingStatus, count(l))
+        from Library l
+        where l.user.id = :userId
+        group by l.readingStatus
+    """)
+    List<LibraryStatusCount> countByUserIdGroupByReadingStatus(@Param("userId") Long userId);
 
-    long countByUserIdAndReadingStatus(Long userId, ReadingStatus status);
+    long countByUserAndReadingStatus(User user, ReadingStatus status);
 
 
     // [전체 검색 - 서재 보유 여부 매핑용] ALADIN 소스 도서 중 ISBN 목록에 포함된 값만 반환

--- a/src/main/java/app/nook/library/repository/dto/LibraryStatusCount.java
+++ b/src/main/java/app/nook/library/repository/dto/LibraryStatusCount.java
@@ -1,0 +1,9 @@
+package app.nook.library.repository.dto;
+
+import app.nook.library.domain.enums.ReadingStatus;
+
+public record LibraryStatusCount(
+        ReadingStatus readingStatus,
+        long count
+) {
+}

--- a/src/main/java/app/nook/library/service/LibraryQueryService.java
+++ b/src/main/java/app/nook/library/service/LibraryQueryService.java
@@ -29,7 +29,9 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.EnumMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -70,13 +72,23 @@ public class LibraryQueryService {
         CursorResponse<LibraryViewDto.UserStatusBookItem, Long> cursorResponse =
                 toResolvedCursorResponse(userId, libraries.getContent(), size);
 
-        int totalCount = 0;
-        if (cursor == null) {
-            // 첫 페이지에서만 전체 개수를 함께 내려준다
-            totalCount = (int) libraryRepository.countByUserIdAndReadingStatus(userId, status);
-        }
+        return LibraryConverter.toStatusBookResponse(status, cursorResponse);
+    }
 
-        return LibraryConverter.toStatusBookResponse(status, totalCount, cursorResponse);
+    // 상태별 책 개수 조회
+    public LibraryViewDto.StatusBookCountsResponseDto getBookCountsByStatus(Long userId) {
+        Map<ReadingStatus, Long> counts = new EnumMap<>(ReadingStatus.class);
+        for (ReadingStatus status : ReadingStatus.values()) {
+            counts.put(status, 0L);
+        }
+        libraryRepository.countByUserIdGroupByReadingStatus(userId)
+                .forEach(count -> counts.put(count.readingStatus(), count.count()));
+
+        return new LibraryViewDto.StatusBookCountsResponseDto(
+                counts.get(ReadingStatus.BEFORE),
+                counts.get(ReadingStatus.READING),
+                counts.get(ReadingStatus.FINISHED)
+        );
     }
 
     public Set<String> getOwnedIsbns(Long userId, List<String> isbns) {
@@ -185,7 +197,7 @@ public class LibraryQueryService {
 
     public LibraryViewDto.YearResponseDto getReadingYears(Long userId) {
         User user = getUser(userId);
-        // 가입 연도부터 현재 연도까지 연속된 선택 범위를 만든다
+        // 가입 연도부터 현재 연도까지 연속된 선택 범위 생성
         int startYear = user.getCreatedDate().getYear();
         int currentYear = LocalDateTime.now().getYear();
         List<Integer> years = IntStream.rangeClosed(startYear, currentYear)

--- a/src/main/resources/db/migration/V20260818_210000__repair_book_timelines_library_cascade.sql
+++ b/src/main/resources/db/migration/V20260818_210000__repair_book_timelines_library_cascade.sql
@@ -1,0 +1,20 @@
+-- Hibernate ddl-auto가 생성한 이름 없는 FK가 남아 있으면 V5의 명명된 FK와 중복될 수 있다.
+-- 모든 book_timelines.library_id -> library FK를 제거한 뒤, CASCADE FK 하나만 다시 생성한다.
+DO $$
+DECLARE
+    constraint_name TEXT;
+BEGIN
+    FOR constraint_name IN
+        SELECT conname
+        FROM pg_constraint
+        WHERE contype = 'f'
+          AND conrelid = 'book_timelines'::regclass
+          AND confrelid = 'library'::regclass
+    LOOP
+        EXECUTE format('ALTER TABLE book_timelines DROP CONSTRAINT %I', constraint_name);
+    END LOOP;
+END $$;
+
+ALTER TABLE book_timelines
+    ADD CONSTRAINT fk_book_timelines_library
+        FOREIGN KEY (library_id) REFERENCES library (library_id) ON DELETE CASCADE;

--- a/src/test/java/app/nook/controller/library/LibraryControllerTest.java
+++ b/src/test/java/app/nook/controller/library/LibraryControllerTest.java
@@ -262,7 +262,6 @@ class LibraryControllerTest extends AbstractWebMvcRestDocsTests {
         LibraryViewDto.StatusBookResponseDto response =
                 new LibraryViewDto.StatusBookResponseDto(
                         ReadingStatus.READING,
-                        1,
                         cursorResponse
                 );
 
@@ -287,7 +286,6 @@ class LibraryControllerTest extends AbstractWebMvcRestDocsTests {
                         ),
                         responseFields(ApiResponseSnippet.withResult(
                                 fieldWithPath("result.readingStatus").type(STRING).description("독서 상태"),
-                                fieldWithPath("result.totalBookNum").type(NUMBER).description("해당 상태의 전체 책 수 (첫 조회 시만 제공)"),
                                 fieldWithPath("result.bookItems").type(OBJECT).description("커서 기반 응답"),
                                 fieldWithPath("result.bookItems.items[]").type(ARRAY).description("도서 목록"),
                                 fieldWithPath("result.bookItems.items[].bookId").type(NUMBER).description("도서 ID"),
@@ -300,6 +298,33 @@ class LibraryControllerTest extends AbstractWebMvcRestDocsTests {
                                 fieldWithPath("result.bookItems.hasNext").type(BOOLEAN).description("다음 페이지 존재 여부")
                         ))
                 ));
+    }
+
+    @Test
+    @DisplayName("서재 상태별 책 개수 조회 성공")
+    @WithCustomUser
+    void 서재_상태별_책_개수_조회_성공() throws Exception {
+        given(libraryQueryService.getBookCountsByStatus(1L))
+                .willReturn(new LibraryViewDto.StatusBookCountsResponseDto(3L, 1L, 5L));
+
+        mockMvc.perform(
+                        get("/api/v1/library/status-counts")
+                                .header(AUTH_HEADER, AUTH_TOKEN)
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.before").value(3))
+                .andExpect(jsonPath("$.result.reading").value(1))
+                .andExpect(jsonPath("$.result.finished").value(5))
+                .andDo(documentWithAuth(
+                        "{class-name}/{method-name}",
+                        responseFields(ApiResponseSnippet.withResult(
+                                fieldWithPath("result.before").type(NUMBER).description("읽기 전 도서 수"),
+                                fieldWithPath("result.reading").type(NUMBER).description("읽는 중 도서 수"),
+                                fieldWithPath("result.finished").type(NUMBER).description("완독 도서 수")
+                        ))
+                ));
+
+        verify(libraryQueryService).getBookCountsByStatus(1L);
     }
 
     @Test
@@ -324,7 +349,6 @@ class LibraryControllerTest extends AbstractWebMvcRestDocsTests {
         LibraryViewDto.StatusBookResponseDto response =
                 new LibraryViewDto.StatusBookResponseDto(
                         ReadingStatus.READING,
-                        1,
                         CursorResponse.of(List.of(), null, false)
                 );
 

--- a/src/test/java/app/nook/library/repository/LibraryRepositoryTest.java
+++ b/src/test/java/app/nook/library/repository/LibraryRepositoryTest.java
@@ -16,6 +16,7 @@ import app.nook.library.domain.enums.LibrarySortType;
 import app.nook.library.domain.enums.ReadingStatus;
 import app.nook.library.dto.LibraryBookCursor;
 import app.nook.library.repository.dto.LibraryBookQueryResult;
+import app.nook.library.repository.dto.LibraryStatusCount;
 import app.nook.record.domain.Record;
 import app.nook.record.domain.enums.Emotion;
 
@@ -235,7 +236,7 @@ class LibraryRepositoryTest extends AbstractPostgresContainerTests {
     }
 
     @Test
-    void countByUserAndReadingStatus_상태별개수를반환한다() {
+    void countByUserIdGroupByReadingStatus_상태별개수를한번에반환한다() {
         User user = User.builder()
                 .email("count-status@library.com")
                 .nickName("count-status")
@@ -256,8 +257,15 @@ class LibraryRepositoryTest extends AbstractPostgresContainerTests {
                 .author("작가")
                 .sourceType(SourceType.ALADIN)
                 .build();
+        Book finishedBook = Book.builder()
+                .isbn13("6666666666663")
+                .title("finished")
+                .author("작가")
+                .sourceType(SourceType.ALADIN)
+                .build();
         bookRepository.save(beforeBook);
         bookRepository.save(readingBook);
+        bookRepository.save(finishedBook);
 
         Library beforeLibrary = Library.builder().user(user).book(beforeBook).build();
         ReflectionTestUtils.setField(beforeLibrary, "readingStatus", ReadingStatus.BEFORE);
@@ -267,11 +275,17 @@ class LibraryRepositoryTest extends AbstractPostgresContainerTests {
         ReflectionTestUtils.setField(readingLibrary, "readingStatus", ReadingStatus.READING);
         libraryRepository.save(readingLibrary);
 
-        long readingCount = libraryRepository.countByUserAndReadingStatus(user, ReadingStatus.READING);
-        long beforeCount = libraryRepository.countByUserAndReadingStatus(user, ReadingStatus.BEFORE);
+        Library finishedLibrary = Library.builder().user(user).book(finishedBook).build();
+        ReflectionTestUtils.setField(finishedLibrary, "readingStatus", ReadingStatus.FINISHED);
+        libraryRepository.save(finishedLibrary);
 
-        assertThat(readingCount).isEqualTo(1);
-        assertThat(beforeCount).isEqualTo(1);
+        List<LibraryStatusCount> counts = libraryRepository.countByUserIdGroupByReadingStatus(user.getId());
+
+        assertThat(counts).containsExactlyInAnyOrder(
+                new LibraryStatusCount(ReadingStatus.BEFORE, 1L),
+                new LibraryStatusCount(ReadingStatus.READING, 1L),
+                new LibraryStatusCount(ReadingStatus.FINISHED, 1L)
+        );
     }
 
     @Test

--- a/src/test/java/app/nook/library/service/LibraryServiceTest.java
+++ b/src/test/java/app/nook/library/service/LibraryServiceTest.java
@@ -22,6 +22,7 @@ import app.nook.library.event.LibraryCacheInvalidateEvent;
 import app.nook.library.exception.LibraryErrorCode;
 import app.nook.library.repository.LibraryRepository;
 import app.nook.library.repository.dto.LibraryBookQueryResult;
+import app.nook.library.repository.dto.LibraryStatusCount;
 import app.nook.library.util.LibraryBookCursorCodec;
 import app.nook.r2.service.PresignedUrlService;
 import app.nook.timeline.service.TimelineCommandService;
@@ -395,8 +396,8 @@ class LibraryServiceTest {
     class ViewBooksByStatus {
 
         @Test
-        @DisplayName("첫 조회면 전체 개수를 포함한다")
-        void viewBooksByStatus_첫조회_전체개수포함() {
+        @DisplayName("첫 조회도 목록만 반환하고 전체 개수를 조회하지 않는다")
+        void viewBooksByStatus_첫조회_목록만반환() {
             User user = UserFixture.user();
 
             Book book1 = BookFixture.book();
@@ -426,7 +427,6 @@ class LibraryServiceTest {
             Slice<Library> slice = new SliceImpl<>(List.of(library1, library2), PageRequest.of(0, size + 1), true);
 
             given(libraryRepository.findByUserIdAndStatusWithCursor(anyLong(), any(), any(), any())).willReturn(slice);
-            given(libraryRepository.countByUserIdAndReadingStatus(anyLong(), any())).willReturn(10L);
             willReturn("https://r2.example.com/cover1.png")
                     .given(presignedUrlService)
                     .resolveImageUrl(1L, "book/users/1/cover1.png");
@@ -435,38 +435,28 @@ class LibraryServiceTest {
                     libraryQueryService.getBooksByStatus(1L, ReadingStatus.READING, null, size);
 
             assertThat(response.readingStatus()).isEqualTo(ReadingStatus.READING);
-            assertThat(response.totalBookNum()).isEqualTo(10);
             assertThat(response.bookItems().items()).hasSize(1);
             assertThat(response.bookItems().items().get(0).coverUrl())
                     .isEqualTo("https://r2.example.com/cover1.png");
-            verify(libraryRepository).countByUserIdAndReadingStatus(1L, ReadingStatus.READING);
+            verify(libraryRepository, never()).countByUserIdGroupByReadingStatus(anyLong());
             verify(presignedUrlService).resolveImageUrl(1L, "book/users/1/cover1.png");
         }
 
         @Test
-        @DisplayName("커서 조회면 전체 개수를 포함하지 않는다")
-        void viewBooksByStatus_커서조회_전체개수미포함() {
-            User user = UserFixture.user();
-            Book book = BookFixture.book();
-            ReflectionTestUtils.setField(book, "id", 1L);
-            ReflectionTestUtils.setField(book, "author", "작가");
-            ReflectionTestUtils.setField(book, "coverImageKey", "https://example.com/cover.jpg");
+        @DisplayName("상태별 책 개수는 한 번의 집계 결과로 반환하고 없는 상태는 0으로 반환한다")
+        void getBookCountsByStatus_상태별개수반환() {
+            given(libraryRepository.countByUserIdGroupByReadingStatus(1L)).willReturn(List.of(
+                    new LibraryStatusCount(ReadingStatus.BEFORE, 3L),
+                    new LibraryStatusCount(ReadingStatus.READING, 1L)
+            ));
 
-            Library library = LibraryFixture.library(user, book);
-            ReflectionTestUtils.setField(library, "id", 8L);
-            ReflectionTestUtils.setField(library, "readingStatus", ReadingStatus.READING);
-            ReflectionTestUtils.setField(library, "startedAt", LocalDate.of(2025, 1, 1));
+            LibraryViewDto.StatusBookCountsResponseDto response =
+                    libraryQueryService.getBookCountsByStatus(1L);
 
-            int size = 1;
-            Slice<Library> slice = new SliceImpl<>(List.of(library), PageRequest.of(0, size + 1), false);
-
-            given(libraryRepository.findByUserIdAndStatusWithCursor(anyLong(), any(), anyLong(), any())).willReturn(slice);
-
-            LibraryViewDto.StatusBookResponseDto response =
-                    libraryQueryService.getBooksByStatus(1L, ReadingStatus.READING, 100L, size);
-
-            assertThat(response.totalBookNum()).isZero();
-            verify(libraryRepository, never()).countByUserIdAndReadingStatus(anyLong(), any());
+            assertThat(response.before()).isEqualTo(3L);
+            assertThat(response.reading()).isEqualTo(1L);
+            assertThat(response.finished()).isZero();
+            verify(libraryRepository).countByUserIdGroupByReadingStatus(1L);
         }
     }
 


### PR DESCRIPTION
## 📄 작업 내용 요약

- 서재 삭제 시 남아 있는 자동 생성 FK까지 정리해 `book_timelines`가 함께 삭제되도록 Flyway 복구 마이그레이션을 추가했습니다.
- 상태별 목록 응답에서 `totalBookNum`을 제거해 무한 스크롤 시 count 조회를 하지 않도록 변경했습니다.
- `GET /api/v1/library/status-counts`에서 BEFORE, READING, FINISHED 개수를 한 번의 그룹 집계로 반환합니다.
- 새 상태별 개수 API의 RestDocs AsciiDoc 문서를 추가했습니다.

---

## 📎 Issue 번호

- 관련 이슈 없음

---

## ✅ 작업 목록

- [x] 기능 구현
- [ ] 코드 리뷰 반영
- [x] 테스트 코드 작성
- [x] 문서 업데이트

---

## 📝 기타 참고사항

- API 변경: `GET /api/v1/library/status`의 `result.totalBookNum` 필드를 제거했습니다. 클라이언트는 상태별 탭 개수가 필요할 때 `GET /api/v1/library/status-counts`를 호출해야 합니다.
- DB 변경: `V20260818_210000__repair_book_timelines_library_cascade.sql`이 기존 `book_timelines -> library` FK를 CASCADE FK 하나로 복구합니다.
- 환경 변수 변경은 없습니다.
- 검증: `./gradlew compileTestJava` 통과. 상태별 개수 API의 RestDocs 스니펫 생성을 확인했습니다. 선택 테스트는 Gradle 데몬 점유로 결과 파일 생성까지 완료되지 않아 재실행이 필요합니다.