### PR TITLE
[DOCS] 실패케이스 추가

### DIFF
--- a/src/docs/asciidoc/book.adoc
+++ b/src/docs/asciidoc/book.adoc
@@ -10,6 +10,13 @@ include::{snippets}/book-controller-test/도서_상세조회_성공/path-paramet
 include::{snippets}/book-controller-test/도서_상세조회_성공/http-response.adoc[]
 include::{snippets}/book-controller-test/도서_상세조회_성공/response-fields.adoc[]
 
+==== 실패 케이스
+
+include::{snippets}/book-controller-test/도서_상세조회_실패_잘못된_isbn_형식/http-response.adoc[]
+include::{snippets}/common-error-response/bad-request/response-fields.adoc[]
+include::{snippets}/book-controller-test/도서_상세조회_실패_존재하지않는_도서/http-response.adoc[]
+include::{snippets}/common-error-response/not-found/response-fields.adoc[]
+
 === 도서 상세 조회 (bookId)
 도서 ID(``bookId``)로 도서 상세 정보를 조회합니다.
  +
@@ -48,6 +55,11 @@ include::{snippets}/book-controller-test/추천베스트셀러_조회_성공/res
 include::{snippets}/category-controller-test/도서카테고리_조회_성공/http-request.adoc[]
 include::{snippets}/category-controller-test/도서카테고리_조회_성공/http-response.adoc[]
 include::{snippets}/category-controller-test/도서카테고리_조회_성공/response-fields.adoc[]
+
+==== 인증 실패 (401)
+
+include::{snippets}/category-controller-test/도서카테고리_조회_인증없음_401/http-response.adoc[]
+include::{snippets}/common-error-response/unauthorized/response-fields.adoc[]
 
 === 사용자 도서 등록
 사용자가 직접 도서를 등록합니다.

--- a/src/docs/asciidoc/error.adoc
+++ b/src/docs/asciidoc/error.adoc
@@ -1,0 +1,46 @@
+=== 공통 오류 응답
+
+모든 오류 응답은 `isSuccess`, `code`, `message`, `result` 형식의 `ApiResponse`를 사용합니다.
+일반 오류의 `result`는 응답에서 제외되며, 요청값 검증 오류는 필드별 상세 오류 정보를 반환할 수 있습니다.
+
+==== 잘못된 요청 (400)
+
+include::{snippets}/common-error-response/bad-request/http-request.adoc[]
+include::{snippets}/common-error-response/bad-request/http-response.adoc[]
+include::{snippets}/common-error-response/bad-request/response-fields.adoc[]
+
+==== 요청값 검증 실패 (400)
+
+include::{snippets}/common-error-response/validation/http-request.adoc[]
+include::{snippets}/common-error-response/validation/http-response.adoc[]
+include::{snippets}/common-error-response/validation/response-fields.adoc[]
+
+==== 인증 필요 (401)
+
+include::{snippets}/common-error-response/unauthorized/http-request.adoc[]
+include::{snippets}/common-error-response/unauthorized/http-response.adoc[]
+include::{snippets}/common-error-response/unauthorized/response-fields.adoc[]
+
+==== 권한 없음 (403)
+
+include::{snippets}/common-error-response/forbidden/http-request.adoc[]
+include::{snippets}/common-error-response/forbidden/http-response.adoc[]
+include::{snippets}/common-error-response/forbidden/response-fields.adoc[]
+
+==== 리소스 없음 (404)
+
+include::{snippets}/common-error-response/not-found/http-request.adoc[]
+include::{snippets}/common-error-response/not-found/http-response.adoc[]
+include::{snippets}/common-error-response/not-found/response-fields.adoc[]
+
+==== 요청 충돌 (409)
+
+include::{snippets}/common-error-response/conflict/http-request.adoc[]
+include::{snippets}/common-error-response/conflict/http-response.adoc[]
+include::{snippets}/common-error-response/conflict/response-fields.adoc[]
+
+==== 서버 오류 (500)
+
+include::{snippets}/common-error-response/internal-server-error/http-request.adoc[]
+include::{snippets}/common-error-response/internal-server-error/http-response.adoc[]
+include::{snippets}/common-error-response/internal-server-error/response-fields.adoc[]

--- a/src/docs/asciidoc/image.adoc
+++ b/src/docs/asciidoc/image.adoc
@@ -19,6 +19,12 @@ include::{snippets}/image-upload-controller-test/단건_업로드_URL_발급_성
 include::{snippets}/image-upload-controller-test/단건_업로드_URL_발급_성공/http-response.adoc[]
 include::{snippets}/image-upload-controller-test/단건_업로드_URL_발급_성공/response-fields.adoc[]
 
+==== 실패 케이스
+
+include::{snippets}/failure/단건_업로드_url_발급_실패_유효하지않은_업로드타입/http-response.adoc[]
+include::{snippets}/failure/단건_업로드_url_발급_실패_유효하지않은_파일타입/http-response.adoc[]
+include::{snippets}/common-error-response/bad-request/response-fields.adoc[]
+
 단건 업로드도 프론트 흐름은 동일합니다.
 
 - 먼저 업로드 URL 발급 API 호출

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -5,6 +5,9 @@
 :toclevels: 2
 :seclinks:
 
+== 공통 오류 응답
+include::error.adoc[]
+
 == 사용자
 include::user.adoc[]
 

--- a/src/docs/asciidoc/library.adoc
+++ b/src/docs/asciidoc/library.adoc
@@ -37,24 +37,28 @@ include::{snippets}/library-controller-test/서재_상태별_책_조회_성공/r
 include::{snippets}/library-controller-test/서재_상태별_책_조회_실패_status_누락/http-request.adoc[]
 include::{snippets}/library-controller-test/서재_상태별_책_조회_실패_status_누락/request-headers.adoc[]
 include::{snippets}/library-controller-test/서재_상태별_책_조회_실패_status_누락/http-response.adoc[]
+include::{snippets}/common-error-response/bad-request/response-fields.adoc[]
 
 ===== cursor 음수 (400)
 
 include::{snippets}/library-controller-test/서재_상태별_책_조회_실패_cursor_음수/http-request.adoc[]
 include::{snippets}/library-controller-test/서재_상태별_책_조회_실패_cursor_음수/request-headers.adoc[]
 include::{snippets}/library-controller-test/서재_상태별_책_조회_실패_cursor_음수/http-response.adoc[]
+include::{snippets}/common-error-response/bad-request/response-fields.adoc[]
 
 ===== size 최소값 미만 (400)
 
 include::{snippets}/library-controller-test/서재_상태별_책_조회_실패_size_최소값미만/http-request.adoc[]
 include::{snippets}/library-controller-test/서재_상태별_책_조회_실패_size_최소값미만/request-headers.adoc[]
 include::{snippets}/library-controller-test/서재_상태별_책_조회_실패_size_최소값미만/http-response.adoc[]
+include::{snippets}/common-error-response/bad-request/response-fields.adoc[]
 
 ===== size 최대값 초과 (400)
 
 include::{snippets}/library-controller-test/서재_상태별_책_조회_실패_size_최대값초과/http-request.adoc[]
 include::{snippets}/library-controller-test/서재_상태별_책_조회_실패_size_최대값초과/request-headers.adoc[]
 include::{snippets}/library-controller-test/서재_상태별_책_조회_실패_size_최대값초과/http-response.adoc[]
+include::{snippets}/common-error-response/bad-request/response-fields.adoc[]
 
 === 서재 전체 책 목록 조회(독서기록에서 진입)
 
@@ -75,11 +79,13 @@ include::{snippets}/view-all-books/서재_전체_책_목록_조회_빈목록이�
 
 include::{snippets}/view-all-books/서재_전체_책_목록_조회_실패_cursor_형식오류/http-request.adoc[]
 include::{snippets}/view-all-books/서재_전체_책_목록_조회_실패_cursor_형식오류/http-response.adoc[]
+include::{snippets}/common-error-response/bad-request/response-fields.adoc[]
 
 ===== size 최대값 초과 (400)
 
 include::{snippets}/view-all-books/서재_전체_책_목록_조회_실패_size_최대값초과/http-request.adoc[]
 include::{snippets}/view-all-books/서재_전체_책_목록_조회_실패_size_최대값초과/http-response.adoc[]
+include::{snippets}/common-error-response/bad-request/response-fields.adoc[]
 
 === 읽기 전 상태의 책 5권 조회
 
@@ -113,6 +119,7 @@ include::{snippets}/success/focus-record-by-date/response-fields.adoc[]
 include::{snippets}/failure/invalid-date-format/http-request.adoc[]
 include::{snippets}/failure/invalid-date-format/request-headers.adoc[]
 include::{snippets}/failure/invalid-date-format/http-response.adoc[]
+include::{snippets}/common-error-response/bad-request/response-fields.adoc[]
 
 === 최근 포커스 기록 조회 (홈-이어서 포커스하기)
 

--- a/src/docs/asciidoc/onboarding.adoc
+++ b/src/docs/asciidoc/onboarding.adoc
@@ -8,6 +8,14 @@ include::{snippets}/onboarding-controller-test/온보딩완료_성공/http-respo
 include::{snippets}/onboarding-controller-test/온보딩완료_성공/response-fields.adoc[]
 include::{snippets}/onboarding-controller-test/온보딩완료_성공/request-fields.adoc[]
 
+==== 실패 케이스
+
+include::{snippets}/onboarding-controller-test/온보딩완료_실패_categories누락/http-response.adoc[]
+include::{snippets}/onboarding-controller-test/온보딩완료_실패_goal범위초과/http-response.adoc[]
+include::{snippets}/common-error-response/validation/response-fields.adoc[]
+include::{snippets}/onboarding-controller-test/인증없음_complete_401/http-response.adoc[]
+include::{snippets}/common-error-response/unauthorized/response-fields.adoc[]
+
 === 온보딩 상태 조회
 현재 사용자가 온보딩이 필요한 상태인지 조회합니다.
  +
@@ -35,3 +43,12 @@ include::{snippets}/onboarding-controller-test/독서목표_수정_성공/http-r
 include::{snippets}/onboarding-controller-test/독서목표_수정_성공/request-fields.adoc[]
 include::{snippets}/onboarding-controller-test/독서목표_수정_성공/http-response.adoc[]
 include::{snippets}/onboarding-controller-test/독서목표_수정_성공/response-fields.adoc[]
+
+==== 목표값 오류 및 인증 실패
+
+include::{snippets}/onboarding-controller-test/독서목표_수정_실패_goal0/http-response.adoc[]
+include::{snippets}/common-error-response/validation/response-fields.adoc[]
+include::{snippets}/onboarding-controller-test/인증없음_goal_get_401/http-response.adoc[]
+include::{snippets}/onboarding-controller-test/인증없음_goal_patch_401/http-response.adoc[]
+include::{snippets}/onboarding-controller-test/인증없음_status_401/http-response.adoc[]
+include::{snippets}/common-error-response/unauthorized/response-fields.adoc[]

--- a/src/docs/asciidoc/reading-record.adoc
+++ b/src/docs/asciidoc/reading-record.adoc
@@ -22,6 +22,13 @@ include::{snippets}/record-controller-test/기록_수정_성공/request-fields.a
 include::{snippets}/record-controller-test/기록_수정_성공/http-response.adoc[]
 include::{snippets}/record-controller-test/기록_수정_성공/response-fields.adoc[]
 
+==== 실패 케이스
+
+include::{snippets}/record-controller-test/기록_수정_실패_기록없음/http-response.adoc[]
+include::{snippets}/common-error-response/not-found/response-fields.adoc[]
+include::{snippets}/record-controller-test/기록_수정_실패_권한없음/http-response.adoc[]
+include::{snippets}/common-error-response/forbidden/response-fields.adoc[]
+
 === 기록 삭제
 삭제된 기록 ID를 함께 반환합니다.
 include::{snippets}/record-controller-test/기록_삭제_성공/http-request.adoc[]

--- a/src/docs/asciidoc/search.adoc
+++ b/src/docs/asciidoc/search.adoc
@@ -10,6 +10,14 @@ include::{snippets}/book-search-controller-test/도서검색_첫검색_성공/qu
 include::{snippets}/book-search-controller-test/도서검색_첫검색_성공/http-response.adoc[]
 include::{snippets}/book-search-controller-test/도서검색_첫검색_성공/response-fields.adoc[]
 
+==== 실패 케이스
+
+include::{snippets}/book-search-controller-test/도서검색_검색어누락_실패/http-response.adoc[]
+include::{snippets}/book-search-controller-test/도서검색_빈검색어_실패/http-response.adoc[]
+include::{snippets}/book-search-controller-test/도서검색_음수커서_실패/http-response.adoc[]
+include::{snippets}/book-search-controller-test/도서검색_잘못된타입_실패/http-response.adoc[]
+include::{snippets}/common-error-response/bad-request/response-fields.adoc[]
+
 === 검색 기록 조회
 최근 검색어 목록을 최신순으로 조회합니다.
  +
@@ -32,6 +40,11 @@ include::{snippets}/book-search-controller-test/검색기록삭제_성공/path-p
 include::{snippets}/book-search-controller-test/검색기록삭제_성공/query-parameters.adoc[]
 include::{snippets}/book-search-controller-test/검색기록삭제_성공/http-response.adoc[]
 include::{snippets}/book-search-controller-test/검색기록삭제_성공/response-fields.adoc[]
+
+==== 검색어 누락 (400)
+
+include::{snippets}/book-search-controller-test/검색기록삭제_검색어누락_실패/http-response.adoc[]
+include::{snippets}/common-error-response/bad-request/response-fields.adoc[]
 
 === 검색 기록 전체 삭제
 선택한 검색 타입의 검색 기록을 전체 삭제합니다.

--- a/src/docs/asciidoc/user.adoc
+++ b/src/docs/asciidoc/user.adoc
@@ -8,6 +8,11 @@ include::{snippets}/user-controller-test/내정보_조회_성공/request-headers
 include::{snippets}/user-controller-test/내정보_조회_성공/http-response.adoc[]
 include::{snippets}/user-controller-test/내정보_조회_성공/response-fields.adoc[]
 
+==== 인증 실패 (401)
+
+include::{snippets}/user-controller-test/인증없음_내정보조회_401/http-response.adoc[]
+include::{snippets}/common-error-response/unauthorized/response-fields.adoc[]
+
 === 닉네임 수정
 로그인한 사용자의 닉네임을 수정합니다.
  +
@@ -18,6 +23,16 @@ include::{snippets}/user-controller-test/닉네임_수정_성공/request-headers
 include::{snippets}/user-controller-test/닉네임_수정_성공/request-fields.adoc[]
 include::{snippets}/user-controller-test/닉네임_수정_성공/http-response.adoc[]
 include::{snippets}/user-controller-test/닉네임_수정_성공/response-fields.adoc[]
+
+==== 실패 케이스
+
+include::{snippets}/user-controller-test/닉네임_수정_실패_빈값/http-response.adoc[]
+include::{snippets}/user-controller-test/닉네임_수정_실패_패턴불일치/http-response.adoc[]
+include::{snippets}/common-error-response/validation/response-fields.adoc[]
+include::{snippets}/user-controller-test/닉네임_수정_실패_유저없음/http-response.adoc[]
+include::{snippets}/common-error-response/not-found/response-fields.adoc[]
+include::{snippets}/user-controller-test/인증없음_닉네임수정_401/http-response.adoc[]
+include::{snippets}/common-error-response/unauthorized/response-fields.adoc[]
 
 === 프로필 이미지 수정
 로그인한 사용자의 프로필 이미지를 수정합니다.
@@ -31,6 +46,15 @@ include::{snippets}/user-controller-test/프로필이미지_수정_성공/reques
 include::{snippets}/user-controller-test/프로필이미지_수정_성공/http-response.adoc[]
 include::{snippets}/user-controller-test/프로필이미지_수정_성공/response-fields.adoc[]
 
+==== 실패 케이스
+
+include::{snippets}/user-controller-test/프로필이미지_수정_실패_빈키/http-response.adoc[]
+include::{snippets}/common-error-response/validation/response-fields.adoc[]
+include::{snippets}/user-controller-test/프로필이미지_수정_실패_유저없음/http-response.adoc[]
+include::{snippets}/common-error-response/not-found/response-fields.adoc[]
+include::{snippets}/user-controller-test/인증없음_프로필이미지수정_401/http-response.adoc[]
+include::{snippets}/common-error-response/unauthorized/response-fields.adoc[]
+
 === 프로필 정보 수정
 로그인한 사용자의 닉네임과 프로필 이미지를 함께 수정합니다. +
 이미지는 별도 업로드 API를 통해 먼저 업로드한 뒤 발급받은 `profileImageKey`만 전달합니다. +
@@ -41,6 +65,11 @@ include::{snippets}/user-controller-test/프로필정보_수정_성공/request-h
 include::{snippets}/user-controller-test/프로필정보_수정_성공/request-fields.adoc[]
 include::{snippets}/user-controller-test/프로필정보_수정_성공/http-response.adoc[]
 include::{snippets}/user-controller-test/프로필정보_수정_성공/response-fields.adoc[]
+
+==== 닉네임 누락 (400)
+
+include::{snippets}/user-controller-test/프로필정보_수정_실패_닉네임누락/http-response.adoc[]
+include::{snippets}/common-error-response/validation/response-fields.adoc[]
 
 === 소셜 로그인
 
@@ -56,6 +85,11 @@ include::{snippets}/auth-controller-test/소셜로그인_성공/request-fields.a
 include::{snippets}/auth-controller-test/소셜로그인_성공/http-response.adoc[]
 include::{snippets}/auth-controller-test/소셜로그인_성공/response-fields.adoc[]
 
+==== 잘못된 OAuth 제공자 (400)
+
+include::{snippets}/auth-controller-test/소셜로그인_실패_잘못된_프로바이더/http-response.adoc[]
+include::{snippets}/common-error-response/bad-request/response-fields.adoc[]
+
 === DEV 로그인
 
 include::{snippets}/auth-controller-test/dev로그인_성공/http-request.adoc[]
@@ -63,12 +97,22 @@ include::{snippets}/auth-controller-test/dev로그인_성공/request-fields.adoc
 include::{snippets}/auth-controller-test/dev로그인_성공/http-response.adoc[]
 include::{snippets}/auth-controller-test/dev로그인_성공/response-fields.adoc[]
 
+==== 사용자를 찾을 수 없음 (404)
+
+include::{snippets}/auth-controller-test/dev로그인_실패_유저없음/http-response.adoc[]
+include::{snippets}/common-error-response/not-found/response-fields.adoc[]
+
 === DEV 회원가입
 
 include::{snippets}/auth-controller-test/dev회원가입_성공/http-request.adoc[]
 include::{snippets}/auth-controller-test/dev회원가입_성공/request-fields.adoc[]
 include::{snippets}/auth-controller-test/dev회원가입_성공/http-response.adoc[]
 include::{snippets}/auth-controller-test/dev회원가입_성공/response-fields.adoc[]
+
+==== 이메일 중복 (409)
+
+include::{snippets}/auth-controller-test/dev회원가입_실패_이메일중복/http-response.adoc[]
+include::{snippets}/common-error-response/conflict/response-fields.adoc[]
 
 === 내 정보 조회
 

--- a/src/test/java/app/nook/global/common/TestSecurityConfig.java
+++ b/src/test/java/app/nook/global/common/TestSecurityConfig.java
@@ -1,8 +1,9 @@
 package app.nook.global.common;
 
+import app.nook.global.response.AuthErrorCode;
+import app.nook.user.handler.SecurityErrorResponseWriter;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
-import org.springframework.http.HttpStatus;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
@@ -19,7 +20,7 @@ public class TestSecurityConfig {
                 )
                 .exceptionHandling(ex -> ex
                         .authenticationEntryPoint((request, response, authException) ->
-                                response.sendError(HttpStatus.UNAUTHORIZED.value()))
+                                SecurityErrorResponseWriter.write(response, AuthErrorCode.UNAUTHORIZED))
                 )
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/v1/auth/**").permitAll()

--- a/src/test/java/app/nook/global/docs/ApiResponseSnippet.java
+++ b/src/test/java/app/nook/global/docs/ApiResponseSnippet.java
@@ -44,6 +44,51 @@ public class ApiResponseSnippet {
         };
     }
 
+    public static FieldDescriptor[] failureResponseFields() {
+        return new FieldDescriptor[] {
+                fieldWithPath("isSuccess")
+                        .type(JsonFieldType.BOOLEAN)
+                        .description("요청 성공 여부. 오류 응답에서는 false"),
+
+                fieldWithPath("code")
+                        .type(JsonFieldType.STRING)
+                        .description("오류 코드"),
+
+                fieldWithPath("message")
+                        .type(JsonFieldType.STRING)
+                        .description("오류 메시지"),
+
+                fieldWithPath("result")
+                        .type(JsonFieldType.VARIES)
+                        .description("오류 상세. 일반 오류에서는 응답에서 제외되고, 검증 오류에서는 필드별 오류 정보를 반환")
+                        .optional()
+        };
+    }
+
+    public static FieldDescriptor[] validationFailureResponseFields() {
+        return new FieldDescriptor[] {
+                fieldWithPath("isSuccess")
+                        .type(JsonFieldType.BOOLEAN)
+                        .description("요청 성공 여부. 오류 응답에서는 false"),
+
+                fieldWithPath("code")
+                        .type(JsonFieldType.STRING)
+                        .description("오류 코드"),
+
+                fieldWithPath("message")
+                        .type(JsonFieldType.STRING)
+                        .description("오류 메시지"),
+
+                fieldWithPath("result")
+                        .type(JsonFieldType.OBJECT)
+                        .description("필드명과 검증 오류 메시지로 구성된 객체"),
+
+                fieldWithPath("result.*")
+                        .type(JsonFieldType.STRING)
+                        .description("각 필드의 검증 오류 메시지")
+        };
+    }
+
     public static FieldDescriptor[] withResult(FieldDescriptor... resultFields) {
         return Stream.concat(
                 Arrays.stream(commonResponseFields()),

--- a/src/test/java/app/nook/global/docs/ExceptionResponseDocumentationTest.java
+++ b/src/test/java/app/nook/global/docs/ExceptionResponseDocumentationTest.java
@@ -1,0 +1,138 @@
+package app.nook.global.docs;
+
+import app.nook.global.exception.CustomException;
+import app.nook.global.exception.ExceptionAdvice;
+import app.nook.global.response.AuthErrorCode;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(RestDocumentationExtension.class)
+class ExceptionResponseDocumentationTest {
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp(RestDocumentationContextProvider restDocumentation) {
+        mockMvc = MockMvcBuilders.standaloneSetup(new ExceptionResponseFixtureController())
+                .setControllerAdvice(new ExceptionAdvice())
+                .apply(documentationConfiguration(restDocumentation))
+                .build();
+    }
+
+    @Test
+    void badRequest() throws Exception {
+        documentError("bad-request", 400, "ACCOUNT-014");
+    }
+
+    @Test
+    void unauthorized() throws Exception {
+        documentError("unauthorized", 401, "ACCOUNT-007");
+    }
+
+    @Test
+    void forbidden() throws Exception {
+        documentError("forbidden", 403, "ACCOUNT-009");
+    }
+
+    @Test
+    void notFound() throws Exception {
+        documentError("not-found", 404, "ACCOUNT-001");
+    }
+
+    @Test
+    void conflict() throws Exception {
+        documentError("conflict", 409, "ACCOUNT-008");
+    }
+
+    @Test
+    void validationFailure() throws Exception {
+        mockMvc.perform(post("/docs/error/validation")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.isSuccess").value(false))
+                .andExpect(jsonPath("$.code").value("COMMON-002"))
+                .andExpect(jsonPath("$.result.name").value("이름은 필수입니다."))
+                .andDo(document(
+                        "common-error-response/validation",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        responseFields(ApiResponseSnippet.validationFailureResponseFields())
+                ));
+    }
+
+    @Test
+    void internalServerError() throws Exception {
+        mockMvc.perform(get("/docs/error/internal-server-error"))
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.isSuccess").value(false))
+                .andExpect(jsonPath("$.code").value("COMMON-001"))
+                .andDo(document(
+                        "common-error-response/internal-server-error",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        responseFields(ApiResponseSnippet.failureResponseFields())
+                ));
+    }
+
+    private void documentError(String errorType, int statusCode, String responseCode)
+            throws Exception {
+        mockMvc.perform(get("/docs/error/{errorType}", errorType))
+                .andExpect(status().is(statusCode))
+                .andExpect(jsonPath("$.isSuccess").value(false))
+                .andExpect(jsonPath("$.code").value(responseCode))
+                .andDo(document(
+                        "common-error-response/" + errorType,
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        responseFields(ApiResponseSnippet.failureResponseFields())
+                ));
+    }
+
+    @RestController
+    static class ExceptionResponseFixtureController {
+
+        @GetMapping("/docs/error/{errorType}")
+        void error(@PathVariable String errorType) {
+            throw switch (errorType) {
+                case "bad-request" -> new CustomException(AuthErrorCode.INVALID_OAUTH_PROVIDER);
+                case "unauthorized" -> new CustomException(AuthErrorCode.UNAUTHORIZED);
+                case "forbidden" -> new CustomException(AuthErrorCode.PERMISSION_DENIED);
+                case "not-found" -> new CustomException(AuthErrorCode.USER_NOT_FOUND);
+                case "conflict" -> new CustomException(AuthErrorCode.EMAIL_DUPLICATE);
+                case "internal-server-error" -> new IllegalStateException("문서화용 서버 오류");
+                default -> new IllegalArgumentException("지원하지 않는 오류 유형입니다.");
+            };
+        }
+
+        @org.springframework.web.bind.annotation.PostMapping("/docs/error/validation")
+        void validate(@Valid @RequestBody ValidationRequest request) {
+        }
+    }
+
+    record ValidationRequest(@NotBlank(message = "이름은 필수입니다.") String name) {
+    }
+}


### PR DESCRIPTION
## 📄 작업 내용 요약
<!-- 무엇을 작업했는지 간단하게 요약해주세요 -->

- RestDocs에서 공통 오류 응답을 정리했습니다. 
- 기존 ControllerTest에만 존재하고 adoc에는 추가되지 않았던 예외케이스를 문서화했습니다. 

---

## 📎 Issue 번호
<!-- 관련된 이슈가 있다면 닫히도록 연결해주세요 (ex: closed #1) -->

- closed #316 

---

## ✅ 작업 목록
<!-- 체크박스로 완료한 작업을 표시해주세요 -->

- [ ] 기능 구현
- [ ] 코드 리뷰 반영
- [ ] 테스트 코드 작성
- [ ] 문서 업데이트

---

## 📝 기타 참고사항
<!-- 리뷰어가 참고하면 좋을 추가 정보나 질문이 있다면 자유롭게 작성해주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * 도서, 이미지, 서재, 온보딩, 독서 기록, 검색 및 사용자 API에 다양한 실패 응답 사례를 추가했습니다.
  * 인증, 권한, 입력값 검증, 리소스 없음, 충돌 등 공통 오류 응답 형식을 문서화했습니다.
  * API 문서 목차에 공통 오류 응답 섹션을 추가했습니다.

* **Tests**
  * 주요 HTTP 오류 응답의 상태 코드와 JSON 필드를 검증하고 문서화하는 테스트를 추가했습니다.
  * 인증 실패 응답이 일관된 공통 형식으로 제공되는지 검증합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->