### PR TITLE
[FIX] 기록 삭제 응답 및 프로필 수정 API 보완

### DIFF
--- a/src/docs/asciidoc/reading-record.adoc
+++ b/src/docs/asciidoc/reading-record.adoc
@@ -23,6 +23,7 @@ include::{snippets}/record-controller-test/기록_수정_성공/http-response.ad
 include::{snippets}/record-controller-test/기록_수정_성공/response-fields.adoc[]
 
 === 기록 삭제
+삭제된 기록 ID를 함께 반환합니다.
 include::{snippets}/record-controller-test/기록_삭제_성공/http-request.adoc[]
 include::{snippets}/record-controller-test/기록_삭제_성공/request-headers.adoc[]
 include::{snippets}/record-controller-test/기록_삭제_성공/path-parameters.adoc[]

--- a/src/docs/asciidoc/user.adoc
+++ b/src/docs/asciidoc/user.adoc
@@ -31,6 +31,17 @@ include::{snippets}/user-controller-test/프로필이미지_수정_성공/reques
 include::{snippets}/user-controller-test/프로필이미지_수정_성공/http-response.adoc[]
 include::{snippets}/user-controller-test/프로필이미지_수정_성공/response-fields.adoc[]
 
+=== 프로필 정보 수정
+로그인한 사용자의 닉네임과 프로필 이미지를 함께 수정합니다. +
+이미지는 별도 업로드 API를 통해 먼저 업로드한 뒤 발급받은 `profileImageKey`만 전달합니다. +
+기존 이미지는 비동기로 삭제됩니다.
+
+include::{snippets}/user-controller-test/프로필정보_수정_성공/http-request.adoc[]
+include::{snippets}/user-controller-test/프로필정보_수정_성공/request-headers.adoc[]
+include::{snippets}/user-controller-test/프로필정보_수정_성공/request-fields.adoc[]
+include::{snippets}/user-controller-test/프로필정보_수정_성공/http-response.adoc[]
+include::{snippets}/user-controller-test/프로필정보_수정_성공/response-fields.adoc[]
+
 === 소셜 로그인
 
 `GOOGLE`, `KAKAO` 두 가지 방법으로 소셜 로그인 요청을 보낼 수 있습니다.

--- a/src/main/java/app/nook/record/controller/RecordController.java
+++ b/src/main/java/app/nook/record/controller/RecordController.java
@@ -74,13 +74,13 @@ public class RecordController {
     }
 
     @PostMapping("/books/{bookId}")
-    public ApiResponse<Void> saveRecord(
+    public ApiResponse<RecordResponseDto.RecordIdDto> saveRecord(
             @CurrentUser User user,
             @PathVariable Long bookId,
             @Valid @RequestBody RecordRequestDto requestDto
             ) {
-        recordCommandService.createRecord(user, bookId, requestDto);
-        return ApiResponse.onSuccess(null, SuccessCode.CREATED);
+        Long recordId = recordCommandService.createRecord(user, bookId, requestDto);
+        return ApiResponse.onSuccess(new RecordResponseDto.RecordIdDto(recordId), SuccessCode.CREATED);
     }
 
     @PutMapping("/{recordId}")
@@ -94,12 +94,12 @@ public class RecordController {
     }
 
     @DeleteMapping("/{recordId}")
-    public ApiResponse<Void> deleteRecord(
+    public ApiResponse<RecordResponseDto.RecordIdDto> deleteRecord(
             @CurrentUser User user,
             @PathVariable Long recordId
     ) {
-        recordCommandService.deleteRecord(user, recordId);
-        return ApiResponse.onSuccess(null, SuccessCode.NO_CONTENT);
+        Long deletedRecordId = recordCommandService.deleteRecord(user, recordId);
+        return ApiResponse.onSuccess(new RecordResponseDto.RecordIdDto(deletedRecordId), SuccessCode.OK);
     }
 
     @GetMapping("/count")

--- a/src/main/java/app/nook/record/dto/BookRecordDto.java
+++ b/src/main/java/app/nook/record/dto/BookRecordDto.java
@@ -13,6 +13,7 @@ public record BookRecordDto(
 ) {
     public record BookRecordItemDto(
             Long bookId,
+            Long recordId,
             String title,
             String author,
             String recordContent,

--- a/src/main/java/app/nook/record/dto/RecordResponseDto.java
+++ b/src/main/java/app/nook/record/dto/RecordResponseDto.java
@@ -2,6 +2,11 @@ package app.nook.record.dto;
 
 public class RecordResponseDto {
 
+    public record RecordIdDto(
+            Long recordId
+    ) {
+    }
+
     public record RecordDetailDto(
             Long recordId,
             String content,

--- a/src/main/java/app/nook/record/repository/RecordQueryRepositoryImpl.java
+++ b/src/main/java/app/nook/record/repository/RecordQueryRepositoryImpl.java
@@ -51,6 +51,7 @@ public class RecordQueryRepositoryImpl implements RecordQueryRepository{
         List<BookRecordDto.BookRecordItemDto> items = queryFactory
                 .select(Projections.constructor(BookRecordDto.BookRecordItemDto.class,
                         record.library.book.id,
+                        Expressions.nullExpression(Long.class),
                         record.library.book.title,
                         record.library.book.author,
                         Expressions.nullExpression(String.class),
@@ -79,18 +80,19 @@ public class RecordQueryRepositoryImpl implements RecordQueryRepository{
             return items;
         }
 
-        // 2) 책별 최신 기록 content 조회 후 합치기
+        // 2) 책별 최신 기록 ID와 content 조회 후 합치기
         List<Long> bookIds = items.stream()
                 .map(BookRecordDto.BookRecordItemDto::bookId)
                 .toList();
-        Map<Long, String> latestContentByBook = findLatestContentByBook(userId, bookIds);
+        Map<Long, LatestRecord> latestRecordsByBook = findLatestRecordsByBook(userId, bookIds);
 
         return items.stream()
                 .map(item -> new BookRecordDto.BookRecordItemDto(
                         item.bookId(),
+                        latestRecordsByBook.get(item.bookId()).id(),
                         item.title(),
                         item.author(),
-                        latestContentByBook.get(item.bookId()),
+                        latestRecordsByBook.get(item.bookId()).content(),
                         item.coverImageUrl(),
                         item.recordCount(),
                         item.lastCreatedDate()
@@ -98,12 +100,12 @@ public class RecordQueryRepositoryImpl implements RecordQueryRepository{
                 .toList();
     }
 
-    // 책별 최신(생성일 기준) 기록의 content를 조회해 bookId -> content 로 매핑
-    private Map<Long, String> findLatestContentByBook(Long userId, List<Long> bookIds) {
+    // 책별 최신(생성일 기준) 기록을 조회해 bookId -> 대표 기록으로 매핑
+    private Map<Long, LatestRecord> findLatestRecordsByBook(Long userId, List<Long> bookIds) {
         QLibrary library = QLibrary.library;
 
         List<Tuple> rows = queryFactory
-                .select(record.library.book.id, record.content)
+                .select(record.library.book.id, record.id, record.content)
                 .from(record)
                 .join(record.library, library)
                 .where(
@@ -113,14 +115,20 @@ public class RecordQueryRepositoryImpl implements RecordQueryRepository{
                 .orderBy(record.library.book.id.asc(), record.createdDate.desc(), record.id.desc())
                 .fetch();
 
-        Map<Long, String> latestContentByBook = new HashMap<>();
+        Map<Long, LatestRecord> latestRecordsByBook = new HashMap<>();
         for (Tuple row : rows) {
             Long bookId = row.get(record.library.book.id);
-            if (!latestContentByBook.containsKey(bookId)) {
-                latestContentByBook.put(bookId, row.get(record.content));
+            if (!latestRecordsByBook.containsKey(bookId)) {
+                latestRecordsByBook.put(bookId, new LatestRecord(
+                        row.get(record.id),
+                        row.get(record.content)
+                ));
             }
         }
-        return latestContentByBook;
+        return latestRecordsByBook;
+    }
+
+    private record LatestRecord(Long id, String content) {
     }
 
     // 감정 필터

--- a/src/main/java/app/nook/record/service/RecordCommandService.java
+++ b/src/main/java/app/nook/record/service/RecordCommandService.java
@@ -46,7 +46,7 @@ public class RecordCommandService {
 
     // 기록 생성
     @Transactional
-    public void createRecord(
+    public Long createRecord(
             User user,
             Long bookId,
             RecordRequestDto requestDto
@@ -87,6 +87,7 @@ public class RecordCommandService {
         }
 
         timelineCommandService.appendRecordCreated(newRecord, imageKeys.size());
+        return newRecord.getId();
     }
 
     // 기록 수정
@@ -113,7 +114,7 @@ public class RecordCommandService {
 
     // 기록 삭제
     @Transactional
-    public void deleteRecord(
+    public Long deleteRecord(
             User user,
             Long recordId
     ) {
@@ -132,6 +133,7 @@ public class RecordCommandService {
         record.getImages().clear();
         recordRepository.delete(record);
         eventPublisher.publishEvent(new RecordDeletedEvent(recordId, keysToDelete));
+        return recordId;
     }
 
     public RecordResponseDto.RecordCountDto countRecords(Long userId) {

--- a/src/main/java/app/nook/record/service/RecordQueryService.java
+++ b/src/main/java/app/nook/record/service/RecordQueryService.java
@@ -68,6 +68,7 @@ public class RecordQueryService {
         List<BookRecordDto.BookRecordItemDto> resolvedPageContent = pageContent.stream()
                 .map(item -> new BookRecordDto.BookRecordItemDto(
                         item.bookId(),
+                        item.recordId(),
                         item.title(),
                         item.author(),
                         item.recordContent(),

--- a/src/main/java/app/nook/user/controller/UserController.java
+++ b/src/main/java/app/nook/user/controller/UserController.java
@@ -53,4 +53,19 @@ public class UserController {
     ) {
         return ApiResponse.onSuccess(userProfileService.updateProfileImage(user.getId(), request.profileImageKey()), SuccessCode.OK);
     }
+
+    /**
+     * 닉네임과 프로필 이미지 수정
+     * PATCH /users/me/profile
+     */
+    @PatchMapping("/profile")
+    public ApiResponse<UserProfileDto.ProfileUpdateResponse> updateProfile(
+            @CurrentUser User user,
+            @Valid @RequestBody UserProfileDto.ProfileUpdateRequest request
+    ) {
+        return ApiResponse.onSuccess(
+                userProfileService.updateProfile(user.getId(), request.nickName(), request.profileImageKey()),
+                SuccessCode.OK
+        );
+    }
 }

--- a/src/main/java/app/nook/user/dto/UserProfileDto.java
+++ b/src/main/java/app/nook/user/dto/UserProfileDto.java
@@ -4,6 +4,8 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
+import java.util.List;
+
 public class UserProfileDto {
 
     public record MyPageResponse(
@@ -12,6 +14,7 @@ public class UserProfileDto {
             String email,
             String profileImageUrl
     ) {}
+
 
     public record NickNameUpdateRequest(
             @NotBlank
@@ -32,4 +35,19 @@ public class UserProfileDto {
     public record ProfileImageUpdateResponse(
             String profileImageUrl
     ) {}
+
+    public record ProfileUpdateRequest(
+            @NotBlank
+            @Pattern(regexp = "^[a-zA-Z0-9가-힣]{2,20}$", message = "닉네임은 2~20자의 영문, 숫자, 한글만 사용할 수 있습니다.")
+            String nickName,
+            @NotBlank
+            @Size(max = 512)
+            String profileImageKey
+    ) {}
+
+    public record ProfileUpdateResponse(
+            String nickName,
+            String profileImageUrl
+    ) {}
+
 }

--- a/src/main/java/app/nook/user/service/UserProfileService.java
+++ b/src/main/java/app/nook/user/service/UserProfileService.java
@@ -67,6 +67,29 @@ public class UserProfileService {
         });
     }
 
+    // 프로필 이미지 소유권을 검증한 뒤 닉네임과 이미지를 하나의 DB 트랜잭션에서 변경한다
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    public UserProfileDto.ProfileUpdateResponse updateProfile(Long userId, String nickName, String profileImageKey) {
+        presignedUrlService.validateOwnedImageKey(userId, profileImageKey, "profile");
+
+        return new TransactionTemplate(transactionManager).execute(status -> {
+            User user = getUser(userId);
+            String oldKey = user.getProfileImageKey();
+
+            user.updateNickName(nickName);
+            user.updateProfileImage(profileImageKey);
+
+            if (oldKey != null && !oldKey.isBlank() && !oldKey.equals(profileImageKey)) {
+                eventPublisher.publishEvent(new ProfileImageCleanupEvent(oldKey));
+            }
+
+            return new UserProfileDto.ProfileUpdateResponse(
+                    user.getNickName(),
+                    presignedUrlService.resolveImageUrl(userId, profileImageKey)
+            );
+        });
+    }
+
     private User getUser(Long userId) {
         return userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(AuthErrorCode.USER_NOT_FOUND));

--- a/src/test/java/app/nook/controller/record/RecordControllerTest.java
+++ b/src/test/java/app/nook/controller/record/RecordControllerTest.java
@@ -86,6 +86,7 @@ class RecordControllerTest extends AbstractWebMvcRestDocsTests {
             // given
             BookRecordDto.BookRecordItemDto firstItem = new BookRecordDto.BookRecordItemDto(
                     101L,
+                    501L,
                     "작별하지 않는다",
                     "한강",
                     "가장 오래 남았던 문장을 기록한 독서 메모입니다.",
@@ -95,6 +96,7 @@ class RecordControllerTest extends AbstractWebMvcRestDocsTests {
             );
             BookRecordDto.BookRecordItemDto secondItem = new BookRecordDto.BookRecordItemDto(
                     99L,
+                    499L,
                     "소년이 온다",
                     "한강",
                     "감정이 크게 남은 부분을 짧게 정리한 기록입니다.",
@@ -121,6 +123,7 @@ class RecordControllerTest extends AbstractWebMvcRestDocsTests {
                             .param("order", SortType.RECENT_RECORDED.name()))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.result.items[0].bookId").value(101))
+                    .andExpect(jsonPath("$.result.items[0].recordId").value(501))
                     .andExpect(jsonPath("$.result.items[0].title").value("작별하지 않는다"))
                     .andExpect(jsonPath("$.result.nextCursor").value(encodedCursor))
                     .andExpect(jsonPath("$.result.hasNext").value(true))
@@ -134,6 +137,7 @@ class RecordControllerTest extends AbstractWebMvcRestDocsTests {
                             responseFields(ApiResponseSnippet.withResult(
                                     fieldWithPath("result.items").type(JsonFieldType.ARRAY).description("사용자의 독서 기록을 책 단위로 묶어 반환한 목록"),
                                     fieldWithPath("result.items[].bookId").type(JsonFieldType.NUMBER).description("독서 기록이 연결된 도서 ID"),
+                                    fieldWithPath("result.items[].recordId").type(JsonFieldType.NUMBER).description("목록 카드에 표시된 최신 기록 ID. 수정·삭제 요청에 사용"),
                                     fieldWithPath("result.items[].title").type(JsonFieldType.STRING).description("도서 제목"),
                                     fieldWithPath("result.items[].author").type(JsonFieldType.STRING).description("도서 저자명"),
                                     fieldWithPath("result.items[].recordContent").type(JsonFieldType.STRING).description("해당 도서에서 가장 최근에 작성된 기록 내용. 목록 카드에서 대표 미리보기로 사용"),
@@ -392,7 +396,7 @@ class RecordControllerTest extends AbstractWebMvcRestDocsTests {
                         List.of("record/users/1/first.png")
                 );
 
-                willDoNothing().given(recordCommandService).createRecord(any(), anyLong(), any());
+                given(recordCommandService.createRecord(any(), anyLong(), any())).willReturn(10L);
 
                 // when & then
                 mockMvc.perform(post("/api/v1/records/books/{bookId}", 1L)
@@ -402,6 +406,7 @@ class RecordControllerTest extends AbstractWebMvcRestDocsTests {
                         .andExpect(status().isOk())
                         .andExpect(jsonPath("$.isSuccess").value(true))
                         .andExpect(jsonPath("$.code").value("SUCCESS-201"))
+                        .andExpect(jsonPath("$.result.recordId").value(10))
                         .andDo(documentWithAuth(
                                 "record-controller-test/기록_생성_성공",
                                 pathParameters(
@@ -413,7 +418,9 @@ class RecordControllerTest extends AbstractWebMvcRestDocsTests {
                                         fieldWithPath("imageKeys").type(JsonFieldType.ARRAY).description("업로드 완료된 이미지 key 목록").optional(),
                                         fieldWithPath("imageKeys[]").description("업로드 완료된 record 이미지 key")
                                 ),
-                                responseFields(ApiResponseSnippet.commonResponseFieldsWithNullableResult())
+                                responseFields(ApiResponseSnippet.withResult(
+                                        fieldWithPath("result.recordId").type(JsonFieldType.NUMBER).description("생성된 기록 ID")
+                                ))
                         ));
             }
         }
@@ -579,18 +586,22 @@ class RecordControllerTest extends AbstractWebMvcRestDocsTests {
             @WithCustomUser
             void 기록_삭제_성공() throws Exception {
                 // given
-                willDoNothing().given(recordCommandService).deleteRecord(any(), anyLong());
+                given(recordCommandService.deleteRecord(any(), anyLong())).willReturn(10L);
 
                 // when & then
                 mockMvc.perform(delete("/api/v1/records/{recordId}", 10L)
                                 .header(AUTH_HEADER, AUTH_TOKEN))
                         .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.code").value("SUCCESS-200"))
+                        .andExpect(jsonPath("$.result.recordId").value(10))
                         .andDo(documentWithAuth(
                                 "record-controller-test/기록_삭제_성공",
                                 pathParameters(
                                         parameterWithName("recordId").description("삭제할 기록 ID")
                                 ),
-                                responseFields(ApiResponseSnippet.commonResponseFieldsWithNullableResult())
+                                responseFields(ApiResponseSnippet.withResult(
+                                        fieldWithPath("result.recordId").type(JsonFieldType.NUMBER).description("삭제된 기록 ID")
+                                ))
                         ));
             }
         }

--- a/src/test/java/app/nook/controller/user/UserControllerTest.java
+++ b/src/test/java/app/nook/controller/user/UserControllerTest.java
@@ -246,4 +246,52 @@ class UserControllerTest extends AbstractWebMvcRestDocsTests {
                         )))
                 .andExpect(status().isUnauthorized());
     }
+
+    @Test
+    @WithCustomUser
+    @DisplayName("프로필 정보 수정 성공")
+    void 프로필정보_수정_성공() throws Exception {
+        UserProfileDto.ProfileUpdateResponse response =
+                new UserProfileDto.ProfileUpdateResponse(
+                        "새닉네임",
+                        "https://presigned-url.example.com/profile.png"
+                );
+        given(userProfileService.updateProfile(anyLong(), anyString(), anyString())).willReturn(response);
+
+        mockMvc.perform(patch("/api/v1/users/me/profile")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of(
+                                "nickName", "새닉네임",
+                                "profileImageKey", "profile/users/1/uuid.png"
+                        )))
+                        .header(AUTH_HEADER, AUTH_TOKEN))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("SUCCESS-200"))
+                .andExpect(jsonPath("$.result.nickName").value("새닉네임"))
+                .andExpect(jsonPath("$.result.profileImageUrl").value("https://presigned-url.example.com/profile.png"))
+                .andDo(documentWithAuth(
+                        "{class-name}/{method-name}",
+                        requestFields(
+                                fieldWithPath("nickName").description("수정할 닉네임 (2~20자, 영문·숫자·한글)"),
+                                fieldWithPath("profileImageKey").description("업로드된 프로필 이미지 key")
+                        ),
+                        responseFields(ApiResponseSnippet.withResult(
+                                fieldWithPath("result.nickName").description("수정된 닉네임"),
+                                fieldWithPath("result.profileImageUrl").description("수정된 프로필 이미지 CDN URL")
+                        ))
+                ));
+    }
+
+    @Test
+    @WithCustomUser
+    @DisplayName("프로필 정보 수정 실패 - 닉네임 누락")
+    void 프로필정보_수정_실패_닉네임누락() throws Exception {
+        mockMvc.perform(patch("/api/v1/users/me/profile")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of(
+                                "profileImageKey", "profile/users/1/uuid.png"
+                        )))
+                        .header(AUTH_HEADER, AUTH_TOKEN))
+                .andExpect(status().isBadRequest());
+    }
 }

--- a/src/test/java/app/nook/record/repository/RecordRepositoryTest.java
+++ b/src/test/java/app/nook/record/repository/RecordRepositoryTest.java
@@ -171,7 +171,7 @@ class RecordRepositoryTest extends AbstractPostgresContainerTests {
                     LocalDateTime.of(2026, 4, 1, 10, 0));
             persistRecord(library, Emotion.SAD, "중간 기록",
                     LocalDateTime.of(2026, 4, 2, 10, 0));
-            persistRecord(library, Emotion.USEFUL, "최신 기록",
+            Record latestRecord = persistRecord(library, Emotion.USEFUL, "최신 기록",
                     LocalDateTime.of(2026, 4, 3, 10, 0));
             em.flush();
             em.clear();
@@ -187,6 +187,7 @@ class RecordRepositoryTest extends AbstractPostgresContainerTests {
             // then - 책 1권으로 묶이고 count=3, content는 가장 최신 기록
             assertThat(result).hasSize(1);
             assertThat(result.get(0).bookId()).isEqualTo(book.getId());
+            assertThat(result.get(0).recordId()).isEqualTo(latestRecord.getId());
             assertThat(result.get(0).recordCount()).isEqualTo(3L);
             assertThat(result.get(0).recordContent()).isEqualTo("최신 기록");
         }

--- a/src/test/java/app/nook/record/service/RecordQueryServiceTest.java
+++ b/src/test/java/app/nook/record/service/RecordQueryServiceTest.java
@@ -572,6 +572,7 @@ class RecordQueryServiceTest {
     ) {
         return new BookRecordDto.BookRecordItemDto(
                 bookId,
+                bookId * 10,
                 title,
                 "저자",
                 "내용",

--- a/src/test/java/app/nook/user/service/UserProfileServiceTest.java
+++ b/src/test/java/app/nook/user/service/UserProfileServiceTest.java
@@ -1,0 +1,110 @@
+package app.nook.user.service;
+
+import app.nook.global.exception.CustomException;
+import app.nook.global.fixture.UserFixture;
+import app.nook.global.response.AuthErrorCode;
+import app.nook.r2.service.PresignedUrlService;
+import app.nook.user.domain.User;
+import app.nook.user.dto.UserProfileDto;
+import app.nook.user.event.ProfileImageCleanupEvent;
+import app.nook.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.SimpleTransactionStatus;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UserProfile 서비스 테스트")
+class UserProfileServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PresignedUrlService presignedUrlService;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
+    @Mock
+    private PlatformTransactionManager transactionManager;
+
+    @InjectMocks
+    private UserProfileService userProfileService;
+
+    @Nested
+    @DisplayName("프로필 정보 수정")
+    class UpdateProfile {
+
+        @Test
+        @DisplayName("닉네임과 이미지를 함께 변경하고 이전 이미지는 정리 이벤트를 발행한다")
+        void 프로필정보_수정_성공() {
+            User user = UserFixture.user();
+            ReflectionTestUtils.setField(user, "profileImageKey", "profile/users/1/old.png");
+            stubTransaction();
+            given(userRepository.findById(1L)).willReturn(Optional.of(user));
+            given(presignedUrlService.resolveImageUrl(1L, "profile/users/1/new.png"))
+                    .willReturn("https://cdn.example.com/new.png");
+
+            UserProfileDto.ProfileUpdateResponse response = userProfileService.updateProfile(
+                    1L,
+                    "새닉네임",
+                    "profile/users/1/new.png"
+            );
+
+            assertThat(user.getNickName()).isEqualTo("새닉네임");
+            assertThat(user.getProfileImageKey()).isEqualTo("profile/users/1/new.png");
+            assertThat(response.nickName()).isEqualTo("새닉네임");
+            assertThat(response.profileImageUrl()).isEqualTo("https://cdn.example.com/new.png");
+            verify(presignedUrlService).validateOwnedImageKey(1L, "profile/users/1/new.png", "profile");
+            verify(eventPublisher).publishEvent(new ProfileImageCleanupEvent("profile/users/1/old.png"));
+        }
+
+        @Test
+        @DisplayName("같은 이미지를 다시 설정하면 정리 이벤트를 발행하지 않는다")
+        void 프로필정보_수정_동일이미지() {
+            User user = UserFixture.user();
+            ReflectionTestUtils.setField(user, "profileImageKey", "profile/users/1/current.png");
+            stubTransaction();
+            given(userRepository.findById(1L)).willReturn(Optional.of(user));
+            given(presignedUrlService.resolveImageUrl(1L, "profile/users/1/current.png"))
+                    .willReturn("https://cdn.example.com/current.png");
+
+            userProfileService.updateProfile(1L, "새닉네임", "profile/users/1/current.png");
+
+            verify(eventPublisher, never()).publishEvent(any(ProfileImageCleanupEvent.class));
+        }
+
+        @Test
+        @DisplayName("사용자가 없으면 USER_NOT_FOUND 예외를 던진다")
+        void 프로필정보_수정_유저없음() {
+            stubTransaction();
+            given(userRepository.findById(1L)).willReturn(Optional.empty());
+
+            CustomException exception = assertThrows(CustomException.class,
+                    () -> userProfileService.updateProfile(1L, "새닉네임", "profile/users/1/new.png"));
+
+            assertThat(exception.getErrorCode()).isEqualTo(AuthErrorCode.USER_NOT_FOUND);
+        }
+    }
+
+    private void stubTransaction() {
+        given(transactionManager.getTransaction(any())).willReturn(new SimpleTransactionStatus());
+    }
+}


### PR DESCRIPTION
## 📄 작업 내용 요약

- 기록 생성·목록·삭제 응답에 `recordId`를 추가했습니다.
- 기록 삭제 성공 응답을 `SUCCESS-204`에서 `SUCCESS-200`과 삭제된 `recordId`로 변경했습니다.
- 닉네임과 프로필 이미지를 한 요청으로 수정하는 `PATCH /api/v1/users/me/profile` API를 추가했습니다.

---

## 📎 Issue 번호

- 관련 이슈 없음

---

## ✅ 작업 목록

- [x] 기능 구현
- [ ] 코드 리뷰 반영
- [x] 테스트 코드 작성
- [x] 문서 업데이트

---

## 📝 기타 참고사항

- API 변경: `GET /api/v1/records`의 항목에 카드에 표시되는 최신 기록의 `recordId`가 추가됩니다. 
- `POST /api/v1/records/books/{bookId}`와 `DELETE /api/v1/records/{recordId}`도 `result.recordId`를 반환합니다.
- API 변경: `PATCH /api/v1/users/me/profile` 요청은 `nickName`, `profileImageKey`를 함께 받으며 두 값을 한 트랜잭션으로 변경합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 닉네임과 프로필 이미지를 한 번에 수정할 수 있는 프로필 수정 기능을 추가했습니다.
  * 프로필 수정 결과로 변경된 닉네임과 이미지 URL을 제공합니다.
  * 기록 생성·삭제 후 해당 기록 ID를 응답합니다.
  * 독서 기록 목록에 각 기록의 ID를 표시합니다.

* **문서**
  * 프로필 수정 API와 기록 삭제 응답 정보를 문서화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->