### PR TITLE
[FEAT] 마이페이지 최근 열람 도서 조회 API 구현

### DIFF
--- a/src/docs/asciidoc/book.adoc
+++ b/src/docs/asciidoc/book.adoc
@@ -1,7 +1,7 @@
 === 최근 열람 도서 조회 (마이페이지)
 최근 열람 도서를 최신 열람 순으로 조회합니다.
  +
-최대 5건을 고정으로 반환하며, 열람 이력이 없으면 ``result: []``를 반환합니다.
+최대 5건을 반환하며, 열람 이력이 없으면 ``result: []``를 반환합니다.
 
 include::{snippets}/book-controller-test/최근_열람_도서_조회_성공/http-request.adoc[]
 include::{snippets}/book-controller-test/최근_열람_도서_조회_성공/http-response.adoc[]

--- a/src/docs/asciidoc/book.adoc
+++ b/src/docs/asciidoc/book.adoc
@@ -1,3 +1,21 @@
+=== 최근 열람 도서 조회 (마이페이지)
+최근 열람 도서를 최신 열람 순으로 조회합니다.
+ +
+최대 5건을 고정으로 반환하며, 열람 이력이 없으면 ``result: []``를 반환합니다.
+
+include::{snippets}/book-controller-test/최근_열람_도서_조회_성공/http-request.adoc[]
+include::{snippets}/book-controller-test/최근_열람_도서_조회_성공/http-response.adoc[]
+include::{snippets}/book-controller-test/최근_열람_도서_조회_성공/response-fields.adoc[]
+
+==== 열람 이력이 없는 경우
+
+include::{snippets}/book-controller-test/최근_열람_도서_조회_이력없음/http-response.adoc[]
+
+==== 인증 실패 (401)
+
+include::{snippets}/book-controller-test/최근_열람_도서_조회_미인증/http-response.adoc[]
+include::{snippets}/common-error-response/unauthorized/response-fields.adoc[]
+
 === 도서 상세 조회 (ISBN)
 ISBN13으로 도서 상세 정보를 조회합니다.
  +

--- a/src/main/java/app/nook/book/controller/BookController.java
+++ b/src/main/java/app/nook/book/controller/BookController.java
@@ -5,6 +5,7 @@ import app.nook.book.dto.BookRequestDto;
 import app.nook.book.dto.BookResponseDto;
 import app.nook.book.facade.UserBookFacade;
 import app.nook.book.service.BookService;
+import app.nook.book.service.BookViewHistoryService;
 import app.nook.global.response.ApiResponse;
 import app.nook.global.response.SuccessCode;
 import app.nook.user.annotation.CurrentUser;
@@ -26,6 +27,15 @@ import java.util.List;
 public class BookController {
     private final BookService bookService;
     private final UserBookFacade userBookFacade;
+    private final BookViewHistoryService bookViewHistoryService;
+
+    @GetMapping("/recently-viewed")
+    public ApiResponse<List<BookResponseDto.RecentlyViewedBookDto>> getRecentlyViewedBooks(
+            @CurrentUser User user
+    ) {
+        return ApiResponse.onSuccess(
+                bookViewHistoryService.getRecentlyViewedBooks(user), SuccessCode.OK);
+    }
 
     // ISBN 기반 상세조회: ALADIN 도서 조회 진입점
     @GetMapping("/{isbn13}")

--- a/src/main/java/app/nook/book/dto/BookResponseDto.java
+++ b/src/main/java/app/nook/book/dto/BookResponseDto.java
@@ -72,4 +72,11 @@ public class BookResponseDto {
             Integer nextCursor,
             List<BookSearchDto> books
     ) {}
+
+    public record RecentlyViewedBookDto(
+            Long bookId,
+            String title,
+            String author,
+            String coverImageUrl
+    ) {}
 }

--- a/src/main/java/app/nook/book/repository/BookViewHistoryRepository.java
+++ b/src/main/java/app/nook/book/repository/BookViewHistoryRepository.java
@@ -7,6 +7,7 @@ import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
@@ -17,8 +18,8 @@ public interface BookViewHistoryRepository extends JpaRepository<BookViewHistory
     @Query("SELECT bvh FROM BookViewHistory bvh WHERE bvh.user = :user AND bvh.book = :book")
     Optional<BookViewHistory> findExisting(@Param("user") User user, @Param("book") Book book);
 
-    @Query("SELECT bvh FROM BookViewHistory bvh WHERE bvh.user = :user ORDER BY bvh.modifiedDate DESC, bvh.id DESC")
-    List<BookViewHistory> findAllRecent(@Param("user") User user);
+    @Query("SELECT bvh FROM BookViewHistory bvh JOIN FETCH bvh.book WHERE bvh.user = :user ORDER BY bvh.modifiedDate DESC, bvh.id DESC")
+    List<BookViewHistory> findAllRecent(@Param("user") User user, Pageable pageable);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT bvh FROM BookViewHistory bvh WHERE bvh.user = :user ORDER BY bvh.modifiedDate DESC, bvh.id DESC")

--- a/src/main/java/app/nook/book/service/BookViewHistoryService.java
+++ b/src/main/java/app/nook/book/service/BookViewHistoryService.java
@@ -2,12 +2,15 @@ package app.nook.book.service;
 
 import app.nook.book.domain.Book;
 import app.nook.book.domain.BookViewHistory;
+import app.nook.book.dto.BookResponseDto;
 import app.nook.book.repository.BookViewHistoryRepository;
 import app.nook.global.exception.CustomException;
 import app.nook.global.response.AuthErrorCode;
+import app.nook.r2.service.PresignedUrlService;
 import app.nook.user.domain.User;
 import app.nook.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,10 +21,26 @@ import java.util.List;
 @Transactional(readOnly = true)
 public class BookViewHistoryService {
 
-    private static final int MAX_HISTORY_SIZE = 10;
+    private static final int MAX_HISTORY_SIZE = 5;
 
     private final BookViewHistoryRepository bookViewHistoryRepository;
     private final UserRepository userRepository;
+    private final PresignedUrlService presignedUrlService;
+
+    public List<BookResponseDto.RecentlyViewedBookDto> getRecentlyViewedBooks(User user) {
+        return bookViewHistoryRepository.findAllRecent(user, PageRequest.of(0, MAX_HISTORY_SIZE)).stream()
+                .limit(MAX_HISTORY_SIZE)
+                .map(history -> {
+                    Book book = history.getBook();
+                    return new BookResponseDto.RecentlyViewedBookDto(
+                            book.getId(),
+                            book.getTitle(),
+                            book.getAuthor(),
+                            presignedUrlService.resolveImageUrl(user.getId(), book.getCoverImageKey())
+                    );
+                })
+                .toList();
+    }
 
     @Transactional
     public void saveBookView(User user, Book book) {
@@ -36,10 +55,9 @@ public class BookViewHistoryService {
 
         List<BookViewHistory> histories = bookViewHistoryRepository.findAllRecentForUpdate(lockedUser);
 
-        if (histories.size() >= MAX_HISTORY_SIZE) {
-            BookViewHistory oldest = histories.get(histories.size() - 1);
-            bookViewHistoryRepository.delete(oldest);
-        }
+        histories.stream()
+                .skip(MAX_HISTORY_SIZE - 1L)
+                .forEach(bookViewHistoryRepository::delete);
 
         bookViewHistoryRepository.save(BookViewHistory.builder()
                 .user(lockedUser)

--- a/src/main/java/app/nook/book/service/BookViewHistoryService.java
+++ b/src/main/java/app/nook/book/service/BookViewHistoryService.java
@@ -44,17 +44,20 @@ public class BookViewHistoryService {
 
     @Transactional
     public void saveBookView(User user, Book book) {
+        // 이력 행이 없는 최초 조회도 직렬화하기 위해 사용자 행을 잠근다.
         User lockedUser = userRepository.findByIdForUpdate(user.getId())
                 .orElseThrow(() -> new CustomException(AuthErrorCode.USER_NOT_FOUND));
 
         bookViewHistoryRepository.findExisting(lockedUser, book)
                 .ifPresent(existingHistory -> {
                     bookViewHistoryRepository.delete(existingHistory);
+                    // 동일한 사용자·도서 이력을 재삽입하기 전에 삭제를 반영해 유니크 제약 충돌을 막는다.
                     bookViewHistoryRepository.flush();
                 });
 
         List<BookViewHistory> histories = bookViewHistoryRepository.findAllRecentForUpdate(lockedUser);
 
+        // 새 이력 한 자리를 확보하면서 기존 최대 개수 초과 데이터도 함께 정리한다.
         histories.stream()
                 .skip(MAX_HISTORY_SIZE - 1L)
                 .forEach(bookViewHistoryRepository::delete);

--- a/src/test/java/app/nook/book/repository/BookViewHistoryRepositoryTest.java
+++ b/src/test/java/app/nook/book/repository/BookViewHistoryRepositoryTest.java
@@ -7,14 +7,21 @@ import app.nook.global.config.QueryDslConfig;
 import app.nook.user.domain.User;
 import app.nook.user.domain.enums.UserRole;
 import app.nook.user.repository.UserRepository;
+import jakarta.persistence.EntityManager;
+import org.hibernate.Hibernate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.test.context.ActiveProfiles;
 
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 
@@ -33,6 +40,9 @@ class BookViewHistoryRepositoryTest extends AbstractPostgresContainerTests {
 
     @Autowired
     private UserRepository userRepository;
+
+    @Autowired
+    private EntityManager entityManager;
 
     private User testUser;
     private Book firstBook;
@@ -75,41 +85,54 @@ class BookViewHistoryRepositoryTest extends AbstractPostgresContainerTests {
     }
 
     @Test
-    @DisplayName("최근 조회 이력을 최신순으로 조회")
-    void findAllRecent_최신순_조회() {
+    @DisplayName("최근 조회 이력은 사용자별 최신 5건을 동률 시 ID 내림차순과 초기화된 도서로 조회")
+    void findAllRecent_사용자별_최신5건_동률시_ID내림차순_도서FetchJoin() {
         // given
-        BookViewHistory firstHistory = bookViewHistoryRepository.save(createBookViewHistory(firstBook));
-        BookViewHistory secondHistory = bookViewHistoryRepository.save(createBookViewHistory(secondBook));
-
-        // when
-        List<BookViewHistory> histories = bookViewHistoryRepository.findAllRecent(testUser);
-
-        // then
-        assertThat(histories).hasSize(2);
-        assertThat(histories.get(0).getId()).isEqualTo(secondHistory.getId());
-        assertThat(histories.get(1).getId()).isEqualTo(firstHistory.getId());
-    }
-
-    @Test
-    @DisplayName("다른 유저의 도서 조회 이력은 조회되지 않음")
-    void 다른유저_도서조회이력_분리() {
-        // given
+        List<BookViewHistory> userHistories = new ArrayList<>();
+        for (int index = 1; index <= 7; index++) {
+            Book book = bookRepository.save(createBook("사용자 책 " + index));
+            userHistories.add(bookViewHistoryRepository.save(createBookViewHistory(book)));
+        }
         User anotherUser = userRepository.save(createUser("another@example.com", "provider-2"));
-        bookViewHistoryRepository.save(createBookViewHistory(firstBook));
-        bookViewHistoryRepository.save(BookViewHistory.builder()
+        BookViewHistory anotherUserHistory = bookViewHistoryRepository.save(BookViewHistory.builder()
                 .user(anotherUser)
-                .book(secondBook)
+                .book(bookRepository.save(createBook("다른 사용자 책")))
                 .build());
 
+        entityManager.flush();
+        LocalDateTime sameModifiedDate = LocalDateTime.of(2026, 8, 20, 12, 0);
+        entityManager.createNativeQuery("UPDATE book_view_history SET modified_date = :modifiedDate")
+                .setParameter("modifiedDate", Timestamp.valueOf(sameModifiedDate))
+                .executeUpdate();
+        entityManager.clear();
+
+        List<Long> expectedHistoryIds = userHistories.stream()
+                .map(BookViewHistory::getId)
+                .sorted(Comparator.reverseOrder())
+                .toList();
+
         // when
-        List<BookViewHistory> testUserHistories = bookViewHistoryRepository.findAllRecent(testUser);
-        List<BookViewHistory> anotherUserHistories = bookViewHistoryRepository.findAllRecent(anotherUser);
+        List<BookViewHistory> histories = bookViewHistoryRepository.findAllRecent(testUser, PageRequest.of(0, 5));
 
         // then
-        assertThat(testUserHistories).hasSize(1);
-        assertThat(testUserHistories.get(0).getBook()).isEqualTo(firstBook);
-        assertThat(anotherUserHistories).hasSize(1);
-        assertThat(anotherUserHistories.get(0).getBook()).isEqualTo(secondBook);
+        assertThat(histories).hasSize(5);
+        assertThat(histories)
+                .extracting(BookViewHistory::getId)
+                .containsExactlyElementsOf(expectedHistoryIds.subList(0, 5));
+        assertThat(histories).allSatisfy(history -> {
+            assertThat(history.getUser().getId()).isEqualTo(testUser.getId());
+            assertThat(Hibernate.isInitialized(history.getBook())).isTrue();
+        });
+        assertThat(histories)
+                .extracting(BookViewHistory::getId)
+                .doesNotContain(anotherUserHistory.getId());
+        System.out.printf(
+                "DATA_SURFACE recent-history historyIds=%s bookIds=%s size=%d otherUserHistoryExcluded=%s bookAssociationsInitialized=%s%n",
+                histories.stream().map(BookViewHistory::getId).toList(),
+                histories.stream().map(history -> history.getBook().getId()).toList(),
+                histories.size(),
+                histories.stream().noneMatch(history -> history.getId().equals(anotherUserHistory.getId())),
+                histories.stream().allMatch(history -> Hibernate.isInitialized(history.getBook())));
     }
 
     private BookViewHistory createBookViewHistory(Book book) {

--- a/src/test/java/app/nook/book/repository/BookViewHistoryRepositoryTest.java
+++ b/src/test/java/app/nook/book/repository/BookViewHistoryRepositoryTest.java
@@ -126,13 +126,6 @@ class BookViewHistoryRepositoryTest extends AbstractPostgresContainerTests {
         assertThat(histories)
                 .extracting(BookViewHistory::getId)
                 .doesNotContain(anotherUserHistory.getId());
-        System.out.printf(
-                "DATA_SURFACE recent-history historyIds=%s bookIds=%s size=%d otherUserHistoryExcluded=%s bookAssociationsInitialized=%s%n",
-                histories.stream().map(BookViewHistory::getId).toList(),
-                histories.stream().map(history -> history.getBook().getId()).toList(),
-                histories.size(),
-                histories.stream().noneMatch(history -> history.getId().equals(anotherUserHistory.getId())),
-                histories.stream().allMatch(history -> Hibernate.isInitialized(history.getBook())));
     }
 
     private BookViewHistory createBookViewHistory(Book book) {

--- a/src/test/java/app/nook/book/service/BookViewHistoryServiceTest.java
+++ b/src/test/java/app/nook/book/service/BookViewHistoryServiceTest.java
@@ -8,7 +8,6 @@ import app.nook.r2.service.PresignedUrlService;
 import app.nook.user.domain.User;
 import app.nook.user.domain.enums.UserRole;
 import app.nook.user.repository.UserRepository;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -25,7 +24,6 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 
@@ -173,7 +171,7 @@ class BookViewHistoryServiceTest {
 
     @Test
     @DisplayName("최근 조회 도서 조회 - 저장소 순서대로 다섯 권을 정확한 DTO로 변환한다")
-    void getRecentlyViewedBooks_다섯권_저장소순서와DTO필드를보존한다() throws Exception {
+    void getRecentlyViewedBooks_다섯권_저장소순서와DTO필드를보존한다() {
         // given
         List<BookViewHistory> histories = List.of(
                 createBookViewHistory(createBook(101L, "첫 번째", "저자 1", "book/users/1/first.png")),
@@ -213,8 +211,6 @@ class BookViewHistoryServiceTest {
                         "https://cdn.example.com/fourth.png",
                         "https://cdn.example.com/fifth.png"
                 );
-        assertThat(serializedFieldNames(result.get(0)))
-                .containsExactly("bookId", "title", "author", "coverImageUrl");
         verify(bookViewHistoryRepository).findAllRecent(testUser, PageRequest.of(0, 5));
         verify(presignedUrlService).resolveImageUrl(1L, "book/users/1/first.png");
         verify(presignedUrlService).resolveImageUrl(1L, "book/users/1/second.png");
@@ -334,14 +330,6 @@ class BookViewHistoryServiceTest {
                 .build();
         ReflectionTestUtils.setField(book, "id", id);
         return book;
-    }
-
-    private List<String> serializedFieldNames(BookResponseDto.RecentlyViewedBookDto dto) throws Exception {
-        ObjectMapper objectMapper = new ObjectMapper();
-        Iterator<String> fieldNames = objectMapper.readTree(objectMapper.writeValueAsString(dto)).fieldNames();
-        List<String> result = new ArrayList<>();
-        fieldNames.forEachRemaining(result::add);
-        return result;
     }
 
     private List<BookViewHistory> createMultipleHistories(int count) {

--- a/src/test/java/app/nook/book/service/BookViewHistoryServiceTest.java
+++ b/src/test/java/app/nook/book/service/BookViewHistoryServiceTest.java
@@ -2,23 +2,30 @@ package app.nook.book.service;
 
 import app.nook.book.domain.Book;
 import app.nook.book.domain.BookViewHistory;
+import app.nook.book.dto.BookResponseDto;
 import app.nook.book.repository.BookViewHistoryRepository;
+import app.nook.r2.service.PresignedUrlService;
 import app.nook.user.domain.User;
 import app.nook.user.domain.enums.UserRole;
 import app.nook.user.repository.UserRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 
@@ -26,6 +33,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -36,6 +44,9 @@ class BookViewHistoryServiceTest {
 
     @Mock
     private UserRepository userRepository;
+
+    @Mock
+    private PresignedUrlService presignedUrlService;
 
     @InjectMocks
     private BookViewHistoryService bookViewHistoryService;
@@ -113,14 +124,21 @@ class BookViewHistoryServiceTest {
         BookViewHistory saved = historyCaptor.getValue();
         assertThat(saved.getUser()).isEqualTo(testUser);
         assertThat(saved.getBook()).isEqualTo(testBook);
+
+        InOrder inOrder = inOrder(userRepository, bookViewHistoryRepository);
+        inOrder.verify(userRepository).findByIdForUpdate(1L);
+        inOrder.verify(bookViewHistoryRepository).findExisting(testUser, testBook);
+        inOrder.verify(bookViewHistoryRepository).delete(existingHistory);
+        inOrder.verify(bookViewHistoryRepository).flush();
+        inOrder.verify(bookViewHistoryRepository).findAllRecentForUpdate(testUser);
+        inOrder.verify(bookViewHistoryRepository).save(any(BookViewHistory.class));
     }
 
-    @Test
-    @DisplayName("도서 조회 이력 저장 - 10개 초과 시 가장 오래된 기록 삭제")
-    void saveBookView_10개초과_가장오래된기록삭제() {
-        // given
-        List<BookViewHistory> histories = createMultipleHistories(10);
-        BookViewHistory oldest = histories.get(9);
+    @ParameterizedTest(name = "existing rows: {0}")
+    @ValueSource(ints = {0, 1, 2, 3, 4})
+    @DisplayName("도서 조회 이력 저장 - 0~4개는 보존 이력을 삭제하지 않음")
+    void saveBookView_4개이하_보존이력삭제안함(int existingCount) {
+        List<BookViewHistory> histories = createMultipleHistories(existingCount);
 
         given(userRepository.findByIdForUpdate(1L))
                 .willReturn(Optional.of(testUser));
@@ -129,11 +147,175 @@ class BookViewHistoryServiceTest {
         given(bookViewHistoryRepository.findAllRecentForUpdate(testUser))
                 .willReturn(histories);
 
-        // when
         bookViewHistoryService.saveBookView(testUser, testBook);
 
+        verify(bookViewHistoryRepository, never()).delete(any(BookViewHistory.class));
+        verify(bookViewHistoryRepository).save(any(BookViewHistory.class));
+    }
+
+    @Test
+    @DisplayName("도서 조회 이력 저장 - 5개면 가장 오래된 1개 삭제")
+    void saveBookView_5개_가장오래된1개삭제() {
+        assertRetentionDeletes(5, 4);
+    }
+
+    @Test
+    @DisplayName("도서 조회 이력 저장 - 레거시 6개면 가장 오래된 2개 삭제")
+    void saveBookView_레거시6개_가장오래된2개삭제() {
+        assertRetentionDeletes(6, 4, 5);
+    }
+
+    @Test
+    @DisplayName("도서 조회 이력 저장 - 레거시 10개면 가장 오래된 6개 삭제")
+    void saveBookView_레거시10개_가장오래된6개삭제() {
+        assertRetentionDeletes(10, 4, 5, 6, 7, 8, 9);
+    }
+
+    @Test
+    @DisplayName("최근 조회 도서 조회 - 저장소 순서대로 다섯 권을 정확한 DTO로 변환한다")
+    void getRecentlyViewedBooks_다섯권_저장소순서와DTO필드를보존한다() throws Exception {
+        // given
+        List<BookViewHistory> histories = List.of(
+                createBookViewHistory(createBook(101L, "첫 번째", "저자 1", "book/users/1/first.png")),
+                createBookViewHistory(createBook(102L, "두 번째", "저자 2", "book/users/1/second.png")),
+                createBookViewHistory(createBook(103L, "세 번째", "저자 3", "book/users/1/third.png")),
+                createBookViewHistory(createBook(104L, "네 번째", "저자 4", "book/users/1/fourth.png")),
+                createBookViewHistory(createBook(105L, "다섯 번째", "저자 5", "book/users/1/fifth.png"))
+        );
+        given(bookViewHistoryRepository.findAllRecent(testUser, PageRequest.of(0, 5)))
+                .willReturn(histories);
+        given(presignedUrlService.resolveImageUrl(1L, "book/users/1/first.png"))
+                .willReturn("https://cdn.example.com/first.png");
+        given(presignedUrlService.resolveImageUrl(1L, "book/users/1/second.png"))
+                .willReturn("https://cdn.example.com/second.png");
+        given(presignedUrlService.resolveImageUrl(1L, "book/users/1/third.png"))
+                .willReturn("https://cdn.example.com/third.png");
+        given(presignedUrlService.resolveImageUrl(1L, "book/users/1/fourth.png"))
+                .willReturn("https://cdn.example.com/fourth.png");
+        given(presignedUrlService.resolveImageUrl(1L, "book/users/1/fifth.png"))
+                .willReturn("https://cdn.example.com/fifth.png");
+
+        // when
+        List<BookResponseDto.RecentlyViewedBookDto> result = bookViewHistoryService.getRecentlyViewedBooks(testUser);
+
         // then
-        verify(bookViewHistoryRepository).delete(oldest);
+        assertThat(result).extracting(BookResponseDto.RecentlyViewedBookDto::bookId)
+                .containsExactly(101L, 102L, 103L, 104L, 105L);
+        assertThat(result).extracting(BookResponseDto.RecentlyViewedBookDto::title)
+                .containsExactly("첫 번째", "두 번째", "세 번째", "네 번째", "다섯 번째");
+        assertThat(result).extracting(BookResponseDto.RecentlyViewedBookDto::author)
+                .containsExactly("저자 1", "저자 2", "저자 3", "저자 4", "저자 5");
+        assertThat(result).extracting(BookResponseDto.RecentlyViewedBookDto::coverImageUrl)
+                .containsExactly(
+                        "https://cdn.example.com/first.png",
+                        "https://cdn.example.com/second.png",
+                        "https://cdn.example.com/third.png",
+                        "https://cdn.example.com/fourth.png",
+                        "https://cdn.example.com/fifth.png"
+                );
+        assertThat(serializedFieldNames(result.get(0)))
+                .containsExactly("bookId", "title", "author", "coverImageUrl");
+        verify(bookViewHistoryRepository).findAllRecent(testUser, PageRequest.of(0, 5));
+        verify(presignedUrlService).resolveImageUrl(1L, "book/users/1/first.png");
+        verify(presignedUrlService).resolveImageUrl(1L, "book/users/1/second.png");
+        verify(presignedUrlService).resolveImageUrl(1L, "book/users/1/third.png");
+        verify(presignedUrlService).resolveImageUrl(1L, "book/users/1/fourth.png");
+        verify(presignedUrlService).resolveImageUrl(1L, "book/users/1/fifth.png");
+    }
+
+    @Test
+    @DisplayName("최근 조회 도서 조회 - 외부 URL과 null 및 빈 표지를 resolver 결과 그대로 반환한다")
+    void getRecentlyViewedBooks_외부NullBlank표지_resolver결과를보존한다() {
+        // given
+        String externalUrl = "https://image.aladin.co.kr/product/cover.jpg";
+        List<BookViewHistory> histories = List.of(
+                createBookViewHistory(createBook(201L, "외부 표지", "저자", externalUrl)),
+                createBookViewHistory(createBook(202L, "null 표지", "저자", null)),
+                createBookViewHistory(createBook(203L, "빈 표지", "저자", "")),
+                createBookViewHistory(createBook(204L, "공백 표지", "저자", " "))
+        );
+        given(bookViewHistoryRepository.findAllRecent(testUser, PageRequest.of(0, 5)))
+                .willReturn(histories);
+        given(presignedUrlService.resolveImageUrl(1L, externalUrl)).willReturn(externalUrl);
+        given(presignedUrlService.resolveImageUrl(1L, null)).willReturn(null);
+        given(presignedUrlService.resolveImageUrl(1L, "")).willReturn("");
+        given(presignedUrlService.resolveImageUrl(1L, " ")).willReturn(" ");
+
+        // when
+        List<BookResponseDto.RecentlyViewedBookDto> result = bookViewHistoryService.getRecentlyViewedBooks(testUser);
+
+        // then
+        assertThat(result).extracting(BookResponseDto.RecentlyViewedBookDto::bookId)
+                .containsExactly(201L, 202L, 203L, 204L);
+        assertThat(result).extracting(BookResponseDto.RecentlyViewedBookDto::coverImageUrl)
+                .containsExactly(externalUrl, null, "", " ");
+        verify(presignedUrlService).resolveImageUrl(1L, externalUrl);
+        verify(presignedUrlService).resolveImageUrl(1L, null);
+        verify(presignedUrlService).resolveImageUrl(1L, "");
+        verify(presignedUrlService).resolveImageUrl(1L, " ");
+    }
+
+    @Test
+    @DisplayName("최근 조회 도서 조회 - 이력이 없으면 비어 있는 목록을 반환한다")
+    void getRecentlyViewedBooks_이력없음_빈목록을반환한다() {
+        // given
+        given(bookViewHistoryRepository.findAllRecent(testUser, PageRequest.of(0, 5)))
+                .willReturn(List.of());
+
+        // when
+        List<BookResponseDto.RecentlyViewedBookDto> result = bookViewHistoryService.getRecentlyViewedBooks(testUser);
+
+        // then
+        assertThat(result).isNotNull().isEmpty();
+        verify(bookViewHistoryRepository).findAllRecent(testUser, PageRequest.of(0, 5));
+        verify(presignedUrlService, never()).resolveImageUrl(any(), any());
+    }
+
+    @Test
+    @DisplayName("최근 조회 도서 조회 - 저장소가 여섯 건을 제공해도 첫 다섯 DTO만 반환한다")
+    void getRecentlyViewedBooks_저장소에6건_첫다섯DTO만반환한다() {
+        // given
+        List<BookViewHistory> histories = List.of(
+                createBookViewHistory(createBook(301L, "첫 번째", "저자", null)),
+                createBookViewHistory(createBook(302L, "두 번째", "저자", null)),
+                createBookViewHistory(createBook(303L, "세 번째", "저자", null)),
+                createBookViewHistory(createBook(304L, "네 번째", "저자", null)),
+                createBookViewHistory(createBook(305L, "다섯 번째", "저자", null)),
+                createBookViewHistory(createBook(306L, "여섯 번째", "저자", null))
+        );
+        given(bookViewHistoryRepository.findAllRecent(testUser, PageRequest.of(0, 5)))
+                .willReturn(histories);
+
+        // when
+        List<BookResponseDto.RecentlyViewedBookDto> result = bookViewHistoryService.getRecentlyViewedBooks(testUser);
+
+        // then
+        assertThat(result).extracting(BookResponseDto.RecentlyViewedBookDto::bookId)
+                .containsExactly(301L, 302L, 303L, 304L, 305L);
+        verify(bookViewHistoryRepository).findAllRecent(testUser, PageRequest.of(0, 5));
+    }
+
+    private void assertRetentionDeletes(int existingCount, int... deletedIndexes) {
+        List<BookViewHistory> histories = createMultipleHistories(existingCount);
+
+        given(userRepository.findByIdForUpdate(1L))
+                .willReturn(Optional.of(testUser));
+        given(bookViewHistoryRepository.findExisting(testUser, testBook))
+                .willReturn(Optional.empty());
+        given(bookViewHistoryRepository.findAllRecentForUpdate(testUser))
+                .willReturn(histories);
+
+        bookViewHistoryService.saveBookView(testUser, testBook);
+
+        List<BookViewHistory> expectedDeletes = new ArrayList<>();
+        for (int deletedIndex : deletedIndexes) {
+            expectedDeletes.add(histories.get(deletedIndex));
+        }
+
+        ArgumentCaptor<BookViewHistory> deletedHistoryCaptor = ArgumentCaptor.forClass(BookViewHistory.class);
+        verify(bookViewHistoryRepository, org.mockito.Mockito.times(deletedIndexes.length))
+                .delete(deletedHistoryCaptor.capture());
+        assertThat(deletedHistoryCaptor.getAllValues()).containsExactlyElementsOf(expectedDeletes);
         verify(bookViewHistoryRepository).save(any(BookViewHistory.class));
     }
 
@@ -142,6 +324,24 @@ class BookViewHistoryServiceTest {
                 .user(testUser)
                 .book(book)
                 .build();
+    }
+
+    private Book createBook(Long id, String title, String author, String coverImageKey) {
+        Book book = Book.builder()
+                .title(title)
+                .author(author)
+                .coverImageKey(coverImageKey)
+                .build();
+        ReflectionTestUtils.setField(book, "id", id);
+        return book;
+    }
+
+    private List<String> serializedFieldNames(BookResponseDto.RecentlyViewedBookDto dto) throws Exception {
+        ObjectMapper objectMapper = new ObjectMapper();
+        Iterator<String> fieldNames = objectMapper.readTree(objectMapper.writeValueAsString(dto)).fieldNames();
+        List<String> result = new ArrayList<>();
+        fieldNames.forEachRemaining(result::add);
+        return result;
     }
 
     private List<BookViewHistory> createMultipleHistories(int count) {

--- a/src/test/java/app/nook/controller/book/BookControllerTest.java
+++ b/src/test/java/app/nook/controller/book/BookControllerTest.java
@@ -128,24 +128,6 @@
 
       @Test
       @WithCustomUser
-      @DisplayName("최근 열람 도서 조회는 페이지 매개변수를 계약으로 사용하지 않는다")
-      void 최근_열람_도서_조회_페이지_매개변수_미사용() throws Exception {
-          List<BookResponseDto.RecentlyViewedBookDto> response = List.of(
-                  new BookResponseDto.RecentlyViewedBookDto(101L, "첫 번째 책", "저자 1", null),
-                  new BookResponseDto.RecentlyViewedBookDto(102L, "두 번째 책", "저자 2", null)
-          );
-          given(bookViewHistoryService.getRecentlyViewedBooks(any())).willReturn(response);
-
-          mockMvc.perform(get("/api/v1/books/recently-viewed").param("size", "1")
-                          .header(AUTH_HEADER, AUTH_TOKEN))
-                  .andExpect(status().isOk())
-                  .andExpect(jsonPath("$.result", org.hamcrest.Matchers.hasSize(2)))
-                  .andExpect(jsonPath("$.result[0]", aMapWithSize(4)))
-                  .andExpect(jsonPath("$.result[1]", aMapWithSize(4)));
-      }
-
-      @Test
-      @WithCustomUser
       @DisplayName("ISBN으로 도서 상세 조회 성공")
       void 도서_상세조회_성공() throws Exception {
           String isbn13 = "9788936434267";

--- a/src/test/java/app/nook/controller/book/BookControllerTest.java
+++ b/src/test/java/app/nook/controller/book/BookControllerTest.java
@@ -8,6 +8,7 @@
   import app.nook.book.exception.BookErrorCode;
   import app.nook.book.facade.UserBookFacade;
   import app.nook.book.service.BookService;
+  import app.nook.book.service.BookViewHistoryService;
   import app.nook.global.common.AbstractWebMvcRestDocsTests;
   import app.nook.global.common.security.WithCustomUser;
   import app.nook.global.config.WebSecurityConfig;
@@ -29,6 +30,7 @@
   import java.util.List;
 
   import static org.hamcrest.Matchers.nullValue;
+  import static org.hamcrest.Matchers.aMapWithSize;
   import static org.mockito.ArgumentMatchers.*;
   import static org.mockito.BDDMockito.given;
   import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
@@ -60,6 +62,87 @@
 
       @MockitoBean
       private UserBookFacade userBookFacade;
+
+      @MockitoBean
+      private BookViewHistoryService bookViewHistoryService;
+
+      @Test
+      @WithCustomUser
+      @DisplayName("최근 열람 도서 조회 성공 - 정확한 네 필드 응답")
+      void 최근_열람_도서_조회_성공() throws Exception {
+          List<BookResponseDto.RecentlyViewedBookDto> response = List.of(
+                  new BookResponseDto.RecentlyViewedBookDto(
+                          101L, "채식주의자", "한강", "http://example.com/cover1.jpg"),
+                  new BookResponseDto.RecentlyViewedBookDto(
+                          102L, "소년이 온다", "한강", "http://example.com/cover2.jpg")
+          );
+          given(bookViewHistoryService.getRecentlyViewedBooks(any())).willReturn(response);
+
+          mockMvc.perform(get("/api/v1/books/recently-viewed")
+                          .header(AUTH_HEADER, AUTH_TOKEN))
+                  .andExpect(status().isOk())
+                  .andExpect(jsonPath("$", aMapWithSize(4)))
+                  .andExpect(jsonPath("$.isSuccess").value(true))
+                  .andExpect(jsonPath("$.code").value("SUCCESS-200"))
+                  .andExpect(jsonPath("$.message").isNotEmpty())
+                  .andExpect(jsonPath("$.result", org.hamcrest.Matchers.hasSize(2)))
+                  .andExpect(jsonPath("$.result[0]", aMapWithSize(4)))
+                  .andExpect(jsonPath("$.result[0].bookId").value(101L))
+                  .andExpect(jsonPath("$.result[0].title").value("채식주의자"))
+                  .andExpect(jsonPath("$.result[0].author").value("한강"))
+                  .andExpect(jsonPath("$.result[0].coverImageUrl").value("http://example.com/cover1.jpg"))
+                  .andExpect(jsonPath("$.result[1]", aMapWithSize(4)))
+                  .andExpect(jsonPath("$.result[1].bookId").value(102L))
+                  .andExpect(jsonPath("$.result[1].coverImageUrl").value("http://example.com/cover2.jpg"))
+                  .andDo(documentWithAuth(
+                          "{class-name}/{method-name}",
+                          responseFields(ApiResponseSnippet.withResult(
+                                  fieldWithPath("result[].bookId").description("도서 ID"),
+                                  fieldWithPath("result[].title").description("도서 제목"),
+                                  fieldWithPath("result[].author").description("저자"),
+                                  fieldWithPath("result[].coverImageUrl").description("표지 이미지 URL").optional()
+                          ))
+                  ));
+      }
+
+      @Test
+      @WithCustomUser
+      @DisplayName("최근 열람 도서가 없으면 빈 result 배열을 반환한다")
+      void 최근_열람_도서_조회_이력없음() throws Exception {
+          given(bookViewHistoryService.getRecentlyViewedBooks(any())).willReturn(Collections.emptyList());
+
+          mockMvc.perform(get("/api/v1/books/recently-viewed")
+                          .header(AUTH_HEADER, AUTH_TOKEN))
+                  .andExpect(status().isOk())
+                  .andExpect(jsonPath("$", aMapWithSize(4)))
+                  .andExpect(jsonPath("$.result").isArray())
+                  .andExpect(jsonPath("$.result", org.hamcrest.Matchers.hasSize(0)));
+      }
+
+      @Test
+      @DisplayName("최근 열람 도서 조회는 인증이 필요하다")
+      void 최근_열람_도서_조회_미인증() throws Exception {
+          mockMvc.perform(get("/api/v1/books/recently-viewed"))
+                  .andExpect(status().isUnauthorized());
+      }
+
+      @Test
+      @WithCustomUser
+      @DisplayName("최근 열람 도서 조회는 페이지 매개변수를 계약으로 사용하지 않는다")
+      void 최근_열람_도서_조회_페이지_매개변수_미사용() throws Exception {
+          List<BookResponseDto.RecentlyViewedBookDto> response = List.of(
+                  new BookResponseDto.RecentlyViewedBookDto(101L, "첫 번째 책", "저자 1", null),
+                  new BookResponseDto.RecentlyViewedBookDto(102L, "두 번째 책", "저자 2", null)
+          );
+          given(bookViewHistoryService.getRecentlyViewedBooks(any())).willReturn(response);
+
+          mockMvc.perform(get("/api/v1/books/recently-viewed").param("size", "1")
+                          .header(AUTH_HEADER, AUTH_TOKEN))
+                  .andExpect(status().isOk())
+                  .andExpect(jsonPath("$.result", org.hamcrest.Matchers.hasSize(2)))
+                  .andExpect(jsonPath("$.result[0]", aMapWithSize(4)))
+                  .andExpect(jsonPath("$.result[1]", aMapWithSize(4)));
+      }
 
       @Test
       @WithCustomUser


### PR DESCRIPTION
## 📄 작업 내용 요약
<!-- 무엇을 작업했는지 간단하게 요약해주세요 -->

- 최근 열람 도서 조회 API 구현
- 최근 열람 순으로 최대 5권 반환
- 테스트 및 문서 수정

---

## 📎 Issue 번호
<!-- 관련된 이슈가 있다면 닫히도록 연결해주세요 (ex: closed #1) -->

- closed #319 

---

## ✅ 작업 목록
<!-- 체크박스로 완료한 작업을 표시해주세요 -->

- [x] 기능 구현
- [x] 코드 리뷰 반영
- [x] 테스트 코드 작성
- [x] 문서 업데이트

---

## 📝 기타 참고사항
<!-- 리뷰어가 참고하면 좋을 추가 정보나 질문이 있다면 자유롭게 작성해주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 마이페이지에서 최근 열람한 도서 목록을 확인할 수 있는 API를 추가했습니다.
  - 최근 열람 도서는 최신순으로 최대 5건까지 제공됩니다.
  - 도서 ID, 제목, 저자, 표지 이미지 URL을 함께 확인할 수 있습니다.
  - 열람 이력이 없으면 빈 목록을 반환하며, 인증 상태에 따른 응답을 제공합니다.

- **개선**
  - 최근 열람 이력 보관 한도를 5건으로 조정했습니다.
  - 새 열람 이력이 저장될 때 오래된 기록이 자동으로 정리됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->